### PR TITLE
Fix deployment issue

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
         "@babel/core": "^7.23.5",
         "@babel/preset-react": "^7.23.3",
         "@emotion/styled": "^11.11.0",
+        "@netlify/plugin-nextjs": "^5.0.0-beta.7",
         "@tailwindcss/typography": "^0.5.10",
         "autoprefixer": "^10.4.16",
         "clsx": "^2.1.0",
@@ -984,6 +985,14 @@
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.1.0",
         "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/@netlify/plugin-nextjs": {
+      "version": "5.0.0-beta.7",
+      "resolved": "https://registry.npmjs.org/@netlify/plugin-nextjs/-/plugin-nextjs-5.0.0-beta.7.tgz",
+      "integrity": "sha512-Hw6uBXag5CvUEPtaLx2NXNlJQ5f3S6+3W518nexPaBcPK4m3kK6wMpl10mpfoUskoEHFrbqn3LKdpf4uKKDDTQ==",
+      "engines": {
+        "node": ">=18.0.0"
       }
     },
     "node_modules/@next/env": {

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "@babel/core": "^7.23.5",
     "@babel/preset-react": "^7.23.3",
     "@emotion/styled": "^11.11.0",
+    "@netlify/plugin-nextjs": "^5.0.0-beta.7",
     "@tailwindcss/typography": "^0.5.10",
     "autoprefixer": "^10.4.16",
     "clsx": "^2.1.0",


### PR DESCRIPTION
This PR adds[ @netlify/plugin-nextjs with the beta version (5.0.0-beta.8)](https://www.npmjs.com/package/@netlify/plugin-nextjs/v/5.0.0-beta.7?activeTab=versions). The update is aimed at addressing the deployment issue we've been encountering, where the size of deployed functions exceeds the limit imposed by AWS Lambda.

---

From Netlify support

_I see you're using Next.js 14.1.0.  Would you be willing to try the new Beta Next.js runtime? [Version 5.0.0 beta 8](https://www.npmjs.com/package/@netlify/plugin-nextjs/v/5.0.0-beta.7?activeTab=versions) is the currently latest. We won’t be providing any support now for this version until it is release. However, you could try this now and see if it works for you. The beta version is meant for Next.js 13.5 and up (Next.js 14). 
 
Another option would be to downgrade to an earlier version (prior to Next.js 13.5) and continue using the Next.js runtime v4.41.3_