### PR TITLE
Switch to named exports for components

### DIFF
--- a/src/app/_components/BreadCrumbs.tsx
+++ b/src/app/_components/BreadCrumbs.tsx
@@ -6,7 +6,7 @@ import { TextLink } from '@/components/TextLink'
 
 import { PATHS } from '@/constants/paths'
 
-export default function BreadCrumbs() {
+export function BreadCrumbs() {
   const pathname = usePathname()
   const pathNames = pathname.split('/').filter((path) => path)
 

--- a/src/app/_components/CaseStudiesList.tsx
+++ b/src/app/_components/CaseStudiesList.tsx
@@ -1,13 +1,16 @@
-import CaseStudyListItem from '@/components/CaseStudyListItem'
+import { CaseStudyListItem } from '@/components/CaseStudyListItem'
 
 import { CaseStudyData } from '@/types/caseStudyTypes'
 
-type Props = {
+type CaseStudiesListProps = {
   caseStudies: CaseStudyData[]
   className?: string
 }
 
-export default function CaseStudiesList({ caseStudies, className }: Props) {
+export function CaseStudiesList({
+  caseStudies,
+  className,
+}: CaseStudiesListProps) {
   if (caseStudies.length === 0) {
     return <p>No case studies available.</p>
   }

--- a/src/app/_components/CaseStudyListItem.tsx
+++ b/src/app/_components/CaseStudyListItem.tsx
@@ -6,11 +6,7 @@ import { CaseStudyData } from '@/types/caseStudyTypes'
 
 import { PATHS } from '@/constants/paths'
 
-export default function CaseStudyListItem({
-  caseStudy,
-}: {
-  caseStudy: CaseStudyData
-}) {
+export function CaseStudyListItem({ caseStudy }: { caseStudy: CaseStudyData }) {
   const {
     slug,
     title,

--- a/src/app/_components/CustomImage.tsx
+++ b/src/app/_components/CustomImage.tsx
@@ -1,11 +1,11 @@
 import Image from 'next/image'
 
-type Props = {
+type CustomImageProps = {
   src: string
   alt: string
 }
 
-export default function CustomImage({ src, alt }: Props) {
+export function CustomImage({ src, alt }: CustomImageProps) {
   return (
     <Image
       src={src}

--- a/src/app/_components/EventListItem.tsx
+++ b/src/app/_components/EventListItem.tsx
@@ -8,7 +8,7 @@ import { formatDate } from '@/utils/formatDate'
 
 import { PATHS } from '@/constants/paths'
 
-export default function EventListItem({ event }: { event: EventData }) {
+export function EventListItem({ event }: { event: EventData }) {
   const {
     slug,
     title,

--- a/src/app/_components/EventsList.tsx
+++ b/src/app/_components/EventsList.tsx
@@ -1,13 +1,13 @@
-import EventListItem from '@/components/EventListItem'
+import { EventListItem } from '@/components/EventListItem'
 
 import { EventData } from '@/types/eventTypes'
 
-type Props = {
+type EventsListProps = {
   events: EventData[]
   className?: string
 }
 
-export default function EventsList({ events, className }: Props) {
+export function EventsList({ events, className }: EventsListProps) {
   if (events.length === 0) {
     return <p>No events available.</p>
   }

--- a/src/app/_components/FeaturedCaseStudies.tsx
+++ b/src/app/_components/FeaturedCaseStudies.tsx
@@ -1,4 +1,4 @@
-import CaseStudiesList from '@/components/CaseStudiesList'
+import { CaseStudiesList } from '@/components/CaseStudiesList'
 
 import { CaseStudyData } from '@/types/caseStudyTypes'
 

--- a/src/app/_components/Footer.tsx
+++ b/src/app/_components/Footer.tsx
@@ -2,7 +2,7 @@
 
 import { TextLink } from '@/components/TextLink'
 
-export default function Footer() {
+export function Footer() {
   return (
     <footer className="py-8 px-12">
       <hr />

--- a/src/app/_components/Logo.tsx
+++ b/src/app/_components/Logo.tsx
@@ -1,6 +1,6 @@
 import Image from 'next/image'
 
-export default function Logo() {
+export function Logo() {
   return (
     <Image
       src="/assets/images/logo.svg"

--- a/src/app/_components/MarkdownContent.tsx
+++ b/src/app/_components/MarkdownContent.tsx
@@ -1,13 +1,13 @@
 import ReactMarkdown from 'react-markdown'
 import rehypeRaw from 'rehype-raw'
 
-import CustomImage from '@/components/CustomImage'
+import { CustomImage } from '@/components/CustomImage'
 
-type Props = {
+type MarkdownContentProps = {
   children: string
 }
 
-export default function MarkdownContent({ children }: Props) {
+export function MarkdownContent({ children }: MarkdownContentProps) {
   return (
     <ReactMarkdown
       rehypePlugins={[rehypeRaw]}

--- a/src/app/_components/Navigation.tsx
+++ b/src/app/_components/Navigation.tsx
@@ -1,6 +1,6 @@
 import Link from 'next/link'
 
-import Logo from '@/components/Logo'
+import { Logo } from '@/components/Logo'
 import { TextLink } from '@/components/TextLink'
 
 import { PATHS } from '@/constants/paths'
@@ -26,7 +26,7 @@ function NavigationLink({ label, path }: { label: string; path: string }) {
   )
 }
 
-export default function Navigation() {
+export function Navigation() {
   return (
     <nav className="flex justify-between items-center p-4">
       <Link

--- a/src/app/_components/NetlifyIdentityManager.tsx
+++ b/src/app/_components/NetlifyIdentityManager.tsx
@@ -4,12 +4,10 @@ import { useEffect } from 'react'
 
 import netlifyIdentity from 'netlify-identity-widget'
 
-const NetlifyIdentityManager = () => {
+export function NetlifyIdentityManager() {
   useEffect(() => {
     netlifyIdentity.init()
   }, [])
 
   return null
 }
-
-export default NetlifyIdentityManager

--- a/src/app/_components/PageHeader.tsx
+++ b/src/app/_components/PageHeader.tsx
@@ -1,12 +1,12 @@
 import { TextLink } from '@/components/TextLink'
 
-type Props = {
+type PageHeaderProps = {
   title: string
   description: string
   link?: { url: string; text: string }
 }
 
-export default function PageHeader({ title, description, link }: Props) {
+export function PageHeader({ title, description, link }: PageHeaderProps) {
   return (
     <header>
       <h1>{title}</h1>

--- a/src/app/_components/Section.tsx
+++ b/src/app/_components/Section.tsx
@@ -1,6 +1,6 @@
 import { TextLink } from '@/components/TextLink'
 
-type Props = {
+type SectionProps = {
   content: string | string[]
   kicker?: string
   link?: { url: string; text: string }
@@ -22,7 +22,13 @@ function Content({ content }: { content: string | string[] }) {
   return <p>{content}</p>
 }
 
-export function Section({ content, kicker, link, title, children }: Props) {
+export function Section({
+  content,
+  kicker,
+  link,
+  title,
+  children,
+}: SectionProps) {
   return (
     <section>
       {kicker && <span className="uppercase text-sm">{kicker}</span>}

--- a/src/app/_components/StructuredDataScript.tsx
+++ b/src/app/_components/StructuredDataScript.tsx
@@ -4,7 +4,7 @@ type StructuredDataScriptProps = {
   structuredData: WithContext<Thing>
 }
 
-export default function StructuredDataScript({
+export function StructuredDataScript({
   structuredData,
 }: StructuredDataScriptProps) {
   return (

--- a/src/app/_components/UpcomingEvents.tsx
+++ b/src/app/_components/UpcomingEvents.tsx
@@ -1,4 +1,4 @@
-import EventsList from '@/components/EventsList'
+import { EventsList } from '@/components/EventsList'
 
 import { EventData } from '@/types/eventTypes'
 

--- a/src/app/_components/VideoArticle.tsx
+++ b/src/app/_components/VideoArticle.tsx
@@ -1,12 +1,12 @@
 import { TextLink } from '@/components/TextLink'
 
-type Props = {
+type VideoArticleProps = {
   title: string
   content: string
   link: string
 }
 
-export default function VideoArticle({ title, content, link }: Props) {
+export function VideoArticle({ title, content, link }: VideoArticleProps) {
   return (
     <article>
       <h3>{title}</h3>

--- a/src/app/about/page.tsx
+++ b/src/app/about/page.tsx
@@ -1,9 +1,9 @@
 import { WebPage, WithContext } from 'schema-dts'
 
-import PageHeader from '@/components/PageHeader'
+import { PageHeader } from '@/components/PageHeader'
 import { Section } from '@/components/Section'
-import StructuredDataScript from '@/components/StructuredDataScript'
-import VideoArticle from '@/components/VideoArticle'
+import { StructuredDataScript } from '@/components/StructuredDataScript'
+import { VideoArticle } from '@/components/VideoArticle'
 
 import { createMetadata } from '@/utils/createMetadata'
 import { generateWebPageStructuredData } from '@/utils/structuredData'

--- a/src/app/blog/BlogClient.tsx
+++ b/src/app/blog/BlogClient.tsx
@@ -14,7 +14,7 @@ import { PATHS } from '@/constants/paths'
 
 const POSTS_PER_LOAD = 9
 
-export default function BlogClient({ posts }: { posts: BlogPostData[] }) {
+export function BlogClient({ posts }: { posts: BlogPostData[] }) {
   const [searchQuery, setSearchQuery] = useState<string>('')
   const [visibleCount, setVisibleCount] = useState<number>(POSTS_PER_LOAD)
 

--- a/src/app/blog/[slug]/page.tsx
+++ b/src/app/blog/[slug]/page.tsx
@@ -7,8 +7,8 @@ import matter from 'gray-matter'
 import type { Route } from 'next'
 import { BlogPosting, WithContext } from 'schema-dts'
 
-import MarkdownContent from '@/components/MarkdownContent'
-import StructuredDataScript from '@/components/StructuredDataScript'
+import { MarkdownContent } from '@/components/MarkdownContent'
+import { StructuredDataScript } from '@/components/StructuredDataScript'
 
 import { BlogPostData } from '@/types/blogPostTypes'
 import { SeoMetadata } from '@/types/metadataTypes'
@@ -17,10 +17,10 @@ import { createMetadata } from '@/utils/createMetadata'
 import { formatDate } from '@/utils/formatDate'
 import { baseOrganizationSchema } from '@/utils/structuredData'
 
-import { PATHS, PathValues } from '@/constants/paths'
+import { PATHS } from '@/constants/paths'
 import { BASE_URL, ORGANIZATION_NAME } from '@/constants/siteMetadata'
 
-type Props = {
+type BlogPostProps = {
   params: {
     slug: string
   }
@@ -45,7 +45,7 @@ function getPostData(slug: string): { content: string; data: BlogPostData } {
   return { content, data: data as BlogPostData }
 }
 
-export async function generateMetadata({ params }: Props) {
+export async function generateMetadata({ params }: BlogPostProps) {
   const { slug } = params
   const { data } = getPostData(slug)
 
@@ -84,7 +84,7 @@ function createBlogPostStructuredData(
   }
 }
 
-export default function BlogPost({ params }: Props) {
+export default function BlogPost({ params }: BlogPostProps) {
   const { slug } = params
   const { content, data } = getPostData(slug)
 

--- a/src/app/blog/page.tsx
+++ b/src/app/blog/page.tsx
@@ -1,7 +1,7 @@
 import { WebPage, WithContext } from 'schema-dts'
 
-import PageHeader from '@/components/PageHeader'
-import StructuredDataScript from '@/components/StructuredDataScript'
+import { PageHeader } from '@/components/PageHeader'
+import { StructuredDataScript } from '@/components/StructuredDataScript'
 
 import { BlogPostData } from '@/types/blogPostTypes'
 
@@ -17,7 +17,7 @@ import { attributes } from '@/content/pages/blog.md'
 import { PATHS } from '@/constants/paths'
 import { BASE_URL } from '@/constants/siteMetadata'
 
-import BlogClient from './BlogClient'
+import { BlogClient } from './BlogClient'
 
 const { title, description, seo } = attributes
 

--- a/src/app/case-studies/[slug]/page.tsx
+++ b/src/app/case-studies/[slug]/page.tsx
@@ -5,7 +5,7 @@ import matter from 'gray-matter'
 import { Route } from 'next'
 import { Article, WithContext } from 'schema-dts'
 
-import StructuredDataScript from '@/components/StructuredDataScript'
+import { StructuredDataScript } from '@/components/StructuredDataScript'
 
 import { CaseStudyData } from '@/types/caseStudyTypes'
 import { SeoMetadata } from '@/types/metadataTypes'
@@ -16,7 +16,7 @@ import { baseOrganizationSchema } from '@/utils/structuredData'
 import { PATHS } from '@/constants/paths'
 import { BASE_URL } from '@/constants/siteMetadata'
 
-type Props = {
+type CaseStudyProps = {
   params: {
     slug: string
   }
@@ -41,7 +41,7 @@ function getCaseStudyData(slug: string): CaseStudyData {
   return data as CaseStudyData
 }
 
-export async function generateMetadata({ params }: Props) {
+export async function generateMetadata({ params }: CaseStudyProps) {
   const { slug } = params
   const data = getCaseStudyData(slug)
 
@@ -76,7 +76,7 @@ function createCaseStudyPostStructuredData(
   }
 }
 
-export default function CaseStudy({ params }: Props) {
+export default function CaseStudy({ params }: CaseStudyProps) {
   const { slug } = params
   const data = getCaseStudyData(slug)
 

--- a/src/app/case-studies/page.tsx
+++ b/src/app/case-studies/page.tsx
@@ -1,7 +1,7 @@
 import { WebPage, WithContext } from 'schema-dts'
 
-import PageHeader from '@/components/PageHeader'
-import StructuredDataScript from '@/components/StructuredDataScript'
+import { PageHeader } from '@/components/PageHeader'
+import { StructuredDataScript } from '@/components/StructuredDataScript'
 import { TextLink } from '@/components/TextLink'
 
 import { CaseStudyData } from '@/types/caseStudyTypes'

--- a/src/app/ecosystem/page.tsx
+++ b/src/app/ecosystem/page.tsx
@@ -1,6 +1,6 @@
 import { FeaturedCaseStudies } from '@/components/FeaturedCaseStudies'
-import PageHeader from '@/components/PageHeader'
-import StructuredDataScript from '@/components/StructuredDataScript'
+import { PageHeader } from '@/components/PageHeader'
+import { StructuredDataScript } from '@/components/StructuredDataScript'
 import { TextLink } from '@/components/TextLink'
 
 import { createMetadata } from '@/utils/createMetadata'

--- a/src/app/events/[slug]/page.tsx
+++ b/src/app/events/[slug]/page.tsx
@@ -7,7 +7,7 @@ import matter from 'gray-matter'
 import { Route } from 'next'
 import { Event, WithContext } from 'schema-dts'
 
-import StructuredDataScript from '@/components/StructuredDataScript'
+import { StructuredDataScript } from '@/components/StructuredDataScript'
 
 import { EventData } from '@/types/eventTypes'
 import { SeoMetadata } from '@/types/metadataTypes'
@@ -17,7 +17,7 @@ import { createMetadata } from '@/utils/createMetadata'
 import { PATHS } from '@/constants/paths'
 import { BASE_URL } from '@/constants/siteMetadata'
 
-type Props = {
+type EventProps = {
   params: {
     slug: string
   }
@@ -42,7 +42,7 @@ function getEventsData(slug: string): EventData {
   return data as EventData
 }
 
-export async function generateMetadata({ params }: Props) {
+export async function generateMetadata({ params }: EventProps) {
   const { slug } = params
   const data = getEventsData(slug)
 
@@ -69,7 +69,7 @@ function createEventPostStructuredData(data: EventData): WithContext<Event> {
   }
 }
 
-export default function Event({ params }: Props) {
+export default function Event({ params }: EventProps) {
   const { slug } = params
   const data = getEventsData(slug)
 

--- a/src/app/events/page.tsx
+++ b/src/app/events/page.tsx
@@ -1,8 +1,8 @@
 import { WebPage, WithContext } from 'schema-dts'
 
-import EventsList from '@/components/EventsList'
-import PageHeader from '@/components/PageHeader'
-import StructuredDataScript from '@/components/StructuredDataScript'
+import { EventsList } from '@/components/EventsList'
+import { PageHeader } from '@/components/PageHeader'
+import { StructuredDataScript } from '@/components/StructuredDataScript'
 
 import { EventData } from '@/types/eventTypes'
 

--- a/src/app/get-involved/page.tsx
+++ b/src/app/get-involved/page.tsx
@@ -1,7 +1,7 @@
-import PageHeader from '@/components/PageHeader'
-import StructuredDataScript from '@/components/StructuredDataScript'
+import { PageHeader } from '@/components/PageHeader'
+import { StructuredDataScript } from '@/components/StructuredDataScript'
 import { TextLink } from '@/components/TextLink'
-import VideoArticle from '@/components/VideoArticle'
+import { VideoArticle } from '@/components/VideoArticle'
 
 import { createMetadata } from '@/utils/createMetadata'
 import { generateWebPageStructuredData } from '@/utils/structuredData'

--- a/src/app/governance/page.tsx
+++ b/src/app/governance/page.tsx
@@ -1,5 +1,5 @@
-import PageHeader from '@/components/PageHeader'
-import StructuredDataScript from '@/components/StructuredDataScript'
+import { PageHeader } from '@/components/PageHeader'
+import { StructuredDataScript } from '@/components/StructuredDataScript'
 import { TextLink } from '@/components/TextLink'
 import { UpcomingEvents } from '@/components/UpcomingEvents'
 

--- a/src/app/grants/page.tsx
+++ b/src/app/grants/page.tsx
@@ -1,6 +1,6 @@
 import { GetInvolvedList } from '@/components/GetInvolvedList'
-import PageHeader from '@/components/PageHeader'
-import StructuredDataScript from '@/components/StructuredDataScript'
+import { PageHeader } from '@/components/PageHeader'
+import { StructuredDataScript } from '@/components/StructuredDataScript'
 import { TextLink } from '@/components/TextLink'
 import { UpcomingEvents } from '@/components/UpcomingEvents'
 

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -2,11 +2,11 @@ import { Metadata } from 'next'
 
 import '@/styles/globals.scss'
 
-import BreadCrumbs from '@/components/BreadCrumbs'
-import Footer from '@/components/Footer'
-import Navigation from '@/components/Navigation'
-import NetlifyIdentityManager from '@/components/NetlifyIdentityManager'
-import StructuredDataScript from '@/components/StructuredDataScript'
+import { BreadCrumbs } from '@/components/BreadCrumbs'
+import { Footer } from '@/components/Footer'
+import { Navigation } from '@/components/Navigation'
+import { NetlifyIdentityManager } from '@/components/NetlifyIdentityManager'
+import { StructuredDataScript } from '@/components/StructuredDataScript'
 
 import { baseOrganizationSchema } from '@/utils/structuredData'
 

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,9 +1,9 @@
 import { GetInvolvedList } from '@/components/GetInvolvedList'
-import PageHeader from '@/components/PageHeader'
+import { PageHeader } from '@/components/PageHeader'
 import { ResourcesList } from '@/components/ResourcesList'
 import { Section } from '@/components/Section'
 import { TextLink } from '@/components/TextLink'
-import VideoArticle from '@/components/VideoArticle'
+import { VideoArticle } from '@/components/VideoArticle'
 
 import { createMetadata } from '@/utils/createMetadata'
 

--- a/src/app/policy/page.tsx
+++ b/src/app/policy/page.tsx
@@ -1,4 +1,4 @@
-import StructuredDataScript from '@/components/StructuredDataScript'
+import { StructuredDataScript } from '@/components/StructuredDataScript'
 
 import { createMetadata } from '@/utils/createMetadata'
 import { generateWebPageStructuredData } from '@/utils/structuredData'

--- a/src/app/public-data/awards/page.tsx
+++ b/src/app/public-data/awards/page.tsx
@@ -1,5 +1,5 @@
-import PageHeader from '@/components/PageHeader'
-import StructuredDataScript from '@/components/StructuredDataScript'
+import { PageHeader } from '@/components/PageHeader'
+import { StructuredDataScript } from '@/components/StructuredDataScript'
 import { TextLink } from '@/components/TextLink'
 
 import { createMetadata } from '@/utils/createMetadata'

--- a/src/app/public-data/page.tsx
+++ b/src/app/public-data/page.tsx
@@ -1,6 +1,6 @@
 import { FeaturedCaseStudies } from '@/components/FeaturedCaseStudies'
-import PageHeader from '@/components/PageHeader'
-import StructuredDataScript from '@/components/StructuredDataScript'
+import { PageHeader } from '@/components/PageHeader'
+import { StructuredDataScript } from '@/components/StructuredDataScript'
 import { TextLink } from '@/components/TextLink'
 
 import { createMetadata } from '@/utils/createMetadata'

--- a/src/app/terms/page.tsx
+++ b/src/app/terms/page.tsx
@@ -1,4 +1,4 @@
-import StructuredDataScript from '@/components/StructuredDataScript'
+import { StructuredDataScript } from '@/components/StructuredDataScript'
 
 import { createMetadata } from '@/utils/createMetadata'
 import { generateWebPageStructuredData } from '@/utils/structuredData'


### PR DESCRIPTION
This PR introduces a refactor across our component library, transitioning from default exports to named exports for all components. This change aims to enhance code readability and maintainability, facilitate easier and more consistent imports, and improve support for tree-shaking and static analysis tools.

**Key Changes:**
- All components now use named exports, standardizing the way we import and use components throughout the application.
- Named exports make it clear which components are being used in a file, reducing the likelihood of naming conflicts and making code easier to refactor.
- Tools like ESLint and TypeScript can more easily analyze usage and detect unused or missing exports, leading to cleaner, more efficient code.
- By using named exports, we enable better tree-shaking capabilities, potentially reducing bundle sizes by excluding unused code.

**Additional Change*:*
- Enhance code readability and prevent naming conflicts by adopting descriptive prop type names, such as CaseStudiesListProps, for clearer context and easier maintenance across our growing project.