### PR TITLE
Streamline Metadata Generation and Path Handling

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -7,6 +7,9 @@ module.exports = {
       },
     ],
   },
+  experimental: {
+    typedRoutes: true,
+  },
   webpack: (cfg) => {
     cfg.module.rules.push({
       test: /\.md$/,

--- a/src/app/_components/Navigation.tsx
+++ b/src/app/_components/Navigation.tsx
@@ -31,7 +31,7 @@ export function Navigation() {
     <nav className="flex justify-between items-center p-4">
       <Link
         className="block flex-shrink-0 mr-12"
-        href="/"
+        href={PATHS.HOME.path}
         aria-label="Go to homepage"
       >
         <Logo />

--- a/src/app/_components/TextLink.tsx
+++ b/src/app/_components/TextLink.tsx
@@ -1,6 +1,7 @@
 import Link from 'next/link'
 
 import clsx from 'clsx'
+import { Route } from 'next'
 
 type TextLinkProps = {
   href: string
@@ -21,7 +22,7 @@ export function TextLink({
 
   if (isInternalLink) {
     return (
-      <Link href={href} className={className} {...props}>
+      <Link href={href as Route} className={className} {...props}>
         {children}
       </Link>
     )

--- a/src/app/_constants/paths.ts
+++ b/src/app/_constants/paths.ts
@@ -1,8 +1,8 @@
-export type BlogPostsPath = `blog/${string}`
-export type CaseStudiesPath = `case-studies/${string}`
-export type EventsPath = `events/${string}`
+export type BlogPostPath = `/blog/${string}`
+export type CaseStudyPath = `/case-studies/${string}`
+export type EventPath = `/events/${string}`
 
-export type DynamicPathValues = BlogPostsPath | CaseStudiesPath | EventsPath
+export type DynamicPathValues = BlogPostPath | CaseStudyPath | EventPath
 
 export type PathValues =
   | '/about'
@@ -18,7 +18,6 @@ export type PathValues =
   | '/public-data/awards'
   | '/public-data'
   | '/terms'
-  | DynamicPathValues
 
 export interface PathConfig {
   path: PathValues

--- a/src/app/_utils/createMetadata.ts
+++ b/src/app/_utils/createMetadata.ts
@@ -1,12 +1,10 @@
-import { Metadata, Route } from 'next'
+import { Metadata } from 'next'
 
-import { SeoMetadata } from '@/types/metadataTypes'
-
-import { PathValues } from '@/constants/paths'
+import { PathValues, DynamicPathValues } from '@/constants/paths'
 
 export function createMetadata(
-  seo: SeoMetadata,
-  path: PathValues | Route
+  seo: Metadata,
+  path: PathValues | DynamicPathValues
 ): Metadata {
   return {
     title: seo.title,

--- a/src/app/_utils/generateDynamicContentMetadata.ts
+++ b/src/app/_utils/generateDynamicContentMetadata.ts
@@ -1,0 +1,24 @@
+import { Metadata } from 'next'
+
+import { createMetadata } from '@/utils/createMetadata'
+
+import { DynamicPathValues } from '@/constants/paths'
+
+export function generateDynamicContentMetadata({
+  basePath,
+  slug,
+  data,
+}: {
+  basePath: string
+  slug: string
+  data: { title: string; f_description?: string }
+}): Metadata {
+  const seo = {
+    title: data.title,
+    description: data.f_description,
+  }
+
+  const path = `${basePath}/${slug}` as DynamicPathValues
+
+  return createMetadata(seo, path)
+}

--- a/src/app/blog/[slug]/page.tsx
+++ b/src/app/blog/[slug]/page.tsx
@@ -4,17 +4,15 @@ import path from 'path'
 import Image from 'next/image'
 
 import matter from 'gray-matter'
-import type { Route } from 'next'
 import { BlogPosting, WithContext } from 'schema-dts'
 
 import { MarkdownContent } from '@/components/MarkdownContent'
 import { StructuredDataScript } from '@/components/StructuredDataScript'
 
 import { BlogPostData } from '@/types/blogPostTypes'
-import { SeoMetadata } from '@/types/metadataTypes'
 
-import { createMetadata } from '@/utils/createMetadata'
 import { formatDate } from '@/utils/formatDate'
+import { generateDynamicContentMetadata } from '@/utils/generateDynamicContentMetadata'
 import { baseOrganizationSchema } from '@/utils/structuredData'
 
 import { PATHS } from '@/constants/paths'
@@ -49,14 +47,11 @@ export async function generateMetadata({ params }: BlogPostProps) {
   const { slug } = params
   const { data } = getPostData(slug)
 
-  const seo: SeoMetadata = {
-    title: data.title,
-    description: data.f_description,
-  }
-
-  const path: Route = `${PATHS.BLOG.path}/${slug}`
-
-  return createMetadata(seo, path)
+  return generateDynamicContentMetadata({
+    basePath: PATHS.BLOG.path,
+    slug,
+    data,
+  })
 }
 
 function createBlogPostStructuredData(

--- a/src/app/case-studies/[slug]/page.tsx
+++ b/src/app/case-studies/[slug]/page.tsx
@@ -2,15 +2,13 @@ import fs from 'fs'
 import path from 'path'
 
 import matter from 'gray-matter'
-import { Route } from 'next'
 import { Article, WithContext } from 'schema-dts'
 
 import { StructuredDataScript } from '@/components/StructuredDataScript'
 
 import { CaseStudyData } from '@/types/caseStudyTypes'
-import { SeoMetadata } from '@/types/metadataTypes'
 
-import { createMetadata } from '@/utils/createMetadata'
+import { generateDynamicContentMetadata } from '@/utils/generateDynamicContentMetadata'
 import { baseOrganizationSchema } from '@/utils/structuredData'
 
 import { PATHS } from '@/constants/paths'
@@ -45,14 +43,11 @@ export async function generateMetadata({ params }: CaseStudyProps) {
   const { slug } = params
   const data = getCaseStudyData(slug)
 
-  const seo: SeoMetadata = {
-    title: data.title,
-    description: data.f_description || '',
-  }
-
-  const path: Route = `${PATHS.CASE_STUDIES.path}/${slug}`
-
-  return createMetadata(seo, path)
+  return generateDynamicContentMetadata({
+    basePath: PATHS.CASE_STUDIES.path,
+    slug,
+    data,
+  })
 }
 
 function createCaseStudyPostStructuredData(

--- a/src/app/events/[slug]/page.tsx
+++ b/src/app/events/[slug]/page.tsx
@@ -4,15 +4,13 @@ import path from 'path'
 import Image from 'next/image'
 
 import matter from 'gray-matter'
-import { Route } from 'next'
 import { Event, WithContext } from 'schema-dts'
 
 import { StructuredDataScript } from '@/components/StructuredDataScript'
 
 import { EventData } from '@/types/eventTypes'
-import { SeoMetadata } from '@/types/metadataTypes'
 
-import { createMetadata } from '@/utils/createMetadata'
+import { generateDynamicContentMetadata } from '@/utils/generateDynamicContentMetadata'
 
 import { PATHS } from '@/constants/paths'
 import { BASE_URL } from '@/constants/siteMetadata'
@@ -46,14 +44,11 @@ export async function generateMetadata({ params }: EventProps) {
   const { slug } = params
   const data = getEventsData(slug)
 
-  const seo: SeoMetadata = {
-    title: data.title,
-    description: data.f_description || '',
-  }
-
-  const path: Route = `${PATHS.EVENTS.path}/${slug}`
-
-  return createMetadata(seo, path)
+  return generateDynamicContentMetadata({
+    basePath: PATHS.EVENTS.path,
+    slug,
+    data,
+  })
 }
 
 function createEventPostStructuredData(data: EventData): WithContext<Event> {


### PR DESCRIPTION
Refactored the metadata generation process for dynamic content, leveraging a new utility function to reduce duplication and enhance type safety. Also refined path usage across the application for consistency and reliability.

**Key Changes**
- Centralized metadata generation for blog posts and similar dynamic content into `generateDynamicContentMetadata`
- Utilized typed routes for safer and clearer path definitions, aligning with the experimental feature for typed routes.
- Updated `hrefs` to use constants.