### PR TITLE
Exploration to remove type assertions and have stronger types

### DIFF
--- a/src/app/_components/FeaturedBlogPosts.tsx
+++ b/src/app/_components/FeaturedBlogPosts.tsx
@@ -1,5 +1,3 @@
-import { type Route } from 'next'
-
 import { Card } from '@/components/Card'
 import { CardLayout } from '@/components/CardLayout'
 
@@ -29,9 +27,7 @@ export function FeaturedBlogPosts({ maxPosts = 4 }: FeaturedBlogPostsProps) {
           key={slug}
           title={title}
           description={description}
-          cta={{
-            href: `${PATHS.BLOG.path}/${slug}` as Route,
-          }}
+          cta={{ href: PATHS.BLOG.getPathWithSlugs([slug]) }}
           image={image}
           textIsClamped={true}
         />

--- a/src/app/_components/FeaturedCaseStudies.tsx
+++ b/src/app/_components/FeaturedCaseStudies.tsx
@@ -1,5 +1,3 @@
-import { type Route } from 'next'
-
 import { Card } from '@/components/Card'
 import { CardLayout } from '@/components/CardLayout'
 
@@ -31,9 +29,7 @@ export function FeaturedCaseStudies({
           key={slug}
           title={title}
           description={description}
-          cta={{
-            href: `${PATHS.CASE_STUDIES.path}/${slug}` as Route,
-          }}
+          cta={{ href: PATHS.CASE_STUDIES.getPathWithSlugs([slug]) }}
           image={image}
           borderColor="brand-300"
           textIsClamped={true}

--- a/src/app/_constants/paths.ts
+++ b/src/app/_constants/paths.ts
@@ -1,3 +1,5 @@
+import { Route } from 'next'
+
 export type BlogPostPath = `/blog/${string}`
 export type CaseStudyPath = `/case-studies/${string}`
 export type EventPath = `/events/${string}`
@@ -17,44 +19,36 @@ export type PathValues =
   | '/privacy-policy'
   | '/terms'
 
-export interface PathConfig {
-  path: PathValues
-  label: string
-  mainContentPath: string
-  entriesContentPath?: string
-}
-
 const CONTENT_ROOT = 'src/content'
 const CONTENT_PAGES_ROOT = `${CONTENT_ROOT}/pages`
 
-function createPathObject(
-  path: PathValues,
-  label: string,
-  includesEntries: boolean = false,
-  customPath?: string,
-): PathConfig {
-  const config: PathConfig = {
+function createPathObject<
+  P extends PathValues,
+  L extends string,
+  CP extends string
+>(path: P, label: L, customPath?: CP) {
+  return {
     path,
     label,
     mainContentPath: `${CONTENT_PAGES_ROOT}${customPath ?? path}`,
+    entriesContentPath: `${CONTENT_ROOT}${path}`,
+    getPathWithSlugs: function (slugs: Array<string>) {
+      return `${path}/${slugs.join('/')}` as Route<`{${P}/${string}}`>
+    }
   }
-  if (includesEntries) {
-    config.entriesContentPath = `${CONTENT_ROOT}${path}`
-  }
-
-  return config
 }
+export type PathConfig = ReturnType<typeof createPathObject>
 
 export const PATHS = {
   ABOUT: createPathObject('/about', 'About'),
-  BLOG: createPathObject('/blog', 'News & Blog', true),
-  CASE_STUDIES: createPathObject('/case-studies', 'Case Studies', true),
-  ECOSYSTEM: createPathObject('/ecosystem', 'Ecosystem', true),
-  EVENTS: createPathObject('/events', 'Events', true),
+  BLOG: createPathObject('/blog', 'News & Blog'),
+  CASE_STUDIES: createPathObject('/case-studies', 'Case Studies'),
+  ECOSYSTEM: createPathObject('/ecosystem', 'Ecosystem'),
+  EVENTS: createPathObject('/events', 'Events'),
   GET_INVOLVED: createPathObject('/get-involved', 'Get Involved'),
   GOVERNANCE: createPathObject('/governance', 'Governance'),
   GRANTS: createPathObject('/grants', 'Grants'),
-  HOME: createPathObject('/', 'Home', false, '/home'),
+  HOME: createPathObject('/', 'Home', '/home'),
   PRIVACY_POLICY: createPathObject('/privacy-policy', 'Privacy Policy'),
-  TERMS: createPathObject('/terms', 'Terms and Conditions'),
+  TERMS: createPathObject('/terms', 'Terms and Conditions')
 } as const

--- a/src/app/_utils/generateDynamicContentMetadata.ts
+++ b/src/app/_utils/generateDynamicContentMetadata.ts
@@ -3,12 +3,12 @@ import { createMetadata } from '@/utils/createMetadata'
 import { PathValues } from '@/constants/paths'
 
 type DynamicContentMetadata = {
-  path: PathValues
+  basePath: PathValues
   data: { title: string; description?: string; slug: string }
 }
 
 export function generateDynamicContentMetadata({
-  path,
+  basePath,
   data,
 }: DynamicContentMetadata) {
   const seo = {
@@ -16,9 +16,13 @@ export function generateDynamicContentMetadata({
     description: data.description,
   }
 
-  if (path == '/blog' || path == '/case-studies' || path == '/events') {
-    return createMetadata(seo, `${path}/${data.slug}`)
+  if (
+    basePath == '/blog' ||
+    basePath == '/case-studies' ||
+    basePath == '/events'
+  ) {
+    return createMetadata(seo, `${basePath}/${data.slug}`)
   }
 
-  return createMetadata(seo, path)
+  return createMetadata(seo, basePath)
 }

--- a/src/app/_utils/generateDynamicContentMetadata.ts
+++ b/src/app/_utils/generateDynamicContentMetadata.ts
@@ -1,22 +1,24 @@
-import { Metadata } from 'next'
-
 import { createMetadata } from '@/utils/createMetadata'
 
-import { DynamicPathValues } from '@/constants/paths'
+import { PathValues } from '@/constants/paths'
+
+type DynamicContentMetadata = {
+  path: PathValues
+  data: { title: string; description?: string; slug: string }
+}
 
 export function generateDynamicContentMetadata({
-  basePath,
+  path,
   data,
-}: {
-  basePath: string
-  data: { title: string; description?: string; slug: string }
-}): Metadata {
+}: DynamicContentMetadata) {
   const seo = {
     title: data.title,
     description: data.description,
   }
 
-  const path = `${basePath}/${data.slug}` as DynamicPathValues
+  if (path == '/blog' || path == '/case-studies' || path == '/events') {
+    return createMetadata(seo, `${path}/${data.slug}`)
+  }
 
   return createMetadata(seo, path)
 }


### PR DESCRIPTION
This is not meant to be merged, it's more of an exploration to solve the [type assertion issue](https://www.notion.so/filecoin/FF-V4-Remove-type-assertions-where-possible-930e3987cb3c4854b8f201a9d8a3fa81?pvs=4) and make some of the types more explicit.

The main change is in the `src/app/_constants/paths.ts` file:

```ts
import { Route } from 'next'

export type BlogPostPath = `/blog/${string}`
export type CaseStudyPath = `/case-studies/${string}`
export type EventPath = `/events/${string}`

export type DynamicPathValues = BlogPostPath | CaseStudyPath | EventPath

export type PathValues =
  | '/about'
  | '/blog'
  | '/case-studies'
  | '/ecosystem'
  | '/events'
  | '/get-involved'
  | '/governance'
  | '/grants'
  | '/'
  | '/privacy-policy'
  | '/terms'

const CONTENT_ROOT = 'src/content'
const CONTENT_PAGES_ROOT = `${CONTENT_ROOT}/pages`

function createPathObject<
  P extends PathValues,
  L extends string,
  CP extends string
>(path: P, label: L, customPath?: CP) {
  return {
    path,
    label,
    mainContentPath: `${CONTENT_PAGES_ROOT}${customPath ?? path}`,
    entriesContentPath: `${CONTENT_ROOT}${path}`,
    getPathWithSlugs: function (slugs: Array<string>) {
      return `${path}/${slugs.join('/')}` as Route<`{${P}/${string}}`>
    }
  }
}
export type PathConfig = ReturnType<typeof createPathObject>

export const PATHS = {
  ABOUT: createPathObject('/about', 'About'),
  BLOG: createPathObject('/blog', 'News & Blog'),
  CASE_STUDIES: createPathObject('/case-studies', 'Case Studies'),
  ECOSYSTEM: createPathObject('/ecosystem', 'Ecosystem'),
  EVENTS: createPathObject('/events', 'Events'),
  GET_INVOLVED: createPathObject('/get-involved', 'Get Involved'),
  GOVERNANCE: createPathObject('/governance', 'Governance'),
  GRANTS: createPathObject('/grants', 'Grants'),
  HOME: createPathObject('/', 'Home', '/home'),
  PRIVACY_POLICY: createPathObject('/privacy-policy', 'Privacy Policy'),
  TERMS: createPathObject('/terms', 'Terms and Conditions')
} as const

```

