### PR TITLE
Blog Post Pagination

### DIFF
--- a/src/app/_components/BlogPostCard.tsx
+++ b/src/app/_components/BlogPostCard.tsx
@@ -1,0 +1,46 @@
+import Image from 'next/image'
+
+import clsx from 'clsx'
+
+import { Heading } from '@/components/Heading'
+import { TextLink } from '@/components/TextLink'
+
+import type { BlogPostData } from '@/types/blogPostTypes'
+
+import { formatDate } from '@/utils/formatDate'
+
+import { PATHS } from '@/constants/paths'
+
+type BlogPostCardProps = {
+  className?: string
+  post: BlogPostData
+}
+
+export function BlogPostCard({ post, className }: BlogPostCardProps) {
+  const { title, description, slug, image, publishedOn } = post
+
+  return (
+    <li
+      key={slug}
+      className={clsx('rounded-md border border-brand-600 p-4', className)}
+    >
+      {image.url && (
+        <Image
+          src={image.url}
+          alt={image.alt}
+          width={282}
+          height={141}
+          className="object-cover"
+        />
+      )}
+      <Heading tag="h3" variant="lg">
+        {title}
+      </Heading>
+      <p>{description}</p>
+      {publishedOn && (
+        <span className="block">{formatDate(publishedOn, 'blog')}</span>
+      )}
+      <TextLink href={`${PATHS.BLOG.path}/${slug}`}>Read More</TextLink>
+    </li>
+  )
+}

--- a/src/app/_components/BlogPostCard.tsx
+++ b/src/app/_components/BlogPostCard.tsx
@@ -20,10 +20,7 @@ export function BlogPostCard({ post, className }: BlogPostCardProps) {
   const { title, description, slug, image, publishedOn } = post
 
   return (
-    <li
-      key={slug}
-      className={clsx('rounded-md border border-brand-600 p-4', className)}
-    >
+    <li className={clsx('rounded-md border border-brand-600 p-4', className)}>
       {image.url && (
         <Image
           src={image.url}

--- a/src/app/_components/BlogPostCard.tsx
+++ b/src/app/_components/BlogPostCard.tsx
@@ -16,11 +16,20 @@ type BlogPostCardProps = {
   post: BlogPostData
 }
 
+// TODO
+// [] Make the whole card clickable
+// [] Add text ellipsis to the title and/or description
+
 export function BlogPostCard({ post, className }: BlogPostCardProps) {
   const { title, description, slug, image, publishedOn } = post
 
   return (
-    <li className={clsx('rounded-md border border-brand-600 p-4', className)}>
+    <li
+      className={clsx(
+        'h-[400px] overflow-clip rounded-md border border-brand-600 p-4',
+        className,
+      )}
+    >
       {image.url && (
         <Image
           src={image.url}

--- a/src/app/_components/ClientPagination.tsx
+++ b/src/app/_components/ClientPagination.tsx
@@ -1,0 +1,66 @@
+'use client'
+
+import clsx from 'clsx'
+
+type PaginationProps = {
+  currentPage: number
+  total: number
+  size: number
+  setCurrentPage: (page: number) => void
+}
+
+export function ClientPagination({
+  currentPage,
+  setCurrentPage,
+  total,
+  size,
+}: PaginationProps) {
+  const pages = Math.ceil(total / size)
+
+  return (
+    <div className="flex justify-between gap-4 rounded-lg bg-brand-300 p-2 text-brand-700">
+      {/* Prev */}
+      <button
+        className="rounded px-3 py-1 transition hover:bg-brand-400/30"
+        onClick={() => {
+          if (currentPage > 1) setCurrentPage(currentPage - 1)
+        }}
+      >
+        Prev
+      </button>
+
+      {/* Numbers */}
+      <div className="flex justify-center gap-2">
+        {Array.from({ length: pages }).map((_, index) => {
+          const page = index + 1
+
+          return (
+            <button
+              key={page}
+              className={clsx(
+                'size-8 rounded transition-colors duration-75',
+                page == currentPage && 'bg-brand-800 text-brand-100',
+                page != currentPage && 'bg-brand-300 text-brand-700',
+              )}
+              onClick={() => {
+                if (page != currentPage) setCurrentPage(page)
+              }}
+            >
+              {page}
+            </button>
+          )
+        })}
+      </div>
+
+      {/* Next */}
+      <button
+        className="rounded px-3 py-1 transition hover:bg-brand-400/30"
+        onClick={() => {
+          if (currentPage < pages) setCurrentPage(currentPage + 1)
+        }}
+      >
+        Next
+      </button>
+    </div>
+  )
+}

--- a/src/app/blog/BlogClient.tsx
+++ b/src/app/blog/BlogClient.tsx
@@ -2,9 +2,7 @@
 
 import { useState, useMemo, useEffect } from 'react'
 
-import { useSearchParams, usePathname, useRouter } from 'next/navigation'
-
-import type { Route } from 'next'
+import { useSearchParams, usePathname } from 'next/navigation'
 
 import { BlogPostCard } from '@/components/BlogPostCard'
 import { ClientPagination } from '@/components/ClientPagination'
@@ -19,7 +17,6 @@ const PAGE_KEY = 'page'
 export function BlogClient({ posts }: { posts: BlogPostData[] }) {
   const searchParams = useSearchParams()
   const pathname = usePathname()
-  const router = useRouter()
 
   const [searchQuery, setSearchQuery] = useState<string>(() => {
     return searchParams.get(SEARCH_QUERY_KEY) || ''
@@ -58,10 +55,10 @@ export function BlogClient({ posts }: { posts: BlogPostData[] }) {
       params.set(PAGE_KEY, String(currentPage))
     }
 
-    const url = `${pathname}?${params.toString()}` as Route
-    router.replace(url, { scroll: false })
+    const url = `${pathname}?${params.toString()}`
+    window.history.replaceState({}, '', url)
 
-    return () => router.replace(pathname as Route, { scroll: false })
+    return () => window.history.replaceState({}, '', pathname)
   }, [currentPage, searchQuery])
 
   return (

--- a/src/app/blog/BlogClient.tsx
+++ b/src/app/blog/BlogClient.tsx
@@ -3,7 +3,7 @@
 import { useState, useMemo } from 'react'
 
 import { BlogPostCard } from '@/components/BlogPostCard'
-import { Button } from '@/components/Button'
+import { ClientPagination } from '@/components/ClientPagination'
 
 import type { BlogPostData } from '@/types/blogPostTypes'
 
@@ -11,11 +11,10 @@ const POSTS_PER_LOAD = 20
 
 export function BlogClient({ posts }: { posts: BlogPostData[] }) {
   const [searchQuery, setSearchQuery] = useState<string>('')
-  const [visibleCount, setVisibleCount] = useState<number>(POSTS_PER_LOAD)
+  const [currentPage, setCurrentPage] = useState<number>(1)
 
   function handleSearch(event: React.ChangeEvent<HTMLInputElement>) {
     setSearchQuery(event.target.value.toLowerCase())
-    setVisibleCount(POSTS_PER_LOAD)
   }
 
   const sortedPosts = useMemo(() => {
@@ -36,15 +35,6 @@ export function BlogClient({ posts }: { posts: BlogPostData[] }) {
     [searchQuery, sortedPosts],
   )
 
-  function handleLoadMore() {
-    setVisibleCount((currentCount) => currentCount + POSTS_PER_LOAD)
-  }
-
-  const visiblePosts = filteredPosts.slice(0, visibleCount)
-  const hiddenPosts = filteredPosts.slice(visibleCount)
-
-  const hasMorePosts = visibleCount < filteredPosts.length
-
   return (
     <>
       <label htmlFor="search">Search Blog Posts</label>
@@ -61,20 +51,37 @@ export function BlogClient({ posts }: { posts: BlogPostData[] }) {
       <br />
 
       <ul className="grid grid-cols-2 gap-8">
-        {visiblePosts.slice(0, visibleCount).map((post) => {
-          return <BlogPostCard key={post.slug} post={post} />
-        })}
-        {hiddenPosts.map((post) => {
+        {filteredPosts.map((post, i) => {
           return (
-            <BlogPostCard key={post.slug} post={post} className="sr-only" />
+            <BlogPostCard
+              key={post.slug}
+              className={applyClasses(i)}
+              post={post}
+            />
           )
         })}
       </ul>
-      {hasMorePosts && (
-        <Button aria-label="Load more posts" onClick={handleLoadMore}>
-          Load More
-        </Button>
-      )}
+
+      <div className="mx-auto mt-8 max-w-2xl">
+        <ClientPagination
+          currentPage={currentPage}
+          total={filteredPosts.length}
+          size={POSTS_PER_LOAD}
+          setCurrentPage={setCurrentPage}
+        />
+      </div>
     </>
   )
+
+  function applyClasses(i: number) {
+    // Only show 20 posts at a time, the rest show be hidden with sr-only
+    if (
+      i >= (currentPage - 1) * POSTS_PER_LOAD &&
+      i < currentPage * POSTS_PER_LOAD
+    ) {
+      return 'block'
+    }
+
+    return 'sr-only'
+  }
 }

--- a/src/app/blog/BlogClient.tsx
+++ b/src/app/blog/BlogClient.tsx
@@ -2,17 +2,10 @@
 
 import { useState, useMemo } from 'react'
 
-import Image from 'next/image'
-
+import { BlogPostCard } from '@/components/BlogPostCard'
 import { Button } from '@/components/Button'
-import { Heading } from '@/components/Heading'
-import { TextLink } from '@/components/TextLink'
 
-import { BlogPostData } from '@/types/blogPostTypes'
-
-import { formatDate } from '@/utils/formatDate'
-
-import { PATHS } from '@/constants/paths'
+import type { BlogPostData } from '@/types/blogPostTypes'
 
 const POSTS_PER_LOAD = 20
 
@@ -35,13 +28,20 @@ export function BlogClient({ posts }: { posts: BlogPostData[] }) {
     })
   }, [posts])
 
-  const filteredPosts = sortedPosts.filter((post) =>
-    post.title.toLowerCase().includes(searchQuery),
+  const filteredPosts = useMemo(
+    () =>
+      sortedPosts.filter((post) => {
+        return post.title.toLowerCase().includes(searchQuery)
+      }),
+    [searchQuery, sortedPosts],
   )
 
   function handleLoadMore() {
     setVisibleCount((currentCount) => currentCount + POSTS_PER_LOAD)
   }
+
+  const visiblePosts = filteredPosts.slice(0, visibleCount)
+  const hiddenPosts = filteredPosts.slice(visibleCount)
 
   const hasMorePosts = visibleCount < filteredPosts.length
 
@@ -61,34 +61,14 @@ export function BlogClient({ posts }: { posts: BlogPostData[] }) {
       <br />
 
       <ul className="grid grid-cols-2 gap-8">
-        {filteredPosts.slice(0, visibleCount).map((post) => (
-          <li
-            key={post.slug}
-            className="rounded-md border border-brand-600 p-4"
-          >
-            {post.image.url && (
-              <Image
-                src={post.image.url}
-                alt={post.image.alt}
-                width={282}
-                height={141}
-                className="object-cover"
-              />
-            )}
-            <Heading tag="h3" variant="lg">
-              {post.title}
-            </Heading>
-            <p>{post.description}</p>
-            {post.publishedOn && (
-              <span className="block">
-                {formatDate(post.publishedOn, 'blog')}
-              </span>
-            )}
-            <TextLink href={`${PATHS.BLOG.path}/${post.slug}`}>
-              Read More
-            </TextLink>
-          </li>
-        ))}
+        {visiblePosts.slice(0, visibleCount).map((post) => {
+          return <BlogPostCard key={post.slug} post={post} />
+        })}
+        {hiddenPosts.map((post) => {
+          return (
+            <BlogPostCard key={post.slug} post={post} className="sr-only" />
+          )
+        })}
       </ul>
       {hasMorePosts && (
         <Button aria-label="Load more posts" onClick={handleLoadMore}>

--- a/src/app/blog/BlogClient.tsx
+++ b/src/app/blog/BlogClient.tsx
@@ -39,7 +39,7 @@ export function BlogClient({ posts }: { posts: BlogPostData[] }) {
 
   const filteredPosts = useMemo(() => {
     return sortedPosts.filter((post) => {
-      return post.title.toLowerCase().includes(searchQuery)
+      return post.title.toLowerCase().includes(searchQuery.toLowerCase())
     })
   }, [searchQuery, sortedPosts])
 
@@ -108,7 +108,7 @@ export function BlogClient({ posts }: { posts: BlogPostData[] }) {
 
   function handleSearch(event: React.ChangeEvent<HTMLInputElement>) {
     setCurrentPage(1)
-    setSearchQuery(event.target.value.toLowerCase())
+    setSearchQuery(event.target.value)
   }
 
   function applyClasses(i: number) {

--- a/src/app/blog/BlogClient.tsx
+++ b/src/app/blog/BlogClient.tsx
@@ -85,6 +85,12 @@ export function BlogClient({ posts }: { posts: BlogPostData[] }) {
         })}
       </ul>
 
+      {!filteredPosts.length && (
+        <p className="mt-8 rounded-md border border-brand-600 p-4">
+          No results found for your search, try changing your search query.
+        </p>
+      )}
+
       <div className="mx-auto mt-8 max-w-2xl">
         <ClientPagination
           currentPage={currentPage}

--- a/src/app/blog/BlogClient.tsx
+++ b/src/app/blog/BlogClient.tsx
@@ -14,7 +14,7 @@ import { formatDate } from '@/utils/formatDate'
 
 import { PATHS } from '@/constants/paths'
 
-const POSTS_PER_LOAD = 9
+const POSTS_PER_LOAD = 20
 
 export function BlogClient({ posts }: { posts: BlogPostData[] }) {
   const [searchQuery, setSearchQuery] = useState<string>('')
@@ -36,7 +36,7 @@ export function BlogClient({ posts }: { posts: BlogPostData[] }) {
   }, [posts])
 
   const filteredPosts = sortedPosts.filter((post) =>
-    post.title.toLowerCase().includes(searchQuery)
+    post.title.toLowerCase().includes(searchQuery),
   )
 
   function handleLoadMore() {
@@ -56,9 +56,16 @@ export function BlogClient({ posts }: { posts: BlogPostData[] }) {
         className="text-brand-800"
         onChange={handleSearch}
       />
-      <ul>
+
+      <br />
+      <br />
+
+      <ul className="grid grid-cols-2 gap-8">
         {filteredPosts.slice(0, visibleCount).map((post) => (
-          <li key={post.slug}>
+          <li
+            key={post.slug}
+            className="rounded-md border border-brand-600 p-4"
+          >
             {post.image.url && (
               <Image
                 src={post.image.url}

--- a/src/app/blog/BlogClient.tsx
+++ b/src/app/blog/BlogClient.tsx
@@ -48,8 +48,15 @@ export function BlogClient({ posts }: { posts: BlogPostData[] }) {
 
   useEffect(() => {
     const params = new URLSearchParams(searchParams.toString())
-    if (searchQuery) params.set(SEARCH_QUERY_KEY, searchQuery)
-    params.set(PAGE_KEY, String(currentPage))
+
+    if (searchParams.get(SEARCH_QUERY_KEY) != searchQuery) {
+      if (!searchQuery) params.delete(SEARCH_QUERY_KEY)
+      if (searchQuery) params.set(SEARCH_QUERY_KEY, searchQuery)
+    }
+
+    if (searchParams.get(PAGE_KEY) != String(currentPage)) {
+      params.set(PAGE_KEY, String(currentPage))
+    }
 
     const url = `${pathname}?${params.toString()}` as Route
     router.replace(url, { scroll: false })


### PR DESCRIPTION
This PR adds pagination to the blog page index.

It doesn't match the Figma designs perfectly yet, but I want to get feedback on how the feature works before polishing the UI.

- [x]  Display 20 posts at a time while keeping the other posts accessible on the page.
- [x] There will be no progressive loading, all blog posts will be on the page for accessibility and SEO purposes
- [x]  Keep the current page in sync with the URL so that it’s shareable / persisted across reloads
- [x]  Keep the search query in sync with the URL so that it’s shareable / persisted across reloads
- [x]  Fix the blog card’s height to avoid layout shifts

https://www.notion.so/filecoin/FF-V4-Pagination-09ddd17d7f2b429f89982c052f74a923?pvs=4