### PR TITLE
Refactor PageLayout and PageHeader components

### DIFF
--- a/src/app/_components/PageHeader.tsx
+++ b/src/app/_components/PageHeader.tsx
@@ -32,40 +32,34 @@ export function PageHeader({
   metaData,
 }: PageHeaderProps) {
   return (
-    <>
-      <header className="flex flex-col gap-6 md:flex-row">
-        <div className="flex flex-col md:w-1/2">
-          <Heading tag="h1" variant="4xl" className="mb-4">
-            {title}
-          </Heading>
-          {metaData && <div className="mb-6">{metaData}</div>}
-          <p className="mb-6">{description}</p>
-          <div className="flex flex-col gap-4 sm:flex-row sm:gap-6 md:flex-col md:gap-4">
-            <Button href={cta.href} variant="primary" className="flex-1">
-              {cta.text}
+    <header className="flex flex-col gap-6 md:flex-row">
+      <div className="flex flex-col md:w-1/2">
+        <Heading tag="h1" variant="4xl" className="mb-4">
+          {title}
+        </Heading>
+        {metaData && <div className="mb-6">{metaData}</div>}
+        <p className="mb-6">{description}</p>
+        <div className="flex flex-col gap-4 sm:flex-row sm:gap-6 md:flex-col md:gap-4">
+          <Button href={cta.href} variant="primary" className="flex-1">
+            {cta.text}
+          </Button>
+          {secondaryCta && (
+            <Button href={secondaryCta.href} variant="ghost" className="flex-1">
+              {secondaryCta.text}
             </Button>
-            {secondaryCta && (
-              <Button
-                href={secondaryCta.href}
-                variant="ghost"
-                className="flex-1"
-              >
-                {secondaryCta.text}
-              </Button>
-            )}
-          </div>
+          )}
         </div>
-        {image && (
-          <div className="relative h-32 w-full rounded-lg border border-brand-100 sm:h-60 md:h-auto md:w-1/2">
-            <Image
-              fill
-              src={image.url}
-              alt={image.alt}
-              className="block rounded-lg object-cover"
-            />
-          </div>
-        )}
-      </header>
-    </>
+      </div>
+      {image && (
+        <div className="relative h-32 w-full rounded-lg border border-brand-100 sm:h-60 md:h-auto md:w-1/2">
+          <Image
+            fill
+            src={image.url}
+            alt={image.alt}
+            className="block rounded-lg object-cover"
+          />
+        </div>
+      )}
+    </header>
   )
 }

--- a/src/app/_components/PageHeader.tsx
+++ b/src/app/_components/PageHeader.tsx
@@ -1,20 +1,71 @@
+import Image from 'next/image'
+
+import { Button } from '@/components/Button'
 import { Heading } from '@/components/Heading'
-import { TextLink } from '@/components/TextLink'
+
+type ctaProps = {
+  href: string
+  text: string
+  icon?: React.ReactNode
+}
+
+type imageProps = {
+  url: string
+  alt: string
+}
 
 type PageHeaderProps = {
   title: string
   description: string
-  link?: { href: string; text: string }
+  cta: ctaProps
+  secondaryCta?: ctaProps
+  image?: imageProps
+  metaData?: React.ReactNode
 }
 
-export function PageHeader({ title, description, link }: PageHeaderProps) {
+export function PageHeader({
+  title,
+  description,
+  cta,
+  secondaryCta,
+  image,
+  metaData,
+}: PageHeaderProps) {
   return (
-    <header>
-      <Heading className="mb-4" tag="h1" variant="4xl">
-        {title}
-      </Heading>
-      <p>{description}</p>
-      {link && <TextLink href={link.href}>{link.text}</TextLink>}
-    </header>
+    <>
+      <header className="flex flex-col gap-6 md:flex-row">
+        <div className="flex flex-col md:w-1/2">
+          <Heading tag="h1" variant="4xl" className="mb-4">
+            {title}
+          </Heading>
+          {metaData && <div className="mb-6">{metaData}</div>}
+          <p className="mb-6">{description}</p>
+          <div className="flex flex-col gap-4 sm:flex-row sm:gap-6 md:flex-col md:gap-4">
+            <Button href={cta.href} variant="primary" className="flex-1">
+              {cta.text}
+            </Button>
+            {secondaryCta && (
+              <Button
+                href={secondaryCta.href}
+                variant="ghost"
+                className="flex-1"
+              >
+                {secondaryCta.text}
+              </Button>
+            )}
+          </div>
+        </div>
+        {image && (
+          <div className="relative h-32 w-full rounded-lg border border-brand-100 sm:h-60 md:h-auto md:w-1/2">
+            <Image
+              fill
+              src={image.url}
+              alt={image.alt}
+              className="block rounded-lg object-cover"
+            />
+          </div>
+        )}
+      </header>
+    </>
   )
 }

--- a/src/app/_components/PageLayout.tsx
+++ b/src/app/_components/PageLayout.tsx
@@ -1,0 +1,7 @@
+type PageLayoutProps = {
+  children: React.ReactNode
+}
+
+export function PageLayout({ children }: PageLayoutProps) {
+  return <div className="flex flex-col gap-24 sm:gap-16">{children}</div>
+}

--- a/src/app/about/page.tsx
+++ b/src/app/about/page.tsx
@@ -2,11 +2,11 @@ import { Files, LinkedinLogo } from '@phosphor-icons/react/dist/ssr'
 import clsx from 'clsx'
 import { WebPage, WithContext } from 'schema-dts'
 
-import { Button } from '@/components/Button'
 import { Card } from '@/components/Card'
 import { CardLayout } from '@/components/CardLayout'
 import { Heading } from '@/components/Heading'
 import { PageHeader } from '@/components/PageHeader'
+import { PageLayout } from '@/components/PageLayout'
 import { PageSection } from '@/components/PageSection'
 import { StructuredDataScript } from '@/components/StructuredDataScript'
 
@@ -201,94 +201,88 @@ function NameWithLinkedInLink({ name, linkedIn }: NameWithLinkedInLinkProps) {
 
 export default function About() {
   return (
-    <>
+    <PageLayout>
       <StructuredDataScript structuredData={aboutPageStructuredData} />
+      <PageHeader
+        title={header.title}
+        description={header.description}
+        cta={{
+          href: FILECOIN_FOUNDATION_URLS.annualReports.latest,
+          text: 'Learn More in Our Annual Report',
+        }}
+      />
 
-      <div className="flex flex-col gap-24 sm:gap-16">
-        <div className="flex flex-col gap-6 md:w-1/2">
-          <PageHeader title={header.title} description={header.description} />
-          <div className="flex flex-col gap-4 sm:flex-row sm:gap-6 md:flex-col md:gap-4">
-            <Button
-              variant="primary"
-              href={FILECOIN_FOUNDATION_URLS.annualReports.latest}
+      <PageSection
+        kicker="About"
+        title="Our Mission"
+        description="The Foundation’s mission is to preserve humanity’s most important information."
+      />
+
+      <PageSection kicker="What We Do" title="Focus Areas">
+        <CardLayout>
+          {focusAreasData.map(({ title, description }) => (
+            <Card
+              key={title}
+              title={title}
+              description={description}
+              borderColor="brand-300"
+            />
+          ))}
+        </CardLayout>
+      </PageSection>
+
+      <PageSection kicker="Who We Are" title="Board Members">
+        <CardLayout type="blogPost">
+          {boardMembersData.map(({ name, title, linkedIn }) => (
+            <Card
+              key={name}
+              title={<NameWithLinkedInLink name={name} linkedIn={linkedIn} />}
             >
-              Learn More in Our Annual Report
-            </Button>
-          </div>
-        </div>
+              <p className="text-brand-300">{title}</p>
+            </Card>
+          ))}
+        </CardLayout>
+      </PageSection>
 
-        <PageSection
-          kicker="About"
-          title="Our Mission"
-          description="The Foundation’s mission is to preserve humanity’s most important information."
-        />
+      <PageSection
+        kicker="Advisors"
+        title="Advisors"
+        description="Leaders from across web3 and the open-source technology communities have come together to foster the Filecoin ecosystem."
+      >
+        <CardLayout type="blogPost">
+          {advisorsData.map(({ name, title, linkedIn }) => (
+            <Card
+              key={name}
+              title={<NameWithLinkedInLink name={name} linkedIn={linkedIn} />}
+            >
+              <p className="text-brand-300">{title}</p>
+            </Card>
+          ))}
+        </CardLayout>
+      </PageSection>
 
-        <PageSection kicker="What We Do" title="Focus Areas">
-          <CardLayout>
-            {focusAreasData.map(({ title, description }) => (
+      <PageSection kicker="Reports" title="Reports">
+        <CardLayout type="reports">
+          {reportsData.map(({ title, description, link }, index) => (
+            <div
+              key={title}
+              className={clsx({
+                'lg:row-span-2': index === 0,
+              })}
+            >
               <Card
-                key={title}
                 title={title}
                 description={description}
-                borderColor="brand-300"
+                cta={{
+                  href: link,
+                  text: 'View Report',
+                  icon: <Files />,
+                }}
               />
-            ))}
-          </CardLayout>
-        </PageSection>
-
-        <PageSection kicker="Who We Are" title="Board Members">
-          <CardLayout type="blogPost">
-            {boardMembersData.map(({ name, title, linkedIn }) => (
-              <Card
-                key={name}
-                title={<NameWithLinkedInLink name={name} linkedIn={linkedIn} />}
-              >
-                <p className="text-brand-300">{title}</p>
-              </Card>
-            ))}
-          </CardLayout>
-        </PageSection>
-
-        <PageSection
-          kicker="Advisors"
-          title="Advisors"
-          description="Leaders from across web3 and the open-source technology communities have come together to foster the Filecoin ecosystem."
-        >
-          <CardLayout type="blogPost">
-            {advisorsData.map(({ name, title, linkedIn }) => (
-              <Card
-                key={name}
-                title={<NameWithLinkedInLink name={name} linkedIn={linkedIn} />}
-              >
-                <p className="text-brand-300">{title}</p>
-              </Card>
-            ))}
-          </CardLayout>
-        </PageSection>
-
-        <PageSection kicker="Reports" title="Reports">
-          <CardLayout type="reports">
-            {reportsData.map(({ title, description, link }, index) => (
-              <div
-                key={title}
-                className={clsx({
-                  'lg:row-span-2': index === 0,
-                })}
-              >
-                <Card
-                  title={title}
-                  description={description}
-                  cta={{
-                    href: link,
-                    text: 'View Report',
-                    icon: <Files />,
-                  }}
-                />
-              </div>
-            ))}
-          </CardLayout>
-        </PageSection>
-      </div>
-    </>
+            </div>
+          ))}
+        </CardLayout>
+      </PageSection>
+    </PageLayout>
   )
 }

--- a/src/app/blog/page.tsx
+++ b/src/app/blog/page.tsx
@@ -1,6 +1,7 @@
 import { WebPage, WithContext } from 'schema-dts'
 
 import { PageHeader } from '@/components/PageHeader'
+import { PageLayout } from '@/components/PageLayout'
 import { StructuredDataScript } from '@/components/StructuredDataScript'
 
 import { createMetadata } from '@/utils/createMetadata'
@@ -52,11 +53,21 @@ export default function Blog() {
   return (
     <>
       <StructuredDataScript structuredData={blogPageStructuredData} />
-      <PageHeader title={header.title} description={header.description} />
 
-      <div>
-        <BlogClient posts={posts} />
-      </div>
+      <PageLayout>
+        <PageHeader
+          title={header.title}
+          description={header.description}
+          cta={{
+            href: '#',
+            text: 'Read Post',
+          }}
+        />
+
+        <div>
+          <BlogClient posts={posts} />
+        </div>
+      </PageLayout>
     </>
   )
 }

--- a/src/app/blog/page.tsx
+++ b/src/app/blog/page.tsx
@@ -51,23 +51,20 @@ const blogPageStructuredData: WithContext<WebPage> = {
 
 export default function Blog() {
   return (
-    <>
+    <PageLayout>
       <StructuredDataScript structuredData={blogPageStructuredData} />
+      <PageHeader
+        title={header.title}
+        description={header.description}
+        cta={{
+          href: '#',
+          text: 'Read Post',
+        }}
+      />
 
-      <PageLayout>
-        <PageHeader
-          title={header.title}
-          description={header.description}
-          cta={{
-            href: '#',
-            text: 'Read Post',
-          }}
-        />
-
-        <div>
-          <BlogClient posts={posts} />
-        </div>
-      </PageLayout>
-    </>
+      <div>
+        <BlogClient posts={posts} />
+      </div>
+    </PageLayout>
   )
 }

--- a/src/app/case-studies/page.tsx
+++ b/src/app/case-studies/page.tsx
@@ -52,21 +52,18 @@ const caseStudiesPageStructuredData: WithContext<WebPage> = {
 
 export default function CaseStudies() {
   return (
-    <>
+    <PageLayout>
       <StructuredDataScript structuredData={caseStudiesPageStructuredData} />
+      <PageHeader
+        title={header.title}
+        description={header.description}
+        cta={{
+          href: '#',
+          text: 'Learn More',
+        }}
+      />
 
-      <PageLayout>
-        <PageHeader
-          title={header.title}
-          description={header.description}
-          cta={{
-            href: '#',
-            text: 'Learn More',
-          }}
-        />
-
-        <CaseStudiesList caseStudies={caseStudies} />
-      </PageLayout>
-    </>
+      <CaseStudiesList caseStudies={caseStudies} />
+    </PageLayout>
   )
 }

--- a/src/app/case-studies/page.tsx
+++ b/src/app/case-studies/page.tsx
@@ -2,6 +2,7 @@ import { WebPage, WithContext } from 'schema-dts'
 
 import { CaseStudiesList } from '@/components/CaseStudiesList'
 import { PageHeader } from '@/components/PageHeader'
+import { PageLayout } from '@/components/PageLayout'
 import { StructuredDataScript } from '@/components/StructuredDataScript'
 
 import { createMetadata } from '@/utils/createMetadata'
@@ -53,8 +54,19 @@ export default function CaseStudies() {
   return (
     <>
       <StructuredDataScript structuredData={caseStudiesPageStructuredData} />
-      <PageHeader title={header.title} description={header.description} />
-      <CaseStudiesList caseStudies={caseStudies} />
+
+      <PageLayout>
+        <PageHeader
+          title={header.title}
+          description={header.description}
+          cta={{
+            href: '#',
+            text: 'Learn More',
+          }}
+        />
+
+        <CaseStudiesList caseStudies={caseStudies} />
+      </PageLayout>
     </>
   )
 }

--- a/src/app/ecosystem/page.tsx
+++ b/src/app/ecosystem/page.tsx
@@ -5,6 +5,7 @@ import { FeaturedCaseStudies } from '@/components/FeaturedCaseStudies'
 import { FeaturedEcosystemProjects } from '@/components/FeaturedEcosystemProjects'
 import { Heading } from '@/components/Heading'
 import { PageHeader } from '@/components/PageHeader'
+import { PageLayout } from '@/components/PageLayout'
 import { StructuredDataScript } from '@/components/StructuredDataScript'
 
 import { createMetadata } from '@/utils/createMetadata'
@@ -69,12 +70,12 @@ const featuredPartners = [
 
 export default function Ecosystem() {
   return (
-    <>
+    <PageLayout>
       <StructuredDataScript structuredData={ecosystemPageBaseData} />
       <PageHeader
         title={header.title}
         description={header.description}
-        link={{
+        cta={{
           href: FILECOIN_FOUNDATION_URLS.ecosystem.submitOrUpdateProjectForm,
           text: 'Submit or Update Your Project',
         }}
@@ -167,6 +168,6 @@ export default function Ecosystem() {
 
         <FeaturedCaseStudies />
       </section>
-    </>
+    </PageLayout>
   )
 }

--- a/src/app/events/page.tsx
+++ b/src/app/events/page.tsx
@@ -2,6 +2,7 @@ import { WebPage, WithContext } from 'schema-dts'
 
 import { EventsList } from '@/components/EventsList'
 import { PageHeader } from '@/components/PageHeader'
+import { PageLayout } from '@/components/PageLayout'
 import { StructuredDataScript } from '@/components/StructuredDataScript'
 
 import { createMetadata } from '@/utils/createMetadata'
@@ -45,13 +46,20 @@ const eventsPageStructuredData: WithContext<WebPage> = {
 
 export default function Events() {
   return (
-    <>
+    <PageLayout>
       <StructuredDataScript structuredData={eventsPageStructuredData} />
-      <PageHeader title={header.title} description={header.description} />
+      <PageHeader
+        title={header.title}
+        description={header.description}
+        cta={{
+          href: '#',
+          text: 'Learn More',
+        }}
+      />
 
       <div>
         <EventsList events={events} />
       </div>
-    </>
+    </PageLayout>
   )
 }

--- a/src/app/get-involved/page.tsx
+++ b/src/app/get-involved/page.tsx
@@ -1,6 +1,7 @@
 import { GetInvolvedList } from '@/components/GetInvolvedList'
 import { Heading } from '@/components/Heading'
 import { PageHeader } from '@/components/PageHeader'
+import { PageLayout } from '@/components/PageLayout'
 import { Section } from '@/components/Section'
 import { SectionDeepDive } from '@/components/SectionDeepDive'
 import { StructuredDataScript } from '@/components/StructuredDataScript'
@@ -29,9 +30,16 @@ const getInvolvedPageBaseData = generateWebPageStructuredData({
 
 export default function GetInvolved() {
   return (
-    <>
+    <PageLayout>
       <StructuredDataScript structuredData={getInvolvedPageBaseData} />
-      <PageHeader title={header.title} description={header.description} />
+      <PageHeader
+        title={header.title}
+        description={header.description}
+        cta={{
+          href: '#',
+          text: 'Learn More',
+        }}
+      />
 
       <section>
         <Heading tag="h2" variant="xl">
@@ -69,6 +77,6 @@ export default function GetInvolved() {
           href="https://www.youtube.com/watch?v=wP4Bk8lBNUc"
         />
       </SectionDeepDive>
-    </>
+    </PageLayout>
   )
 }

--- a/src/app/governance/page.tsx
+++ b/src/app/governance/page.tsx
@@ -1,5 +1,6 @@
 import { Heading } from '@/components/Heading'
 import { PageHeader } from '@/components/PageHeader'
+import { PageLayout } from '@/components/PageLayout'
 import { Social } from '@/components/Social'
 import { StructuredDataScript } from '@/components/StructuredDataScript'
 import { TextLink } from '@/components/TextLink'
@@ -24,9 +25,16 @@ const governancePageBaseData = generateWebPageStructuredData({
 
 export default function Governance() {
   return (
-    <>
+    <PageLayout>
       <StructuredDataScript structuredData={governancePageBaseData} />
-      <PageHeader title={header.title} description={header.description} />
+      <PageHeader
+        title={header.title}
+        description={header.description}
+        cta={{
+          href: '#',
+          text: 'Learn More',
+        }}
+      />
 
       <section>
         <Heading tag="h2" variant="xl">
@@ -204,6 +212,6 @@ export default function Governance() {
         </Heading>
         <UpcomingEvents />
       </section>
-    </>
+    </PageLayout>
   )
 }

--- a/src/app/grants/page.tsx
+++ b/src/app/grants/page.tsx
@@ -1,6 +1,7 @@
 import { GetInvolvedList } from '@/components/GetInvolvedList'
 import { Heading } from '@/components/Heading'
 import { PageHeader } from '@/components/PageHeader'
+import { PageLayout } from '@/components/PageLayout'
 import { Section } from '@/components/Section'
 import { StructuredDataScript } from '@/components/StructuredDataScript'
 import { TextLink } from '@/components/TextLink'
@@ -24,12 +25,12 @@ const grantsPageBaseData = generateWebPageStructuredData({
 
 export default function Grants() {
   return (
-    <>
+    <PageLayout>
       <StructuredDataScript structuredData={grantsPageBaseData} />
       <PageHeader
         title={header.title}
         description={header.description}
-        link={{ href: FILECOIN_URLS.grants.email, text: 'Email for more info' }}
+        cta={{ href: FILECOIN_URLS.grants.email, text: 'Email for more info' }}
       />
 
       <section>
@@ -181,6 +182,6 @@ export default function Grants() {
         <TextLink href={FILECOIN_URLS.social.slack.href}>Learn More</TextLink>
         <GetInvolvedList />
       </section>
-    </>
+    </PageLayout>
   )
 }

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -13,6 +13,7 @@ import { FeaturedCaseStudies } from '@/components/FeaturedCaseStudies'
 import { Heading } from '@/components/Heading'
 import { HomeExploreSectionCard } from '@/components/HomeExploreSectionCard'
 import { PageHeader } from '@/components/PageHeader'
+import { PageLayout } from '@/components/PageLayout'
 import { PageSection } from '@/components/PageSection'
 import { SectionDivider } from '@/components/SectionDivider'
 
@@ -20,32 +21,28 @@ import { createMetadata } from '@/utils/createMetadata'
 
 import { attributes } from '@/content/pages/home.md'
 
-const { header, seo } = attributes
-
 import { PATHS } from '@/constants/paths'
 import { FILECOIN_URLS } from '@/constants/siteMetadata'
 
+const { header, seo } = attributes
 export const metadata = createMetadata(seo, PATHS.HOME.path)
 
 export default function Home() {
   return (
-    <div className="flex flex-col gap-24 sm:gap-16">
-      <div className="flex flex-col gap-6 md:w-1/2">
-        <PageHeader title={header.title} description={header.description} />
-        <div className="flex flex-col gap-4 sm:flex-row sm:gap-6 md:flex-col md:gap-4">
-          <Button className="flex-1" variant="primary" href={PATHS.ABOUT.path}>
-            Learn More
-          </Button>
-          <Button
-            className="flex-1"
-            variant="ghost"
-            href={FILECOIN_URLS.site}
-            icon={<ArrowUpRight size={24} weight="bold" />}
-          >
-            Discover Filecoin Technology
-          </Button>
-        </div>
-      </div>
+    <PageLayout>
+      <PageHeader
+        title={header.title}
+        description={header.description}
+        cta={{
+          href: PATHS.ABOUT.path,
+          text: 'Learn More',
+        }}
+        secondaryCta={{
+          href: FILECOIN_URLS.site,
+          text: 'Discover Filecoin Technology',
+          icon: <ArrowUpRight size={24} weight="bold" />,
+        }}
+      />
 
       <section>
         <SectionDivider title="Explore" />
@@ -157,6 +154,6 @@ export default function Home() {
           View All
         </Button>
       </PageSection>
-    </div>
+    </PageLayout>
   )
 }

--- a/src/app/privacy-policy/page.tsx
+++ b/src/app/privacy-policy/page.tsx
@@ -1,4 +1,5 @@
 import { PageHeader } from '@/components/PageHeader'
+import { PageLayout } from '@/components/PageLayout'
 import { StructuredDataScript } from '@/components/StructuredDataScript'
 
 import { createMetadata } from '@/utils/createMetadata'
@@ -19,10 +20,17 @@ const policyPageBaseData = generateWebPageStructuredData({
 
 export default function PrivacyPolicy() {
   return (
-    <>
+    <PageLayout>
       <StructuredDataScript structuredData={policyPageBaseData} />
-      <PageHeader title={header.title} description={header.description} />
+      <PageHeader
+        title={header.title}
+        description={header.description}
+        cta={{
+          href: '#',
+          text: 'Learn More',
+        }}
+      />
       <Content />
-    </>
+    </PageLayout>
   )
 }

--- a/src/app/privacy-policy/page.tsx
+++ b/src/app/privacy-policy/page.tsx
@@ -30,6 +30,7 @@ export default function PrivacyPolicy() {
           text: 'Learn More',
         }}
       />
+
       <Content />
     </PageLayout>
   )

--- a/src/app/terms/page.tsx
+++ b/src/app/terms/page.tsx
@@ -1,4 +1,5 @@
 import { PageHeader } from '@/components/PageHeader'
+import { PageLayout } from '@/components/PageLayout'
 import { StructuredDataScript } from '@/components/StructuredDataScript'
 
 import { createMetadata } from '@/utils/createMetadata'
@@ -19,10 +20,18 @@ const termsPageBaseData = generateWebPageStructuredData({
 
 export default function Terms() {
   return (
-    <>
+    <PageLayout>
       <StructuredDataScript structuredData={termsPageBaseData} />
-      <PageHeader title={header.title} description={header.description} />
+      <PageHeader
+        title={header.title}
+        description={header.description}
+        cta={{
+          href: '#',
+          text: 'Learn More',
+        }}
+      />
+
       <Content />
-    </>
+    </PageLayout>
   )
 }


### PR DESCRIPTION
This PR extracts the common page layout styles into a `PageLayout` component and extends the `PageHeader` component to accept `secondaryCTA`, `metaData`, `image` props. It also applies the refactor to all pages.