### PR TITLE
Change footer design

### DIFF
--- a/src/app/_components/Footer.tsx
+++ b/src/app/_components/Footer.tsx
@@ -11,18 +11,18 @@ import {
   FILECOIN_URLS,
 } from '@/constants/siteMetadata'
 
-type Section = {
+type SectionProps = {
   title: string
   children: React.ReactNode
 }
 
-type NavigationListItem = {
+type NavigationListItemProps = {
   label: string
   path: PathValues
 }
 
-type NavigationList = {
-  items: NavigationListItem[]
+type NavigationListProps = {
+  items: NavigationListItemProps[]
 }
 
 const navigationItems = [
@@ -34,7 +34,7 @@ const navigationItems = [
 
 const legalItems = [PATHS.PRIVACY_POLICY, PATHS.TERMS]
 
-function Section({ title, children }: Section) {
+function Section({ title, children }: SectionProps) {
   return (
     <div className="flex flex-col gap-4">
       <span className="block font-bold">{title}</span>
@@ -43,7 +43,7 @@ function Section({ title, children }: Section) {
   )
 }
 
-function NavigationList({ items }: NavigationList) {
+function NavigationList({ items }: NavigationListProps) {
   return (
     <ul className="flex flex-col gap-3">
       {items.map(({ label, path }) => (

--- a/src/app/_components/Footer.tsx
+++ b/src/app/_components/Footer.tsx
@@ -80,8 +80,8 @@ export function Footer() {
       <Social />
       <hr />
 
-      <div className="flex flex-wrap gap-6">
-        <div className="flex flex-wrap gap-5">
+      <div className="flex flex-wrap gap-x-20 gap-y-6">
+        <div className="flex flex-wrap gap-x-12 gap-y-6">
           <Section title="Browse">
             <NavigationList items={navigationItems} />
           </Section>

--- a/src/app/_components/Footer.tsx
+++ b/src/app/_components/Footer.tsx
@@ -11,13 +11,17 @@ import {
   FILECOIN_URLS,
 } from '@/constants/siteMetadata'
 
+type Section = {
+  title: string
+  children: React.ReactNode
+}
+
 type NavigationListItem = {
   label: string
   path: PathValues
 }
 
 type NavigationList = {
-  title: string
   items: NavigationListItem[]
 }
 
@@ -30,18 +34,24 @@ const navigationItems = [
 
 const legalItems = [PATHS.PRIVACY_POLICY, PATHS.TERMS]
 
-function NavigationList({ title, items }: NavigationList) {
+function Section({ title, children }: Section) {
   return (
-    <div>
-      <span className="mb-6 block font-bold">{title}</span>
-      <ul className="flex flex-col gap-3">
-        {items.map(({ label, path }) => (
-          <li key={path}>
-            <TextLink href={path}>{label}</TextLink>
-          </li>
-        ))}
-      </ul>
+    <div className="flex flex-col gap-4">
+      <span className="block font-bold">{title}</span>
+      {children}
     </div>
+  )
+}
+
+function NavigationList({ items }: NavigationList) {
+  return (
+    <ul className="flex flex-col gap-3">
+      {items.map(({ label, path }) => (
+        <li key={path}>
+          <TextLink href={path}>{label}</TextLink>
+        </li>
+      ))}
+    </ul>
   )
 }
 
@@ -49,44 +59,54 @@ export function Footer() {
   return (
     <footer className="mt-16 flex flex-col gap-6">
       <hr />
-      <Logo />
-      <p>
-        For the latest big ideas and news from the Filecoin ecosystem and the
-        decentralized web, subscribe to our newsletter.
-      </p>
-      <Button
-        className="sm:self-start"
-        variant="primary"
-        href={FILECOIN_FOUNDATION_URLS.newsletter}
-      >
-        Sign Up
-      </Button>
-
-      <hr className="mt-6" />
-      <Social />
-      <hr className="mb-6" />
-
-      <div className="flex flex-wrap gap-8 sm:gap-10">
-        <NavigationList title="Browse" items={navigationItems} />
-        <NavigationList title="Legal" items={legalItems} />
-
-        <div className="flex flex-col gap-4">
-          <span className="font-bold">Contact Us</span>
-          <p>
-            For media and collaboration inquiries,{' '}
-            <TextLink href={FILECOIN_FOUNDATION_URLS.email}>
-              Drop us a line
-            </TextLink>
+      <div className="flex flex-col gap-6 sm:flex-row sm:justify-between md:justify-start md:gap-36">
+        <Logo />
+        <div className="sm:max-w-96">
+          <p className="mb-6">
+            For the latest big ideas and news from the Filecoin ecosystem and
+            the decentralized web, subscribe to our newsletter.
           </p>
-          <p>
-            For more information on our ecosystem grants,{' '}
-            <TextLink href={FILECOIN_URLS.grants.email}>Email us</TextLink>
-          </p>
+          <Button
+            className="w-full sm:self-start md:w-auto"
+            variant="primary"
+            href={FILECOIN_FOUNDATION_URLS.newsletter}
+          >
+            Subscribe to Newsletter
+          </Button>
         </div>
       </div>
 
       <hr />
-      <p className="text-center">
+      <Social />
+      <hr />
+
+      <div className="flex flex-wrap gap-6">
+        <div className="flex flex-wrap gap-5">
+          <Section title="Browse">
+            <NavigationList items={navigationItems} />
+          </Section>
+          <Section title="Legal">
+            <NavigationList items={legalItems} />
+          </Section>
+        </div>
+        <Section title="Contact Us">
+          <div>
+            <p className="mb-3">
+              For media and collaboration inquiries,{' '}
+              <TextLink href={FILECOIN_FOUNDATION_URLS.email}>
+                Drop us a line
+              </TextLink>
+            </p>
+            <p>
+              For more information on our ecosystem grants,{' '}
+              <TextLink href={FILECOIN_URLS.grants.email}>Email us</TextLink>
+            </p>
+          </div>
+        </Section>
+      </div>
+
+      <hr />
+      <p className="text-center text-sm">
         &copy; {new Date().getFullYear()} Content on this site is licensed under
         a{' '}
         <TextLink href="https://creativecommons.org/licenses/by/4.0/">

--- a/src/app/_components/Heading.tsx
+++ b/src/app/_components/Heading.tsx
@@ -38,7 +38,7 @@ export function Heading({
   if (icon) {
     return (
       <div className="inline-flex items-center gap-3">
-        <Icon component={icon} size={size} />
+        <Icon component={icon} color="brand-300" size={size} />
         <Tag className={className} {...rest}>
           {children}
         </Tag>

--- a/src/app/_components/Icon.tsx
+++ b/src/app/_components/Icon.tsx
@@ -2,7 +2,7 @@ import { type Icon } from '@phosphor-icons/react'
 
 export type IconProps = {
   component: Icon
-  color: 'inherit' | 'brand-300'
+  color?: 'inherit' | 'brand-300'
   size?: number
   weight?: 'light' | 'regular' | 'bold'
 }
@@ -14,7 +14,7 @@ const colorStyles = {
 
 export function Icon({
   component,
-  color,
+  color = 'inherit',
   size = 24,
   weight = 'regular',
 }: IconProps) {

--- a/src/app/_components/Icon.tsx
+++ b/src/app/_components/Icon.tsx
@@ -2,15 +2,27 @@ import { type Icon } from '@phosphor-icons/react'
 
 export type IconProps = {
   component: Icon
+  color: 'inherit' | 'brand-300'
   size?: number
+  weight?: 'light' | 'regular' | 'bold'
 }
 
-export function Icon({ component, size }: IconProps) {
+const colorStyles = {
+  inherit: 'text-inherit',
+  'brand-300': 'text-brand-300',
+}
+
+export function Icon({
+  component,
+  color,
+  size = 24,
+  weight = 'regular',
+}: IconProps) {
   const Component = component
 
   return (
-    <span className="text-brand-300" aria-hidden="true">
-      <Component size={size || 24} />
+    <span aria-hidden="true" className={colorStyles[color]}>
+      <Component size={size} weight={weight} />
     </span>
   )
 }

--- a/src/app/_components/Social.tsx
+++ b/src/app/_components/Social.tsx
@@ -1,21 +1,35 @@
-import { socialIcons, socialLinks, SocialIconKey } from '@/utils/socialConfig'
+import clsx from 'clsx'
+
+import { Icon } from '@/components/Icon'
+
+import { socialLinksWithIcons } from '@/utils/socialConfig'
+
+const touchTargetSpacing = 2
+const touchTargetClass = `p-${touchTargetSpacing}`
+const touchTargetOffsetClass = `-m-${touchTargetSpacing} sm:mx-0`
 
 export function Social() {
   return (
-    <ul className="flex flex-wrap items-center justify-between gap-4 px-3">
-      {Object.entries(socialLinks).map(([key, { label, href }]) => {
-        const IconComponent = socialIcons[key as SocialIconKey]
-
+    <ul
+      className={clsx(
+        'flex flex-wrap items-center justify-between gap-4 sm:px-8',
+        touchTargetOffsetClass,
+      )}
+    >
+      {socialLinksWithIcons.map(({ label, href, icon }, key) => {
         return (
-          <li key={key}>
+          <li key={key} className="inline-flex">
             <a
+              aria-label={`${label} (opens in new window)`}
               href={href}
               target="_blank"
               rel="noopener noreferrer"
-              className="outline-white hover:text-brand-300 focus:outline-2"
-              aria-label={`${label} (opens in new window)`}
+              className={clsx(
+                'text-brand-100 outline-white hover:text-brand-500 focus:outline-2',
+                touchTargetClass,
+              )}
             >
-              {IconComponent && <IconComponent size={24} aria-hidden="true" />}
+              <Icon component={icon} color="inherit" size={32} weight="light" />
             </a>
           </li>
         )

--- a/src/app/_components/Social.tsx
+++ b/src/app/_components/Social.tsx
@@ -25,7 +25,7 @@ export function Social() {
               target="_blank"
               rel="noopener noreferrer"
               className={clsx(
-                'text-brand-100 outline-white hover:text-brand-500 focus:outline-2',
+                'text-brand-100 outline-white hover:text-brand-400 focus:outline-2',
                 touchTargetClass,
               )}
             >

--- a/src/app/_components/Social.tsx
+++ b/src/app/_components/Social.tsx
@@ -29,7 +29,7 @@ export function Social() {
                 touchTargetClass,
               )}
             >
-              <Icon component={icon} color="inherit" size={32} weight="light" />
+              <Icon component={icon} size={32} weight="light" />
             </a>
           </li>
         )

--- a/src/app/_utils/socialConfig.ts
+++ b/src/app/_utils/socialConfig.ts
@@ -2,30 +2,26 @@ import {
   Butterfly,
   GithubLogo,
   LinkedinLogo,
-  RedditLogo,
-  SlackLogo,
   TwitterLogo,
   YoutubeLogo,
 } from '@phosphor-icons/react/dist/ssr'
 
-import {
-  FILECOIN_FOUNDATION_URLS,
-  FILECOIN_URLS,
-} from '@/constants/siteMetadata'
+import { FILECOIN_FOUNDATION_URLS } from '@/constants/siteMetadata'
 
-export const socialIcons = {
+const socialIcons = {
   bluesky: Butterfly,
   github: GithubLogo,
   linkedin: LinkedinLogo,
-  reddit: RedditLogo,
-  slack: SlackLogo,
   twitter: TwitterLogo,
   youtube: YoutubeLogo,
 }
 
-export type SocialIconKey = keyof typeof socialIcons
+type SocialIconKey = keyof typeof socialIcons
 
-export const socialLinks = {
-  ...FILECOIN_FOUNDATION_URLS.social,
-  ...FILECOIN_URLS.social,
-}
+export const socialLinksWithIcons = Object.entries(
+  FILECOIN_FOUNDATION_URLS.social,
+).map(([key, { label, href }]) => ({
+  label,
+  href,
+  icon: socialIcons[key as SocialIconKey],
+}))


### PR DESCRIPTION
Change `Footer` component styling per [Figma Footer Component Design](https://www.figma.com/file/0pBfQs5tKI6bx5ypPIfVRA/FIL.org-V4-Prototypes?type=design&node-id=168-6670&mode=design&t=DDypYj2fhAj5IFB1-4)

- To comply with accessibility guidelines and enhance usability on touch devices, the touch targets for the social icons have been increased. This is achieved by applying padding within the anchor tags, effectively enlarging the clickable area without altering the visual size of the icons until a total of `48px` is reached.

---

## Notes:

- We should enable `Logo` to accept size properties in a subsequent PR
