### PR TITLE
Improve accessibility of Socials tap target

### DIFF
--- a/src/app/_components/Footer.tsx
+++ b/src/app/_components/Footer.tsx
@@ -49,22 +49,26 @@ export function Footer() {
   return (
     <footer className="mt-16 flex flex-col gap-6">
       <hr />
-      <Logo />
-      <p>
-        For the latest big ideas and news from the Filecoin ecosystem and the
-        decentralized web, subscribe to our newsletter.
-      </p>
-      <Button
-        className="sm:self-start"
-        variant="primary"
-        href={FILECOIN_FOUNDATION_URLS.newsletter}
-      >
-        Sign Up
-      </Button>
+      <div className="flex flex-col gap-6 sm:flex-row sm:justify-between md:justify-start md:gap-36">
+        <Logo />
+        <div className="sm:max-w-96">
+          <p className="mb-6">
+            For the latest big ideas and news from the Filecoin ecosystem and
+            the decentralized web, subscribe to our newsletter.
+          </p>
+          <Button
+            className="w-full sm:self-start md:w-auto"
+            variant="primary"
+            href={FILECOIN_FOUNDATION_URLS.newsletter}
+          >
+            Subscribe to Newsletter
+          </Button>
+        </div>
+      </div>
 
-      <hr className="mt-6" />
+      <hr />
       <Social />
-      <hr className="mb-6" />
+      <hr />
 
       <div className="flex flex-wrap gap-8 sm:gap-10">
         <NavigationList title="Browse" items={navigationItems} />

--- a/src/app/_components/Social.tsx
+++ b/src/app/_components/Social.tsx
@@ -2,7 +2,7 @@ import { socialIcons, socialLinks, SocialIconKey } from '@/utils/socialConfig'
 
 export function Social() {
   return (
-    <ul className="flex flex-wrap items-center justify-between gap-4 px-3">
+    <ul className="flex flex-wrap items-center justify-between gap-4 sm:px-3">
       {Object.entries(socialLinks).map(([key, { label, href }]) => {
         const IconComponent = socialIcons[key as SocialIconKey]
 
@@ -12,7 +12,7 @@ export function Social() {
               href={href}
               target="_blank"
               rel="noopener noreferrer"
-              className="outline-white hover:text-brand-300 focus:outline-2"
+              className="inline-flex items-center justify-center p-2.5 outline-white hover:text-brand-300 focus:outline-2"
               aria-label={`${label} (opens in new window)`}
             >
               {IconComponent && <IconComponent size={24} aria-hidden="true" />}


### PR DESCRIPTION
To comply with accessibility guidelines and enhance usability on touch devices, the touch targets for the social icons have been increased. This is achieved by applying `p-2.5` padding within the anchor tags, effectively enlarging the clickable area without altering the visual size of the icons.

- [Source](https://web.dev/articles/accessible-tap-targets)
- https://developer.chrome.com/docs/lighthouse/seo/tap-targets

## Note: Need to discuss design implications with Filipa