### PR TITLE
Style blog posts section

### DIFF
--- a/src/app/_components/Card.tsx
+++ b/src/app/_components/Card.tsx
@@ -1,3 +1,5 @@
+import { Fragment } from 'react'
+
 import Image from 'next/image'
 
 import { BookOpen } from '@phosphor-icons/react/dist/ssr'
@@ -8,6 +10,7 @@ import { Heading } from '@/components/Heading'
 
 export type CardProps = {
   title: string | React.ReactNode
+  metaData?: Array<string | null | undefined>
   description?: string
   cta?: {
     href: string
@@ -21,6 +24,7 @@ export type CardProps = {
   }
   borderColor?: 'brand-300' | 'brand-500' | 'brand-600'
   textIsClamped?: boolean
+
   as?: React.ElementType
   children?: React.ReactNode
 }
@@ -40,6 +44,7 @@ const imageSizes = {
 
 export function Card({
   title,
+  metaData,
   description,
   cta,
   entryType = 'blogPost',
@@ -67,9 +72,27 @@ export function Card({
           />
         </div>
       )}
-      <div className="flex flex-col gap-3 p-4">
+      <div className="flex flex-col p-4">
+        {metaData && metaData.length > 0 && (
+          <div className="mb-2 flex gap-3 text-brand-300">
+            {metaData.filter(Boolean).map((data, index) => {
+              const isNotLastItem = index < metaData.length - 1
+              const isNotFirstItem = index > 0
+
+              return (
+                <Fragment key={index}>
+                  <span className={clsx({ capitalize: isNotFirstItem })}>
+                    {data}
+                  </span>
+                  {isNotLastItem && <span> | </span>}
+                </Fragment>
+              )
+            })}
+          </div>
+        )}
+
         {title && typeof title === 'string' ? (
-          <Heading tag="h3" variant="lg" className="line-clamp-3 text-ellipsis">
+          <Heading tag="h3" variant="lg" className="line-clamp-2 text-ellipsis">
             {title}
           </Heading>
         ) : (
@@ -79,13 +102,14 @@ export function Card({
         {description && (
           <p
             className={clsx(
-              'mb-10',
+              'mb-10 mt-3',
               textIsClamped && 'line-clamp-3 text-ellipsis',
             )}
           >
             {description}
           </p>
         )}
+
         {cta && (
           <CustomLink
             href={cta.href}
@@ -97,6 +121,7 @@ export function Card({
             </span>
           </CustomLink>
         )}
+
         {children && children}
       </div>
     </Tag>

--- a/src/app/_components/Card.tsx
+++ b/src/app/_components/Card.tsx
@@ -79,7 +79,7 @@ export function Card({
       className={clsx(
         'relative flex h-full flex-col rounded-lg border bg-brand-700 bg-opacity-30 backdrop-blur-xl',
         borderStyles[borderColor],
-        !isEntryVisible && 'sr-only',
+        !isEntryVisible && 'hidden',
       )}
     >
       {image?.url && (

--- a/src/app/_components/Card.tsx
+++ b/src/app/_components/Card.tsx
@@ -1,5 +1,3 @@
-import { Fragment } from 'react'
-
 import Image from 'next/image'
 
 import { BookOpen } from '@phosphor-icons/react/dist/ssr'
@@ -7,10 +5,11 @@ import clsx from 'clsx'
 
 import { CustomLink } from '@/components/CustomLink'
 import { Heading } from '@/components/Heading'
+import { Meta, type MetaDataType } from '@/components/Meta'
 
 export type CardProps = {
   title: string | React.ReactNode
-  metaData?: Array<string | null | undefined>
+  metaData?: MetaDataType
   description?: string
   cta?: {
     href: string
@@ -74,21 +73,9 @@ export function Card({
       )}
       <div className="flex flex-col p-4">
         {metaData && metaData.length > 0 && (
-          <div className="mb-2 flex gap-3 text-brand-300">
-            {metaData.filter(Boolean).map((data, index) => {
-              const isNotLastItem = index < metaData.length - 1
-              const isNotFirstItem = index > 0
-
-              return (
-                <Fragment key={index}>
-                  <span className={clsx({ capitalize: isNotFirstItem })}>
-                    {data}
-                  </span>
-                  {isNotLastItem && <span> | </span>}
-                </Fragment>
-              )
-            })}
-          </div>
+          <span className="mb-2">
+            <Meta metaData={metaData} />
+          </span>
         )}
 
         {title && typeof title === 'string' ? (

--- a/src/app/_components/Card.tsx
+++ b/src/app/_components/Card.tsx
@@ -7,6 +7,12 @@ import { CustomLink } from '@/components/CustomLink'
 import { Heading } from '@/components/Heading'
 import { Meta, type MetaDataType } from '@/components/Meta'
 
+type PaginationContext = {
+  entryIndex: number
+  currentPage: number
+  entriesPerPage: number
+}
+
 export type CardProps = {
   title: string | React.ReactNode
   metaData?: MetaDataType
@@ -23,7 +29,7 @@ export type CardProps = {
   }
   borderColor?: 'brand-300' | 'brand-500' | 'brand-600'
   textIsClamped?: boolean
-
+  pagination?: PaginationContext
   as?: React.ElementType
   children?: React.ReactNode
 }
@@ -41,6 +47,18 @@ const imageSizes = {
     '(max-width: 639px) 320px, (max-width: 767px) 276px, (max-width: 1023px) 340px, 200px',
 }
 
+function shouldDisplayEntry(pagination?: PaginationContext): boolean {
+  if (!pagination) return true
+
+  const { entryIndex, currentPage, entriesPerPage } = pagination
+  const firstVisibleEntryIndex = (currentPage - 1) * entriesPerPage
+  const lastVisibleEntryIndex = currentPage * entriesPerPage
+
+  return (
+    entryIndex >= firstVisibleEntryIndex && entryIndex < lastVisibleEntryIndex
+  )
+}
+
 export function Card({
   title,
   metaData,
@@ -50,14 +68,18 @@ export function Card({
   image,
   borderColor = 'brand-500',
   textIsClamped = false,
+  pagination,
   as: Tag = 'li',
   children,
 }: CardProps) {
+  const isEntryVisible = shouldDisplayEntry(pagination)
+
   return (
     <Tag
       className={clsx(
         'relative flex h-full flex-col rounded-lg border bg-brand-700 bg-opacity-30 backdrop-blur-xl',
         borderStyles[borderColor],
+        !isEntryVisible && 'sr-only',
       )}
     >
       {image?.url && (

--- a/src/app/_components/Heading.tsx
+++ b/src/app/_components/Heading.tsx
@@ -27,9 +27,8 @@ export function Heading({
   ...rest
 }: HeadingProps) {
   const Tag = tag
-  const baseStyles = 'text-brand-100'
 
-  className = clsx(baseStyles, variantStyles[variant], className)
+  className = clsx(variantStyles[variant], className)
 
   return (
     <Tag className={className} {...rest}>

--- a/src/app/_components/Meta.tsx
+++ b/src/app/_components/Meta.tsx
@@ -1,0 +1,27 @@
+import { Fragment } from 'react'
+
+import clsx from 'clsx'
+
+type MetaProps = {
+  metaData: MetaDataType
+}
+
+export type MetaDataType = Array<string | null | undefined>
+
+export function Meta({ metaData }: MetaProps) {
+  return (
+    <div className="flex gap-3 text-brand-300">
+      {metaData.filter(Boolean).map((data, index) => {
+        const isNotLastItem = index < metaData.length - 1
+        const isNotFirstItem = index > 0
+
+        return (
+          <Fragment key={index}>
+            <span className={clsx({ capitalize: isNotFirstItem })}>{data}</span>
+            {isNotLastItem && <span> | </span>}
+          </Fragment>
+        )
+      })}
+    </div>
+  )
+}

--- a/src/app/_components/NoResultsMessage.tsx
+++ b/src/app/_components/NoResultsMessage.tsx
@@ -1,0 +1,17 @@
+import { MagnifyingGlass } from '@phosphor-icons/react/dist/ssr'
+
+import { Heading } from '@/components/Heading'
+
+export function NoResultsMessage() {
+  return (
+    <div className="flex flex-col items-center gap-4 text-brand-200">
+      <span className="grid size-16 place-items-center rounded-full bg-brand-700 text-brand-300">
+        <MagnifyingGlass size={24} />
+      </span>
+      <Heading tag="h3" variant="xl">
+        No Results Found
+      </Heading>
+      <p className="">Try changing your search query.</p>
+    </div>
+  )
+}

--- a/src/app/_components/PageHeader.tsx
+++ b/src/app/_components/PageHeader.tsx
@@ -1,4 +1,4 @@
-import React, { Fragment } from 'react'
+import { Fragment } from 'react'
 
 import Image from 'next/image'
 

--- a/src/app/_components/PageHeader.tsx
+++ b/src/app/_components/PageHeader.tsx
@@ -1,11 +1,8 @@
-import { Fragment } from 'react'
-
 import Image from 'next/image'
-
-import clsx from 'clsx'
 
 import { Button } from '@/components/Button'
 import { Heading } from '@/components/Heading'
+import { Meta, type MetaDataType } from '@/components/Meta'
 
 type ctaProps = {
   href: string
@@ -24,7 +21,7 @@ type PageHeaderProps = {
   cta: ctaProps
   secondaryCta?: ctaProps
   image?: imageProps
-  metaData?: Array<string | null | undefined>
+  metaData?: MetaDataType
 }
 
 export function PageHeader({
@@ -42,21 +39,9 @@ export function PageHeader({
           {title}
         </Heading>
         {metaData && metaData.length > 0 && (
-          <div className="mb-6 flex gap-3 font-bold text-brand-300">
-            {metaData.filter(Boolean).map((data, index) => {
-              const isNotLastItem = index < metaData.length - 1
-              const isNotFirstItem = index > 0
-
-              return (
-                <Fragment key={index}>
-                  <span className={clsx({ capitalize: isNotFirstItem })}>
-                    {data}
-                  </span>
-                  {isNotLastItem && <span> | </span>}
-                </Fragment>
-              )
-            })}
-          </div>
+          <span className="mb-6">
+            <Meta metaData={metaData} />
+          </span>
         )}
         <p className="mb-6">{description}</p>
         <div className="flex flex-col gap-4 sm:flex-row sm:gap-6 md:flex-col md:gap-4">

--- a/src/app/blog/BlogClient.tsx
+++ b/src/app/blog/BlogClient.tsx
@@ -2,22 +2,16 @@
 
 import { useState, useMemo } from 'react'
 
-import Image from 'next/image'
 import { useSearchParams } from 'next/navigation'
-
-import clsx from 'clsx'
 
 import { usePagination } from '@/hooks/usePagination'
 import { useUpdateHistory } from '@/hooks/useUpdateHistory'
 
+import { Card } from '@/components/Card'
 import { CardLayout } from '@/components/CardLayout'
-import { Heading } from '@/components/Heading'
 import { Pagination } from '@/components/Pagination'
-import { TextLink } from '@/components/TextLink'
 
 import { BlogPostData } from '@/types/blogPostTypes'
-
-import { formatDate } from '@/utils/formatDate'
 
 import { PATHS } from '@/constants/paths'
 
@@ -94,38 +88,27 @@ export function BlogClient({ posts }: { posts: BlogPostData[] }) {
         <>
           <CardLayout type="blogPost">
             {filteredAndSortedPosts.map((post, index) => {
-              const { image, title, description, slug, publishedOn } = post
+              const { image, title, description, slug } = post
 
               return (
-                <li
+                <div
                   key={post.slug}
-                  className={clsx(
-                    'h-[400px] overflow-clip rounded-md border border-brand-600 p-4',
-                    determineVisibilityClass(index),
-                  )}
+                  className={determineVisibilityClass(index)}
                 >
-                  {image.url && (
-                    <Image
-                      src={image.url}
-                      alt={image.alt}
-                      width={282}
-                      height={141}
-                      className="object-cover"
-                    />
-                  )}
-                  <Heading tag="h3" variant="lg">
-                    {title}
-                  </Heading>
-                  <p>{description}</p>
-                  {publishedOn && (
-                    <span className="block">
-                      {formatDate(publishedOn, 'blog')}
-                    </span>
-                  )}
-                  <TextLink href={`${PATHS.BLOG.path}/${slug}`}>
-                    Read More
-                  </TextLink>
-                </li>
+                  <Card
+                    title={title}
+                    description={description}
+                    cta={{
+                      href: `${PATHS.BLOG.path}/${slug}`,
+                      text: 'Read Post',
+                    }}
+                    image={{
+                      url: image?.url,
+                      alt: image?.alt,
+                    }}
+                    textIsClamped={true}
+                  />
+                </div>
               )
             })}
           </CardLayout>

--- a/src/app/blog/BlogClient.tsx
+++ b/src/app/blog/BlogClient.tsx
@@ -61,15 +61,6 @@ export function BlogClient({ posts }: { posts: BlogPostData[] }) {
     setCurrentPage(1)
   }
 
-  function determineVisibilityClass(postIndex: number): string {
-    const firstVisiblePostIndex = (currentPage - 1) * POSTS_PER_PAGE
-    const firstInvisiblePostIndex = currentPage * POSTS_PER_PAGE
-    const isVisible =
-      postIndex >= firstVisiblePostIndex && postIndex < firstInvisiblePostIndex
-
-    return isVisible ? 'block' : 'sr-only'
-  }
-
   return (
     <div className="flex flex-col gap-8">
       <div>
@@ -94,28 +85,29 @@ export function BlogClient({ posts }: { posts: BlogPostData[] }) {
               const { image, title, description, slug, publishedOn } = post
 
               return (
-                <div
+                <Card
                   key={post.slug}
-                  className={determineVisibilityClass(index)}
-                >
-                  <Card
-                    title={title}
-                    metaData={[
-                      ...(publishedOn ? [formatDate(publishedOn)] : []),
-                      ...(post.category ? [post.category] : []),
-                    ]}
-                    description={description}
-                    cta={{
-                      href: `${PATHS.BLOG.path}/${slug}`,
-                      text: 'Read Post',
-                    }}
-                    image={{
-                      url: image?.url,
-                      alt: image?.alt,
-                    }}
-                    textIsClamped={true}
-                  />
-                </div>
+                  title={title}
+                  metaData={[
+                    ...(publishedOn ? [formatDate(publishedOn)] : []),
+                    ...(post.category ? [post.category] : []),
+                  ]}
+                  description={description}
+                  cta={{
+                    href: `${PATHS.BLOG.path}/${slug}`,
+                    text: 'Read Post',
+                  }}
+                  image={{
+                    url: image?.url,
+                    alt: image?.alt,
+                  }}
+                  textIsClamped={true}
+                  pagination={{
+                    entryIndex: index,
+                    currentPage,
+                    entriesPerPage: POSTS_PER_PAGE,
+                  }}
+                />
               )
             })}
           </CardLayout>

--- a/src/app/blog/BlogClient.tsx
+++ b/src/app/blog/BlogClient.tsx
@@ -13,6 +13,8 @@ import { Pagination } from '@/components/Pagination'
 
 import { BlogPostData } from '@/types/blogPostTypes'
 
+import { formatDate } from '@/utils/formatDate'
+
 import { PATHS } from '@/constants/paths'
 
 const POSTS_PER_PAGE = 20
@@ -88,7 +90,7 @@ export function BlogClient({ posts }: { posts: BlogPostData[] }) {
         <>
           <CardLayout type="blogPost">
             {filteredAndSortedPosts.map((post, index) => {
-              const { image, title, description, slug } = post
+              const { image, title, description, slug, publishedOn } = post
 
               return (
                 <div
@@ -97,6 +99,10 @@ export function BlogClient({ posts }: { posts: BlogPostData[] }) {
                 >
                   <Card
                     title={title}
+                    metaData={[
+                      ...(publishedOn ? [formatDate(publishedOn)] : []),
+                      ...(post.category ? [post.category] : []),
+                    ]}
                     description={description}
                     cta={{
                       href: `${PATHS.BLOG.path}/${slug}`,

--- a/src/app/blog/BlogClient.tsx
+++ b/src/app/blog/BlogClient.tsx
@@ -4,14 +4,12 @@ import { useState, useMemo } from 'react'
 
 import { useSearchParams } from 'next/navigation'
 
-import { MagnifyingGlass } from '@phosphor-icons/react/dist/ssr'
-
 import { usePagination } from '@/hooks/usePagination'
 import { useUpdateHistory } from '@/hooks/useUpdateHistory'
 
 import { Card } from '@/components/Card'
 import { CardLayout } from '@/components/CardLayout'
-import { Heading } from '@/components/Heading'
+import { NoResultsMessage } from '@/components/NoResultsMessage'
 import { Pagination } from '@/components/Pagination'
 
 import { BlogPostData } from '@/types/blogPostTypes'
@@ -88,15 +86,7 @@ export function BlogClient({ posts }: { posts: BlogPostData[] }) {
       </div>
 
       {filteredAndSortedPosts.length === 0 ? (
-        <div className="flex flex-col items-center gap-4 text-brand-200">
-          <span className="grid size-16 place-items-center rounded-full bg-brand-700 text-brand-300">
-            <MagnifyingGlass size={24} />
-          </span>
-          <Heading tag="h3" variant="xl">
-            No Results Found
-          </Heading>
-          <p className="">Try changing your search query.</p>
-        </div>
+        <NoResultsMessage />
       ) : (
         <>
           <CardLayout type="blogPost">

--- a/src/app/blog/BlogClient.tsx
+++ b/src/app/blog/BlogClient.tsx
@@ -4,11 +4,14 @@ import { useState, useMemo } from 'react'
 
 import { useSearchParams } from 'next/navigation'
 
+import { MagnifyingGlass } from '@phosphor-icons/react/dist/ssr'
+
 import { usePagination } from '@/hooks/usePagination'
 import { useUpdateHistory } from '@/hooks/useUpdateHistory'
 
 import { Card } from '@/components/Card'
 import { CardLayout } from '@/components/CardLayout'
+import { Heading } from '@/components/Heading'
 import { Pagination } from '@/components/Pagination'
 
 import { BlogPostData } from '@/types/blogPostTypes'
@@ -70,22 +73,30 @@ export function BlogClient({ posts }: { posts: BlogPostData[] }) {
   }
 
   return (
-    <>
-      <label htmlFor="search">Search Blog Posts</label>
-      <input
-        type="search"
-        id="search"
-        name="search"
-        value={searchQuery}
-        aria-label="Search blog posts"
-        className="text-brand-800"
-        onChange={handleSearch}
-      />
+    <div className="flex flex-col gap-8">
+      <div>
+        <label htmlFor="search">Search Blog Posts</label>
+        <input
+          type="search"
+          id="search"
+          name="search"
+          value={searchQuery}
+          aria-label="Search blog posts"
+          className="text-brand-800"
+          onChange={handleSearch}
+        />
+      </div>
 
       {filteredAndSortedPosts.length === 0 ? (
-        <p className="mt-8 rounded-md border border-brand-600 p-4">
-          No results found for your search, try changing your search query.
-        </p>
+        <div className="flex flex-col items-center gap-4 text-brand-200">
+          <span className="grid size-16 place-items-center rounded-full bg-brand-700 text-brand-300">
+            <MagnifyingGlass size={24} />
+          </span>
+          <Heading tag="h3" variant="xl">
+            No Results Found
+          </Heading>
+          <p className="">Try changing your search query.</p>
+        </div>
       ) : (
         <>
           <CardLayout type="blogPost">
@@ -128,6 +139,6 @@ export function BlogClient({ posts }: { posts: BlogPostData[] }) {
           </div>
         </>
       )}
-    </>
+    </div>
   )
 }


### PR DESCRIPTION
This PR styles the Blog Posts list section using the `Card` component and includes the`Meta` and `NoResultsMessage` components ~ per [Figma Blog Design](https://www.figma.com/file/0pBfQs5tKI6bx5ypPIfVRA/FIL.org-V4-Prototypes?type=design&node-id=547-11816&mode=design&t=gAuzm182CmWC3SQb-0)

<img width="1268" alt="Screenshot 2024-04-11 at 10 43 24" src="https://github.com/FilecoinFoundationWeb/filecoin-foundation/assets/26620750/5fed70fe-bba1-4be8-9444-e37bc59cffb1">

<img width="1268" alt="Screenshot 2024-04-11 at 10 43 53" src="https://github.com/FilecoinFoundationWeb/filecoin-foundation/assets/26620750/9b4ae930-da71-4875-a953-ef87cbd618f1">
