### PR TITLE
Enforce triple equal checks

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -97,6 +97,8 @@
           "caseInsensitive": true
         }
       }
-    ]
+    ],
+
+    "eqeqeq": "warn"
   }
 }


### PR DESCRIPTION
Tiny PR to add a new ESLINT rule to enforce `===`, as per this [ticket](https://www.notion.so/filecoin/Update-ESLINT-with-team-s-coding-guidelines-f62c979fd1b242578f6648e4a96d06d7?pvs=4).

About the implicit return rule, I found [arrow-body-style](https://eslint.org/docs/latest/rules/arrow-body-style) but I'm not sure it does what we want, it's about _requiring braces around arrow function bodies_.

I didn't find a rule to enforce implicit returns when the function body is only JSX.
