### PR TITLE
Styling Markdown Entries

### DIFF
--- a/src/app/_components/MarkdownContent.tsx
+++ b/src/app/_components/MarkdownContent.tsx
@@ -11,11 +11,11 @@ export function MarkdownContent({ children }: MarkdownContentProps) {
   return (
     <ReactMarkdown
       rehypePlugins={[rehypeRaw]}
+      className="prose"
       components={{
         img: ({ src, alt }) => (
           <CustomImage src={src as string} alt={alt as string} />
         ),
-        p: ({ ...rest }) => <p className="mb-4 text-base" {...rest} />,
       }}
     >
       {children}

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -16,6 +16,93 @@ module.exports = {
         },
       },
     },
+    typography: (theme) => ({
+      DEFAULT: {
+        css: {
+          '--tw-prose-body': theme('colors.brand.100'),
+          '--tw-prose-headings': theme('colors.brand.100'),
+          '--tw-prose-links': theme('colors.brand.300'),
+
+          color: 'var(--tw-prose-body)',
+
+          h1: {
+            fontSize: theme('fontSize.2xl'),
+            fontWeight: theme('fontWeight.bold'),
+            marginBottom: theme('spacing.8'),
+          },
+          h2: {
+            fontSize: theme('fontSize.xl'),
+            fontWeight: theme('fontWeight.bold'),
+            marginBottom: theme('spacing.6'),
+          },
+          h3: {
+            fontSize: theme('fontSize.lg'),
+            fontWeight: theme('fontWeight.bold'),
+            marginBottom: theme('spacing.5'),
+          },
+          h4: {
+            fontSize: theme('fontSize.md'),
+            fontWeight: theme('fontWeight.bold'),
+            marginBottom: theme('spacing.4'),
+          },
+
+          'p, ul, ol': {
+            lineHeight: theme('lineHeight.6'),
+            marginBottom: theme('spacing.6'),
+          },
+          ul: {
+            listStyleType: 'disc',
+          },
+          ol: {
+            listStyleType: 'decimal',
+          },
+          'ul, ol': {
+            paddingLeft: theme('spacing.6'),
+          },
+          li: {
+            paddingLeft: theme('spacing.3'),
+            marginBottom: theme('spacing.1'),
+          },
+          'li > p': {
+            marginBottom: theme('spacing.1'),
+          },
+
+          a: {
+            color: 'var(--tw-prose-links)',
+            '&:hover': {
+              color: theme('colors.brand.400'),
+              textDecoration: 'underline',
+            },
+            '&:focus': {
+              outlineWidth: '2px',
+              outlineStyle: 'solid',
+              outlineColor: 'var(--tw-prose-links)',
+            },
+          },
+
+          'iframe, video, img': {
+            height: 'auto',
+            width: '100%',
+            maxWidth: theme('screens.md'),
+            marginTop: theme('spacing.8'),
+            marginBottom: theme('spacing.8'),
+            marginLeft: 'auto',
+            marginRight: 'auto',
+            borderRadius: theme('borderRadius.md'),
+            outlineWidth: '1px',
+            outlineColor: theme('colors.brand.500'),
+            outlineStyle: 'solid',
+          },
+
+          'iframe[src*="youtube.com"]': {
+            aspectRatio: '16/9',
+            '&:focus': {
+              outline: 'none',
+            },
+          },
+        },
+      },
+    }),
   },
   plugins: [require('@tailwindcss/typography')],
 }


### PR DESCRIPTION
This PR adds typography rules in `tailwind.config.js` to style HTML content generated from Markdown files, following [Figma design](https://www.figma.com/file/0pBfQs5tKI6bx5ypPIfVRA/FIL.org-V4-Prototypes?type=design&node-id=1067-31242&mode=design&t=X6hQ0mKTkDbg0tdj-4).