### PR TITLE
STYLE: home page slack section

### DIFF
--- a/src/app/_components/CTASection.tsx
+++ b/src/app/_components/CTASection.tsx
@@ -14,11 +14,11 @@ export function CTASection({ title, description, cta }: CTASectionProps) {
   return (
     <section className="flex flex-col items-center gap-16">
       <div className="h-px w-full bg-brand-100" />
-      <div className="flex flex-col space-y-6 whitespace-pre-line sm:block sm:text-center">
-        <Heading tag="h2" variant="3xl" className="max-w-72 sm:m-auto">
+      <div className="xs:block xs:max-w-md xs:text-center flex flex-col space-y-6">
+        <Heading tag="h2" variant="3xl">
           {title}
         </Heading>
-        <p className="max-w-[60ch]">{description}</p>
+        <p className="max-w-[75ch]">{description}</p>
         {cta && <Button href={cta.href}>{cta.text}</Button>}
       </div>
     </section>

--- a/src/app/_components/CTASection.tsx
+++ b/src/app/_components/CTASection.tsx
@@ -15,7 +15,7 @@ export function CTASection({ title, description, cta }: CTASectionProps) {
     <section className="flex flex-col items-center gap-16">
       <div className="h-px w-full bg-brand-100" />
       <div className="flex flex-col space-y-6 whitespace-pre-line sm:block sm:text-center">
-        <Heading tag="h2" variant="3xl">
+        <Heading tag="h2" variant="3xl" className="max-w-72 sm:m-auto">
           {title}
         </Heading>
         <p className="max-w-[60ch]">{description}</p>

--- a/src/app/_components/CTASection.tsx
+++ b/src/app/_components/CTASection.tsx
@@ -14,7 +14,7 @@ export function CTASection({ title, description, cta }: CTASectionProps) {
   return (
     <section className="flex flex-col items-center gap-16">
       <div className="h-px w-full bg-brand-100" />
-      <div className="space-y-6 text-left sm:text-center">
+      <div className="flex flex-col space-y-6 whitespace-pre-line sm:block sm:text-center">
         <Heading tag="h2" variant="3xl">
           {title}
         </Heading>

--- a/src/app/_components/CTASection.tsx
+++ b/src/app/_components/CTASection.tsx
@@ -3,7 +3,7 @@ import { Heading } from '@/components/Heading'
 
 type CTASectionProps = {
   title: string
-  description?: string | React.ReactNode
+  description: string | React.ReactNode
   cta?: {
     href: string
     text: string
@@ -12,13 +12,15 @@ type CTASectionProps = {
 
 export function CTASection({ title, description, cta }: CTASectionProps) {
   return (
-    <section className="flex flex-col items-center gap-16">
-      <div className="h-px w-full bg-brand-100" />
-      <div className="xs:block xs:max-w-md xs:text-center flex flex-col space-y-6">
-        <Heading tag="h2" variant="3xl">
-          {title}
-        </Heading>
-        <p className="max-w-[75ch]">{description}</p>
+    <section>
+      <div className="mb-16 h-px w-full bg-brand-100" />
+      <div className="flex flex-col gap-6 sm:items-center">
+        <div className="space-y-8 sm:max-w-md sm:text-center">
+          <Heading tag="h2" variant="3xl">
+            {title}
+          </Heading>
+          <p>{description}</p>
+        </div>
         {cta && <Button href={cta.href}>{cta.text}</Button>}
       </div>
     </section>

--- a/src/app/_components/Heading.tsx
+++ b/src/app/_components/Heading.tsx
@@ -33,7 +33,9 @@ export function Heading({
   const Tag = tag
   const { component: icon, size } = iconProps ?? {}
 
-  className = clsx(variantStyles[variant], className)
+  const baseStyles = 'text-balance'
+
+  className = clsx(baseStyles, variantStyles[variant], className)
 
   if (icon) {
     return (

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -8,6 +8,7 @@ import {
 } from '@phosphor-icons/react/dist/ssr'
 
 import { Button } from '@/components/Button'
+import { CTASection } from '@/components/CTASection'
 import { FeaturedBlogPosts } from '@/components/FeaturedBlogPosts'
 import { FeaturedCaseStudies } from '@/components/FeaturedCaseStudies'
 import { Heading } from '@/components/Heading'
@@ -186,6 +187,14 @@ export default function Home() {
           View All
         </Button>
       </PageSection>
+      <CTASection
+        title={`Become Part of Our\n Vibrant Community`}
+        description="Join Filecoin's Slack to engage with the community and stay updated on the latest&nbsp;developments."
+        cta={{
+          href: FILECOIN_URLS.social.slack.href,
+          text: 'Join Filecoin Slack',
+        }}
+      ></CTASection>
     </PageLayout>
   )
 }

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -188,7 +188,7 @@ export default function Home() {
         </Button>
       </PageSection>
       <CTASection
-        title="Become Part of Our Vibrant&nbsp;Community"
+        title="Become Part of Our Vibrant Community"
         description="Join Filecoin's Slack to engage with the community and stay updated on the latest&nbsp;developments."
         cta={{
           href: FILECOIN_URLS.social.slack.href,

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -194,7 +194,7 @@ export default function Home() {
           href: FILECOIN_URLS.social.slack.href,
           text: 'Join Filecoin Slack',
         }}
-      ></CTASection>
+      />
     </PageLayout>
   )
 }

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -188,7 +188,7 @@ export default function Home() {
         </Button>
       </PageSection>
       <CTASection
-        title={`Become Part of Our\n Vibrant Community`}
+        title="Become Part of Our Vibrant&nbsp;Community"
         description="Join Filecoin's Slack to engage with the community and stay updated on the latest&nbsp;developments."
         cta={{
           href: FILECOIN_URLS.social.slack.href,


### PR DESCRIPTION
## Changes
- This PR addresses issue #82 
- I refactored the `CTASection` a bit, sorry I rushed it the first time. Issue was with the mobile view, the button was not taking the full width

### Before

![Screenshot 2024-04-23 at 14 13 40](https://github.com/FilecoinFoundationWeb/filecoin-foundation/assets/50910606/c4164fde-41c2-4269-9d14-297980c40d70)

### After

![Screenshot 2024-04-23 at 14 13 54](https://github.com/FilecoinFoundationWeb/filecoin-foundation/assets/50910606/9f0ea10b-c68e-4a73-8d48-72f52f3ff95d)


## Note

- In the designs, this component has the following spacing: 32px between `Header` and `Text`, and 24px between `Text` and `Button`. I kept it 24px and 24px, since this was the design of the [Ready to Apply section in /grants 
](https://www.figma.com/file/0pBfQs5tKI6bx5ypPIfVRA/FIL.org-V4-Prototypes?type=design&node-id=1442-28546&mode=design&t=gnr0VjzuzA8lDRU3-4) - component which we are reusing. @filipagr just wanted to confirm if this is ok? Or you would like to stick with 32px and 24px?