### PR TITLE
Revert "CONFIG: new xs breakpoint"

### DIFF
--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -15,9 +15,6 @@ module.exports = {
           800: '#08072e',
         },
       },
-      screens: {
-        xs: '376px',
-      },
     },
   },
   plugins: [require('@tailwindcss/typography')],


### PR DESCRIPTION
Reverts FilecoinFoundationWeb/filecoin-foundation#86 - We don't need the `xs` breakpoint after all.