### PR TITLE
Events Page - Get Involved Section

### DIFF
--- a/src/app/_constants/siteMetadata.ts
+++ b/src/app/_constants/siteMetadata.ts
@@ -18,6 +18,9 @@ const FILECOIN_FOUNDATION_URLS = {
     submitOrUpdateProjectForm:
       'https://airtable.com/apppNMXvdW3i9P1BY/shrvrv4B9JKCP1e4O',
   },
+  events: {
+    sponsorShipsEmail: 'mailto:sponsorships@fil.org',
+  },
   email: 'mailto:hello@fil.org',
   governance: {
     docs: '#',

--- a/src/app/_constants/siteMetadata.ts
+++ b/src/app/_constants/siteMetadata.ts
@@ -19,7 +19,7 @@ const FILECOIN_FOUNDATION_URLS = {
       'https://airtable.com/apppNMXvdW3i9P1BY/shrvrv4B9JKCP1e4O',
   },
   events: {
-    sponsorShipsEmail: 'mailto:sponsorships@fil.org',
+    sponsorshipsEmail: 'mailto:sponsorships@fil.org',
   },
   email: 'mailto:hello@fil.org',
   governance: {

--- a/src/app/events/data/getInvolvedData.ts
+++ b/src/app/events/data/getInvolvedData.ts
@@ -5,10 +5,9 @@ import { FILECOIN_FOUNDATION_URLS } from '@/constants/siteMetadata'
 export const getInvolvedData = [
   {
     title: 'Sponsor an Event',
-    description:
-      'To be featured partner or sponsor an upcoming Foundation-hosted event, reach out to sponsorships@fil.org.',
+    description: `To be featured partner or sponsor an upcoming Foundation-hosted event, reach out to ${FILECOIN_FOUNDATION_URLS.events.sponsorshipsEmail.replace('mailto:', '')}.`,
     cta: {
-      href: FILECOIN_FOUNDATION_URLS.events.sponsorShipsEmail,
+      href: FILECOIN_FOUNDATION_URLS.events.sponsorshipsEmail,
       text: 'Email Us',
       icon: Envelope,
     },

--- a/src/app/events/data/getInvolvedData.ts
+++ b/src/app/events/data/getInvolvedData.ts
@@ -1,0 +1,36 @@
+import { Clipboard, Envelope, HandWaving } from '@phosphor-icons/react/dist/ssr'
+
+import { FILECOIN_FOUNDATION_URLS } from '@/constants/siteMetadata'
+
+export const getInvolvedData = [
+  {
+    title: 'Sponsor an Event',
+    description:
+      'To be featured partner or sponsor an upcoming Foundation-hosted event, reach out to sponsorships@fil.org.',
+    cta: {
+      href: FILECOIN_FOUNDATION_URLS.events.sponsorShipsEmail,
+      text: 'Email Us',
+      icon: Envelope,
+    },
+  },
+  {
+    title: 'Speak at a Filecoin Event',
+    description:
+      'Interested in joining the Filecoin Foundation on stage? Complete the speaker intake form.',
+    cta: {
+      href: '#',
+      text: 'Submit Form',
+      icon: Clipboard,
+    },
+  },
+  {
+    title: 'Join Filecoin Orbit',
+    description:
+      'The Filecoin Orbit program promotes Filecoin technology through community events that raise network awareness. Apply to be an Orbit Ambassador.',
+    cta: {
+      href: '#',
+      text: 'Apply to Filecoin Orbit',
+      icon: HandWaving,
+    },
+  },
+]

--- a/src/app/events/page.tsx
+++ b/src/app/events/page.tsx
@@ -107,7 +107,7 @@ export default function Events() {
               key={title}
               title={title}
               description={description}
-              cta={{ ...cta }}
+              cta={cta}
             />
           ))}
         </CardLayout>

--- a/src/app/events/page.tsx
+++ b/src/app/events/page.tsx
@@ -1,5 +1,7 @@
 import { WebPage, WithContext } from 'schema-dts'
 
+import { Card } from '@/components/Card'
+import { CardLayout } from '@/components/CardLayout'
 import { PageHeader } from '@/components/PageHeader'
 import { PageLayout } from '@/components/PageLayout'
 import { PageSection } from '@/components/PageSection'
@@ -17,6 +19,7 @@ import { attributes } from '@/content/pages/events.md'
 import { PATHS } from '@/constants/paths'
 import { BASE_URL } from '@/constants/siteMetadata'
 
+import { getInvolvedData } from './data/getInvolvedData'
 import { EventsClient } from './EventsClient'
 
 const { featured_post: featuredEventSlug, seo } = attributes
@@ -92,6 +95,22 @@ export default function Events() {
 
       <PageSection kicker="Events" title="All Events">
         <EventsClient events={events} />
+      </PageSection>
+
+      <PageSection
+        kicker="Get Involved"
+        title="Get in Touch With the Events Team"
+      >
+        <CardLayout>
+          {getInvolvedData.map(({ title, description, cta }) => (
+            <Card
+              key={title}
+              title={title}
+              description={description}
+              cta={{ ...cta }}
+            />
+          ))}
+        </CardLayout>
       </PageSection>
     </PageLayout>
   )


### PR DESCRIPTION
Style Events Page - Get Involved Section per Figma design [>>](https://www.figma.com/file/0pBfQs5tKI6bx5ypPIfVRA/FIL.org-V4-Prototypes?type=design&node-id=1231-33806&mode=design&t=Bzqh6wru2l2AsJtp-4)

<img width="1056" alt="Screenshot 2024-05-03 at 07 20 58" src="https://github.com/FilecoinFoundationWeb/filecoin-foundation/assets/26620750/ddce6745-a800-4705-9b61-3fa19f284245">

*Note:* Graphics to be added when design gets them.