### PR TITLE
Style navigation menu mobile

### DIFF
--- a/src/app/_components/Footer.tsx
+++ b/src/app/_components/Footer.tsx
@@ -72,7 +72,11 @@ export function Footer() {
       </div>
 
       <hr />
-      <Social />
+
+      <div className="sm:px-8">
+        <Social />
+      </div>
+
       <hr />
 
       <div className="flex flex-wrap gap-x-20 gap-y-6">

--- a/src/app/_components/MobileNavigation.tsx
+++ b/src/app/_components/MobileNavigation.tsx
@@ -1,0 +1,125 @@
+'use client'
+
+import { Fragment, useState, Dispatch, SetStateAction } from 'react'
+
+import Link from 'next/link'
+
+import { List, X } from '@phosphor-icons/react'
+import clsx from 'clsx'
+
+import { Icon } from '@/components/Icon'
+import { Logo } from '@/components/Logo'
+import { SlideOver } from '@/components/SlideOver'
+import { Social } from '@/components/Social'
+import { TextLink } from '@/components/TextLink'
+
+import { PATHS } from '@/constants/paths'
+
+const getInvolvedItems = [PATHS.EVENTS, PATHS.GRANTS]
+const communityItems = [PATHS.ECOSYSTEM, PATHS.GOVERNANCE]
+
+export function MobileNavigation() {
+  const [open, setOpen] = useState(false)
+
+  return (
+    <Fragment>
+      <button
+        className="-mr-4 flex size-12 items-center justify-center lg:hidden"
+        aria-label="Open mobile navigation"
+        onClick={() => setOpen(!open)}
+      >
+        <Icon component={List} color="brand-300" />
+      </button>
+
+      <SlideOver open={open} setOpen={setOpen}>
+        <div className="flex items-center justify-between px-6 pb-12 pt-8 sm:pb-16 md:pb-24">
+          <Link
+            className="flex-shrink-0 outline-white focus:outline-2"
+            href={PATHS.HOME.path}
+            aria-label="Go to homepage"
+            onClick={() => setOpen(false)}
+          >
+            <Logo />
+          </Link>
+
+          <button
+            className="-mr-4 flex size-12 items-center justify-center"
+            aria-label="Close mobile navigation"
+            onClick={() => setOpen(false)}
+          >
+            <Icon component={X} color="brand-300" />
+          </button>
+        </div>
+
+        <ul
+          className="px-6 pb-12 sm:pb-16 md:pb-24"
+          aria-label="Navigation options"
+        >
+          <MobileLink
+            label={PATHS.ABOUT.label}
+            path={PATHS.ABOUT.path}
+            setOpen={setOpen}
+          />
+
+          <li>
+            <p className="my-2.5 text-brand-300">Get Involved</p>
+          </li>
+          {getInvolvedItems.map((item) => (
+            <MobileLink
+              key={item.path}
+              nested
+              label={item.label}
+              path={item.path}
+              setOpen={setOpen}
+            />
+          ))}
+
+          <li>
+            <p className="my-2.5 text-brand-300">Community</p>
+          </li>
+
+          {communityItems.map((item) => (
+            <MobileLink
+              key={item.path}
+              nested
+              label={item.label}
+              path={item.path}
+              setOpen={setOpen}
+            />
+          ))}
+
+          <MobileLink
+            label={PATHS.BLOG.label}
+            path={PATHS.BLOG.path}
+            setOpen={setOpen}
+          />
+        </ul>
+
+        <div className="px-4">
+          <Social justify="left" />
+        </div>
+      </SlideOver>
+    </Fragment>
+  )
+}
+
+interface MobileLinkProps {
+  label: string
+  path: string
+  nested?: boolean
+  setOpen: Dispatch<SetStateAction<boolean>>
+}
+
+function MobileLink({ label, path, nested, setOpen }: MobileLinkProps) {
+  return (
+    <li className={clsx(nested ? 'border-l border-brand-400' : '-ml-5')}>
+      <TextLink
+        href={path}
+        className="inline-block px-5 py-2.5"
+        onClick={() => setOpen(false)}
+      >
+        {label}
+      </TextLink>
+    </li>
+  )
+}

--- a/src/app/_components/MobileNavigation.tsx
+++ b/src/app/_components/MobileNavigation.tsx
@@ -149,7 +149,7 @@ export function MobileNavigation() {
         </ul>
 
         <div className="px-4">
-          <Social justify="start" />
+          <Social />
         </div>
       </SlideOver>
     </Fragment>

--- a/src/app/_components/MobileNavigation.tsx
+++ b/src/app/_components/MobileNavigation.tsx
@@ -49,11 +49,6 @@ function MobileLink({ label, path, nested, setOpen }: MobileLinkProps) {
   )
 }
 
-const buttonTouchTarget = {
-  class: 'size-12',
-  offsetClass: '-mr-4',
-}
-
 type IconButtonProps = {
   icon: IconProps['component']
   label: string
@@ -65,9 +60,7 @@ function IconButton({ icon: IconComponent, label, onClick }: IconButtonProps) {
     <button
       aria-label={label}
       className={clsx(
-        buttonTouchTarget.class,
-        buttonTouchTarget.offsetClass,
-        'flex items-center justify-center focus:outline-2 focus:outline-brand-100 lg:hidden',
+        'flex size-12 items-center justify-center rounded-lg border border-brand-300 focus:outline-2 focus:outline-brand-100 lg:hidden',
       )}
       onClick={onClick}
     >

--- a/src/app/_components/MobileNavigation.tsx
+++ b/src/app/_components/MobileNavigation.tsx
@@ -81,7 +81,7 @@ export function MobileNavigation() {
       />
 
       <SlideOver open={open} setOpen={setOpen}>
-        <div className="flex items-center justify-between px-6 pb-12 pt-8 sm:pb-16 md:pb-24">
+        <div className="flex items-center justify-between px-6 pb-12 pt-8 sm:pb-16">
           <Link
             className="flex-shrink-0 outline-white focus:outline-2"
             href={PATHS.HOME.path}
@@ -98,10 +98,7 @@ export function MobileNavigation() {
           />
         </div>
 
-        <ul
-          className="px-6 pb-12 sm:pb-16 md:pb-24"
-          aria-label="Navigation options"
-        >
+        <ul className="px-6 pb-12 sm:pb-16" aria-label="Navigation options">
           <MobileLink
             label={PATHS.ABOUT.label}
             path={PATHS.ABOUT.path}

--- a/src/app/_components/MobileNavigation.tsx
+++ b/src/app/_components/MobileNavigation.tsx
@@ -6,12 +6,13 @@ import Link from 'next/link'
 
 import { List, X, Icon as IconType } from '@phosphor-icons/react'
 import clsx from 'clsx'
+import { Route } from 'next'
 
 import { Icon } from '@/components/Icon'
 import { Logo } from '@/components/Logo'
 import { SlideOver } from '@/components/SlideOver'
 import { Social } from '@/components/Social'
-import { TextLink } from '@/components/TextLink'
+import { baseStyles } from '@/components/TextLink'
 
 import { PATHS } from '@/constants/paths'
 
@@ -20,21 +21,33 @@ const communityItems = [PATHS.ECOSYSTEM, PATHS.GOVERNANCE]
 
 type MobileLinkProps = {
   label: string
-  path: string
+  path: Route
   nested?: boolean
   setOpen: Dispatch<SetStateAction<boolean>>
 }
 
 function MobileLink({ label, path, nested, setOpen }: MobileLinkProps) {
+  const touchTargetSpacing = 5
+  const touchTargetClass = `px-${touchTargetSpacing}`
+  const touchTargetOffsetClass = `-ml-${touchTargetSpacing}`
+
   return (
-    <li className={clsx(nested ? 'border-l border-brand-400' : '-ml-5')}>
-      <TextLink
+    <li
+      className={clsx(
+        nested ? 'border-l border-brand-400' : touchTargetOffsetClass,
+      )}
+    >
+      <Link
         href={path}
-        className="inline-block px-5 py-2.5"
+        className={clsx(
+          baseStyles,
+          touchTargetClass,
+          'inline-block px-5 py-2.5',
+        )}
         onClick={() => setOpen(false)}
       >
         {label}
-      </TextLink>
+      </Link>
     </li>
   )
 }

--- a/src/app/_components/MobileNavigation.tsx
+++ b/src/app/_components/MobileNavigation.tsx
@@ -4,11 +4,11 @@ import { Fragment, useState, Dispatch, SetStateAction } from 'react'
 
 import Link from 'next/link'
 
-import { List, X, Icon as IconType } from '@phosphor-icons/react'
+import { List, X } from '@phosphor-icons/react'
 import clsx from 'clsx'
 import { Route } from 'next'
 
-import { Icon } from '@/components/Icon'
+import { Icon, IconProps } from '@/components/Icon'
 import { Logo } from '@/components/Logo'
 import { SlideOver } from '@/components/SlideOver'
 import { Social } from '@/components/Social'
@@ -53,7 +53,7 @@ function MobileLink({ label, path, nested, setOpen }: MobileLinkProps) {
 }
 
 type IconButtonProps = {
-  icon: IconType
+  icon: IconProps['component']
   label: string
   onClick: React.ComponentPropsWithoutRef<'button'>['onClick']
 }

--- a/src/app/_components/MobileNavigation.tsx
+++ b/src/app/_components/MobileNavigation.tsx
@@ -19,6 +19,11 @@ import { PATHS } from '@/constants/paths'
 const getInvolvedItems = [PATHS.EVENTS, PATHS.GRANTS]
 const communityItems = [PATHS.ECOSYSTEM, PATHS.GOVERNANCE]
 
+const linkTouchTarget = {
+  class: 'inline-block px-5 py-2.5',
+  offsetClass: '-ml-5',
+}
+
 type MobileLinkProps = {
   label: string
   path: Route
@@ -27,29 +32,26 @@ type MobileLinkProps = {
 }
 
 function MobileLink({ label, path, nested, setOpen }: MobileLinkProps) {
-  const touchTargetSpacing = 5
-  const touchTargetClass = `px-${touchTargetSpacing}`
-  const touchTargetOffsetClass = `-ml-${touchTargetSpacing}`
-
   return (
     <li
       className={clsx(
-        nested ? 'border-l border-brand-400' : touchTargetOffsetClass,
+        nested ? 'border-l border-brand-400' : linkTouchTarget.offsetClass,
       )}
     >
       <Link
         href={path}
-        className={clsx(
-          linkBaseStyles,
-          touchTargetClass,
-          'inline-block py-2.5',
-        )}
+        className={clsx(linkBaseStyles, linkTouchTarget.class)}
         onClick={() => setOpen(false)}
       >
         {label}
       </Link>
     </li>
   )
+}
+
+const buttonTouchTarget = {
+  class: 'size-12',
+  offsetClass: '-mr-4',
 }
 
 type IconButtonProps = {
@@ -61,8 +63,12 @@ type IconButtonProps = {
 function IconButton({ icon: IconComponent, label, onClick }: IconButtonProps) {
   return (
     <button
-      className="-mr-4 flex size-12 items-center justify-center focus:outline-2 focus:outline-brand-100 lg:hidden"
       aria-label={label}
+      className={clsx(
+        buttonTouchTarget.class,
+        buttonTouchTarget.offsetClass,
+        'flex items-center justify-center focus:outline-2 focus:outline-brand-100 lg:hidden',
+      )}
       onClick={onClick}
     >
       <Icon component={IconComponent} color="brand-300" />

--- a/src/app/_components/MobileNavigation.tsx
+++ b/src/app/_components/MobileNavigation.tsx
@@ -42,7 +42,7 @@ function MobileLink({ label, path, nested, setOpen }: MobileLinkProps) {
         className={clsx(
           linkBaseStyles,
           touchTargetClass,
-          'inline-block px-5 py-2.5',
+          'inline-block py-2.5',
         )}
         onClick={() => setOpen(false)}
       >

--- a/src/app/_components/MobileNavigation.tsx
+++ b/src/app/_components/MobileNavigation.tsx
@@ -103,7 +103,7 @@ export function MobileNavigation() {
   )
 }
 
-interface MobileLinkProps {
+type MobileLinkProps = {
   label: string
   path: string
   nested?: boolean

--- a/src/app/_components/MobileNavigation.tsx
+++ b/src/app/_components/MobileNavigation.tsx
@@ -12,7 +12,7 @@ import { Icon, IconProps } from '@/components/Icon'
 import { Logo } from '@/components/Logo'
 import { SlideOver } from '@/components/SlideOver'
 import { Social } from '@/components/Social'
-import { baseStyles } from '@/components/TextLink'
+import { linkBaseStyles } from '@/components/TextLink'
 
 import { PATHS } from '@/constants/paths'
 
@@ -40,7 +40,7 @@ function MobileLink({ label, path, nested, setOpen }: MobileLinkProps) {
       <Link
         href={path}
         className={clsx(
-          baseStyles,
+          linkBaseStyles,
           touchTargetClass,
           'inline-block px-5 py-2.5',
         )}

--- a/src/app/_components/MobileNavigation.tsx
+++ b/src/app/_components/MobileNavigation.tsx
@@ -18,6 +18,27 @@ import { PATHS } from '@/constants/paths'
 const getInvolvedItems = [PATHS.EVENTS, PATHS.GRANTS]
 const communityItems = [PATHS.ECOSYSTEM, PATHS.GOVERNANCE]
 
+type MobileLinkProps = {
+  label: string
+  path: string
+  nested?: boolean
+  setOpen: Dispatch<SetStateAction<boolean>>
+}
+
+function MobileLink({ label, path, nested, setOpen }: MobileLinkProps) {
+  return (
+    <li className={clsx(nested ? 'border-l border-brand-400' : '-ml-5')}>
+      <TextLink
+        href={path}
+        className="inline-block px-5 py-2.5"
+        onClick={() => setOpen(false)}
+      >
+        {label}
+      </TextLink>
+    </li>
+  )
+}
+
 export function MobileNavigation() {
   const [open, setOpen] = useState(false)
 
@@ -100,26 +121,5 @@ export function MobileNavigation() {
         </div>
       </SlideOver>
     </Fragment>
-  )
-}
-
-type MobileLinkProps = {
-  label: string
-  path: string
-  nested?: boolean
-  setOpen: Dispatch<SetStateAction<boolean>>
-}
-
-function MobileLink({ label, path, nested, setOpen }: MobileLinkProps) {
-  return (
-    <li className={clsx(nested ? 'border-l border-brand-400' : '-ml-5')}>
-      <TextLink
-        href={path}
-        className="inline-block px-5 py-2.5"
-        onClick={() => setOpen(false)}
-      >
-        {label}
-      </TextLink>
-    </li>
   )
 }

--- a/src/app/_components/MobileNavigation.tsx
+++ b/src/app/_components/MobileNavigation.tsx
@@ -4,7 +4,7 @@ import { Fragment, useState, Dispatch, SetStateAction } from 'react'
 
 import Link from 'next/link'
 
-import { List, X } from '@phosphor-icons/react'
+import { List, X, Icon as IconType } from '@phosphor-icons/react'
 import clsx from 'clsx'
 
 import { Icon } from '@/components/Icon'
@@ -39,18 +39,34 @@ function MobileLink({ label, path, nested, setOpen }: MobileLinkProps) {
   )
 }
 
+type IconButtonProps = {
+  icon: IconType
+  label: string
+  onClick: React.ComponentPropsWithoutRef<'button'>['onClick']
+}
+
+function IconButton({ icon: IconComponent, label, onClick }: IconButtonProps) {
+  return (
+    <button
+      className="-mr-4 flex size-12 items-center justify-center focus:outline-2 focus:outline-brand-100 lg:hidden"
+      aria-label={label}
+      onClick={onClick}
+    >
+      <Icon component={IconComponent} color="brand-300" />
+    </button>
+  )
+}
+
 export function MobileNavigation() {
   const [open, setOpen] = useState(false)
 
   return (
     <Fragment>
-      <button
-        className="-mr-4 flex size-12 items-center justify-center lg:hidden"
-        aria-label="Open mobile navigation"
-        onClick={() => setOpen(!open)}
-      >
-        <Icon component={List} color="brand-300" />
-      </button>
+      <IconButton
+        icon={List}
+        label="Open mobile navigation"
+        onClick={() => setOpen(true)}
+      />
 
       <SlideOver open={open} setOpen={setOpen}>
         <div className="flex items-center justify-between px-6 pb-12 pt-8 sm:pb-16 md:pb-24">
@@ -63,13 +79,11 @@ export function MobileNavigation() {
             <Logo />
           </Link>
 
-          <button
-            className="-mr-4 flex size-12 items-center justify-center"
-            aria-label="Close mobile navigation"
+          <IconButton
+            icon={X}
+            label="Close mobile navigation"
             onClick={() => setOpen(false)}
-          >
-            <Icon component={X} color="brand-300" />
-          </button>
+          />
         </div>
 
         <ul

--- a/src/app/_components/MobileNavigation.tsx
+++ b/src/app/_components/MobileNavigation.tsx
@@ -130,7 +130,7 @@ export function MobileNavigation() {
         </ul>
 
         <div className="px-4">
-          <Social justify="left" />
+          <Social justify="start" />
         </div>
       </SlideOver>
     </Fragment>

--- a/src/app/_components/MobileNavigation.tsx
+++ b/src/app/_components/MobileNavigation.tsx
@@ -98,7 +98,6 @@ export function MobileNavigation() {
           <li>
             <p className="my-2.5 text-brand-300">Community</p>
           </li>
-
           {communityItems.map((item) => (
             <MobileLink
               key={item.path}

--- a/src/app/_components/Navigation.tsx
+++ b/src/app/_components/Navigation.tsx
@@ -1,6 +1,7 @@
 import Link from 'next/link'
 
 import { Logo } from '@/components/Logo'
+import { MobileNavigation } from '@/components/MobileNavigation'
 import { TextLink } from '@/components/TextLink'
 
 import { PATHS } from '@/constants/paths'
@@ -31,7 +32,10 @@ export function Navigation() {
         <Logo />
         <span className="sr-only">Home</span>
       </Link>
-      <ul className="gap-5 md:flex">
+
+      <MobileNavigation />
+
+      <ul className="hidden gap-5 lg:flex">
         {navigationItems.map((item) => (
           <NavigationLink key={item.path} label={item.label} path={item.path} />
         ))}

--- a/src/app/_components/SlideOver.tsx
+++ b/src/app/_components/SlideOver.tsx
@@ -1,0 +1,51 @@
+import { Fragment } from 'react'
+
+import { Dialog, Transition } from '@headlessui/react'
+
+interface SlideOverProps {
+  open: boolean
+  setOpen: (open: boolean) => void
+  children: React.ReactNode
+}
+
+export function SlideOver({ open, setOpen, children }: SlideOverProps) {
+  return (
+    <Transition.Root show={open} as={Fragment}>
+      <Dialog className="relative z-10" onClose={setOpen}>
+        <Transition.Child
+          as={Fragment}
+          enter="ease-in-out duration-500 sm:duration-700"
+          enterFrom="opacity-0"
+          enterTo="opacity-100"
+          leave="ease-in-out duration-500 sm:duration-700"
+          leaveFrom="opacity-100"
+          leaveTo="opacity-0"
+        >
+          <div className="fixed inset-0 backdrop-blur-lg" />
+        </Transition.Child>
+
+        <div className="fixed inset-0 overflow-hidden">
+          <div className="absolute inset-0 overflow-hidden">
+            <div className="pointer-events-none fixed inset-y-0 right-0 flex w-full max-w-[480px]">
+              <Transition.Child
+                as={Fragment}
+                enter="transform transition ease-in-out duration-500 sm:duration-700"
+                enterFrom="translate-x-full"
+                enterTo="translate-x-0"
+                leave="transform transition ease-in-out duration-500 sm:duration-700"
+                leaveFrom="translate-x-0"
+                leaveTo="translate-x-full"
+              >
+                <Dialog.Panel className="pointer-events-auto w-full">
+                  <div className="flex h-full flex-col overflow-y-scroll bg-brand-800">
+                    {children}
+                  </div>
+                </Dialog.Panel>
+              </Transition.Child>
+            </div>
+          </div>
+        </div>
+      </Dialog>
+    </Transition.Root>
+  )
+}

--- a/src/app/_components/SlideOver.tsx
+++ b/src/app/_components/SlideOver.tsx
@@ -2,7 +2,7 @@ import { Fragment } from 'react'
 
 import { Dialog, Transition } from '@headlessui/react'
 
-interface SlideOverProps {
+type SlideOverProps = {
   open: boolean
   setOpen: (open: boolean) => void
   children: React.ReactNode

--- a/src/app/_components/Social.tsx
+++ b/src/app/_components/Social.tsx
@@ -8,11 +8,16 @@ const touchTargetSpacing = 2
 const touchTargetClass = `p-${touchTargetSpacing}`
 const touchTargetOffsetClass = `-m-${touchTargetSpacing} sm:mx-0`
 
-export function Social() {
+interface SocialProps {
+  justify?: 'left' | 'between'
+}
+
+export function Social({ justify = 'between' }: SocialProps) {
   return (
     <ul
       className={clsx(
-        'flex flex-wrap items-center justify-between gap-4 sm:px-8',
+        'flex flex-wrap items-center gap-4',
+        justify === 'between' && 'justify-between',
         touchTargetOffsetClass,
       )}
     >

--- a/src/app/_components/Social.tsx
+++ b/src/app/_components/Social.tsx
@@ -9,7 +9,7 @@ const touchTargetClass = `p-${touchTargetSpacing}`
 const touchTargetOffsetClass = `-m-${touchTargetSpacing} sm:mx-0`
 
 type SocialProps = {
-  justify?: 'left' | 'between'
+  justify?: 'start' | 'between'
 }
 
 export function Social({ justify = 'between' }: SocialProps) {
@@ -17,6 +17,7 @@ export function Social({ justify = 'between' }: SocialProps) {
     <ul
       className={clsx(
         'flex flex-wrap items-center gap-4',
+        justify === 'start' && 'justify-start',
         justify === 'between' && 'justify-between',
         touchTargetOffsetClass,
       )}

--- a/src/app/_components/Social.tsx
+++ b/src/app/_components/Social.tsx
@@ -8,7 +8,7 @@ const touchTargetSpacing = 2
 const touchTargetClass = `p-${touchTargetSpacing}`
 const touchTargetOffsetClass = `-m-${touchTargetSpacing} sm:mx-0`
 
-interface SocialProps {
+type SocialProps = {
   justify?: 'left' | 'between'
 }
 

--- a/src/app/_components/Social.tsx
+++ b/src/app/_components/Social.tsx
@@ -4,9 +4,10 @@ import { Icon } from '@/components/Icon'
 
 import { socialLinksWithIcons } from '@/utils/socialConfig'
 
-const touchTargetSpacing = 2
-const touchTargetClass = `p-${touchTargetSpacing}`
-const touchTargetOffsetClass = `-m-${touchTargetSpacing} sm:mx-0`
+const touchTarget = {
+  class: 'p-2',
+  offsetClass: '-m-2 sm:mx-0',
+}
 
 type SocialProps = {
   justify?: 'start' | 'between'
@@ -19,7 +20,7 @@ export function Social({ justify = 'between' }: SocialProps) {
         'flex flex-wrap items-center gap-4',
         justify === 'start' && 'justify-start',
         justify === 'between' && 'justify-between',
-        touchTargetOffsetClass,
+        touchTarget.offsetClass,
       )}
     >
       {socialLinksWithIcons.map(({ label, href, icon }, key) => {
@@ -32,7 +33,7 @@ export function Social({ justify = 'between' }: SocialProps) {
               rel="noopener noreferrer"
               className={clsx(
                 'text-brand-100 outline-white hover:text-brand-400 focus:outline-2',
-                touchTargetClass,
+                touchTarget.class,
               )}
             >
               <Icon component={icon} size={32} weight="light" />

--- a/src/app/_components/Social.tsx
+++ b/src/app/_components/Social.tsx
@@ -9,17 +9,11 @@ const touchTarget = {
   offsetClass: '-m-2 sm:mx-0',
 }
 
-type SocialProps = {
-  justify?: 'start' | 'between'
-}
-
-export function Social({ justify = 'between' }: SocialProps) {
+export function Social() {
   return (
     <ul
       className={clsx(
-        'flex flex-wrap items-center gap-4',
-        justify === 'start' && 'justify-start',
-        justify === 'between' && 'justify-between',
+        'flex flex-wrap items-center justify-between gap-4',
         touchTarget.offsetClass,
       )}
     >

--- a/src/app/_components/TextLink.tsx
+++ b/src/app/_components/TextLink.tsx
@@ -8,14 +8,14 @@ type TextLinkProps = {
   children: React.ReactNode
 } & React.AnchorHTMLAttributes<HTMLAnchorElement>
 
+export const baseStyles = `text-brand-300 hover:underline focus:outline-2 focus:outline-brand-100`
+
 export function TextLink({
   href,
   className,
   children,
   ...rest
 }: TextLinkProps) {
-  const baseStyles = `text-brand-300 hover:underline focus:outline-2 focus:outline-brand-100`
-
   className = clsx(baseStyles, className)
 
   return (

--- a/src/app/_components/TextLink.tsx
+++ b/src/app/_components/TextLink.tsx
@@ -8,7 +8,7 @@ type TextLinkProps = {
   children: React.ReactNode
 } & React.AnchorHTMLAttributes<HTMLAnchorElement>
 
-export const baseStyles = `text-brand-300 hover:underline focus:outline-2 focus:outline-brand-100`
+export const linkBaseStyles = `text-brand-300 hover:underline focus:outline-2 focus:outline-brand-100`
 
 export function TextLink({
   href,
@@ -16,7 +16,7 @@ export function TextLink({
   children,
   ...rest
 }: TextLinkProps) {
-  className = clsx(baseStyles, className)
+  className = clsx(linkBaseStyles, className)
 
   return (
     <CustomLink href={href} className={className} {...rest}>


### PR DESCRIPTION
This PR adds a sliding navigation menu for screen sizes up to `md` (mobiles and tablets):

1. I've added a generic `<SlideOver />` component to separate concerns and keep things cleaner.
2. I've reworked the `<Social />` component to make it reusable in the `<MobileNavigation />` component
3. I've implemented the sliding navigation on mobile as per the [Figma design](https://www.figma.com/file/0pBfQs5tKI6bx5ypPIfVRA/FIL.org-V4-Prototypes?type=design&node-id=1988-78176&mode=design&t=UvnAlLmcodPFI5Js-11)

About the `<MobileNavigation />` implementation, I've played with negative margins to make sure the link's touch targets are big enough. This is why I added `inline-block px-5 py-2.5` to `<TextLink />`, and `-mr-4 size-12` to buttons.

Unlike the Figma design, both the sliding menu and website have a `brand.800` background, which is not ideal for contrast. Adding the gradient background should solve this issue. If not, we can find other ways to better delimit the menu.

Voila!

PS: [The design team seems happy](https://filecoinfoundation.slack.com/archives/C06MTEQ3SP6/p1715009223575449) with the current implementation!