### PR TITLE
Blog page sort

### DIFF
--- a/src/app/_components/BlogSort.tsx
+++ b/src/app/_components/BlogSort.tsx
@@ -11,7 +11,7 @@ import { type SortOptionType } from '@/types/sortTypes'
 import { SORT_KEY } from '@/constants/searchParams'
 import { DEFAULT_SORT_OPTION } from '@/constants/sortConstants'
 
-export function BlogSortController() {
+export function BlogSort() {
   const [sortOption, setSortOption] =
     useState<SortOptionType>(DEFAULT_SORT_OPTION)
   const updateSearchParams = useUpdateSearchParams()

--- a/src/app/_components/BlogSortController.tsx
+++ b/src/app/_components/BlogSortController.tsx
@@ -1,0 +1,25 @@
+'use client'
+
+import { useState, useEffect } from 'react'
+
+import { useUpdateSearchParams } from '@/hooks/useUpdateSearchParams'
+
+import {
+  type SortOptionType,
+  DEFAULT_SORT_OPTION,
+  SortListbox,
+} from '@/components/SortListbox'
+
+export function BlogSortController() {
+  const [sortOption, setSortOption] =
+    useState<SortOptionType>(DEFAULT_SORT_OPTION)
+  const updateSearchParams = useUpdateSearchParams()
+
+  useEffect(() => {
+    updateSearchParams({ sort: sortOption })
+  }, [sortOption, updateSearchParams])
+
+  return (
+    <SortListbox sortOption={sortOption} onSortOptionChange={setSortOption} />
+  )
+}

--- a/src/app/_components/BlogSortController.tsx
+++ b/src/app/_components/BlogSortController.tsx
@@ -4,11 +4,12 @@ import { useState, useEffect } from 'react'
 
 import { useUpdateSearchParams } from '@/hooks/useUpdateSearchParams'
 
-import {
-  type SortOptionType,
-  DEFAULT_SORT_OPTION,
-  SortListbox,
-} from '@/components/SortListbox'
+import { SortListbox } from '@/components/SortListbox'
+
+import { type SortOptionType } from '@/types/sortTypes'
+
+import { SORT_KEY } from '@/constants/searchParams'
+import { DEFAULT_SORT_OPTION } from '@/constants/sortConstants'
 
 export function BlogSortController() {
   const [sortOption, setSortOption] =
@@ -16,7 +17,7 @@ export function BlogSortController() {
   const updateSearchParams = useUpdateSearchParams()
 
   useEffect(() => {
-    updateSearchParams({ sort: sortOption })
+    updateSearchParams({ [SORT_KEY]: sortOption })
   }, [sortOption, updateSearchParams])
 
   return (

--- a/src/app/_components/SortListbox.tsx
+++ b/src/app/_components/SortListbox.tsx
@@ -1,5 +1,5 @@
 'use client'
-import { Fragment, useState } from 'react'
+import { Fragment } from 'react'
 
 import { Listbox } from '@headlessui/react'
 import { ArrowsDownUp, CaretDown, Check } from '@phosphor-icons/react/dist/ssr'
@@ -7,41 +7,42 @@ import clsx from 'clsx'
 
 import { Icon } from '@/components/Icon'
 
-export enum SortType {
-  Newest = 'newest',
-  Oldest = 'oldest',
-}
+export type SortOptionType = 'newest' | 'oldest'
 
 type SortSetting = {
-  id: SortType
+  id: SortOptionType
   name: string
 }
 
 type SortListboxProps = {
-  onSortTypeChange: (selectedOption: SortType) => void
+  sortOption: SortOptionType
+  onSortOptionChange: (selectedSortOption: SortOptionType) => void
 }
 
+export const DEFAULT_SORT_OPTION = 'newest'
+
 const sortSettings: SortSetting[] = [
-  { id: SortType.Newest, name: 'Newest' },
-  { id: SortType.Oldest, name: 'Oldest' },
+  { id: 'newest', name: 'Newest' },
+  { id: 'oldest', name: 'Oldest' },
 ]
 
-export function SortListbox({ onSortTypeChange }: SortListboxProps) {
-  const [selectedSortType, setSelectedSortType] = useState(sortSettings[0])
-
-  function handleChange(newSortType: SortSetting) {
-    setSelectedSortType(newSortType)
-    onSortTypeChange(newSortType.id)
-  }
+export function SortListbox({
+  sortOption,
+  onSortOptionChange,
+}: SortListboxProps) {
+  const selectedSortSetting =
+    sortSettings.find((option) => option.id === sortOption) || sortSettings[0]
 
   return (
-    <Listbox value={selectedSortType} onChange={handleChange}>
+    <Listbox value={sortOption} onChange={onSortOptionChange}>
       {() => (
         <>
           <Listbox.Button className="border-1 inline-flex items-center justify-between gap-2 rounded-lg border border-brand-300 p-3 text-brand-300 hover:border-current hover:text-brand-400 focus:outline-2 focus:outline-brand-100 sm:min-w-40">
             <div className="inline-flex items-center gap-2">
               <Icon component={ArrowsDownUp} />
-              <span className="hidden sm:block">{selectedSortType.name}</span>
+              <span className="hidden sm:block">
+                {selectedSortSetting.name}
+              </span>
             </div>
             <span className="hidden sm:block">
               <Icon component={CaretDown} size={16} weight="bold" />
@@ -49,7 +50,7 @@ export function SortListbox({ onSortTypeChange }: SortListboxProps) {
           </Listbox.Button>
           <Listbox.Options className="absolute z-10 mt-14 min-w-40 overflow-hidden rounded-lg border border-brand-100 bg-brand-800 py-1 text-brand-100 focus-within:outline-2 focus:outline-2 focus:outline-brand-100">
             {sortSettings.map((option) => (
-              <Listbox.Option key={option.id} value={option} as={Fragment}>
+              <Listbox.Option key={option.id} value={option.id} as={Fragment}>
                 {({ active, selected }) => (
                   <li
                     className={clsx(

--- a/src/app/_components/SortListbox.tsx
+++ b/src/app/_components/SortListbox.tsx
@@ -7,24 +7,14 @@ import clsx from 'clsx'
 
 import { Icon } from '@/components/Icon'
 
-export type SortOptionType = 'newest' | 'oldest'
+import { type SortOptionType } from '@/types/sortTypes'
 
-type SortSetting = {
-  id: SortOptionType
-  name: string
-}
+import { sortSettings } from '@/constants/sortConstants'
 
 type SortListboxProps = {
   sortOption: SortOptionType
   onSortOptionChange: (selectedSortOption: SortOptionType) => void
 }
-
-export const DEFAULT_SORT_OPTION = 'newest'
-
-const sortSettings: SortSetting[] = [
-  { id: 'newest', name: 'Newest' },
-  { id: 'oldest', name: 'Oldest' },
-]
 
 export function SortListbox({
   sortOption,

--- a/src/app/_components/SortListbox.tsx
+++ b/src/app/_components/SortListbox.tsx
@@ -1,4 +1,5 @@
 'use client'
+
 import { Fragment } from 'react'
 
 import { Listbox } from '@headlessui/react'
@@ -25,9 +26,14 @@ export function SortListbox({
 
   return (
     <Listbox value={sortOption} onChange={onSortOptionChange}>
-      {() => (
+      {({ open }) => (
         <>
-          <Listbox.Button className="border-1 inline-flex items-center justify-between gap-2 rounded-lg border border-brand-300 p-3 text-brand-300 hover:border-current hover:text-brand-400 focus:outline-2 focus:outline-brand-100 sm:min-w-40">
+          <Listbox.Button
+            aria-haspopup="listbox"
+            aria-expanded={open}
+            aria-label="Sort options"
+            className="border-1 inline-flex items-center justify-between gap-2 rounded-lg border border-brand-300 p-3 text-brand-300 hover:border-current hover:text-brand-400 focus:outline-2 focus:outline-brand-100 sm:min-w-40"
+          >
             <div className="inline-flex items-center gap-2">
               <Icon component={ArrowsDownUp} />
               <span className="hidden sm:block">
@@ -38,7 +44,10 @@ export function SortListbox({
               <Icon component={CaretDown} size={16} weight="bold" />
             </span>
           </Listbox.Button>
-          <Listbox.Options className="absolute z-10 mt-14 min-w-40 overflow-hidden rounded-lg border border-brand-100 bg-brand-800 py-1 text-brand-100 focus-within:outline-2 focus:outline-2 focus:outline-brand-100">
+          <Listbox.Options
+            aria-labelledby="listbox-button"
+            className="absolute z-10 mt-14 min-w-40 overflow-hidden rounded-lg border border-brand-100 bg-brand-800 py-1 text-brand-100 focus-within:outline-2 focus:outline-2 focus:outline-brand-100"
+          >
             {sortSettings.map((option) => (
               <Listbox.Option key={option.id} value={option.id} as={Fragment}>
                 {({ active, selected }) => (

--- a/src/app/_constants/searchParams.ts
+++ b/src/app/_constants/searchParams.ts
@@ -1,2 +1,3 @@
 export const PAGE_KEY = 'page'
 export const SEARCH_KEY = 'search'
+export const SORT_KEY = 'sort'

--- a/src/app/_constants/sortConstants.ts
+++ b/src/app/_constants/sortConstants.ts
@@ -1,0 +1,10 @@
+import { type SortOptionType, type SortSetting } from '@/types/sortTypes'
+
+export const DEFAULT_SORT_OPTION: SortOptionType = 'newest'
+
+export const sortSettings: SortSetting[] = [
+  { id: 'newest', name: 'Newest' },
+  { id: 'oldest', name: 'Oldest' },
+] as const
+
+export const VALID_SORT_OPTIONS = sortSettings.map((setting) => setting.id)

--- a/src/app/_hooks/useSortQuery.ts
+++ b/src/app/_hooks/useSortQuery.ts
@@ -1,0 +1,39 @@
+import { useCallback, useMemo } from 'react'
+
+import {
+  DEFAULT_SORT_OPTION,
+  type SortOptionType,
+} from '@/components/SortListbox'
+
+import { NextServerSearchParams } from '@/types/searchParams'
+
+import { SORT_KEY } from '@/constants/searchParams'
+
+export function useSortQuery(
+  searchParams: NextServerSearchParams,
+  defaultSortOption: SortOptionType = DEFAULT_SORT_OPTION,
+): SortOptionType {
+  const validateSortOptionQuery = useCallback(
+    (sortQuery: string | string[]): SortOptionType => {
+      const validSortOptions: SortOptionType[] = ['newest', 'oldest']
+      const queryValue = Array.isArray(sortQuery) ? sortQuery[0] : sortQuery
+      const normalizedQuery = queryValue.toLowerCase()
+
+      if (validSortOptions.includes(normalizedQuery as SortOptionType)) {
+        return normalizedQuery as SortOptionType
+      }
+
+      return defaultSortOption
+    },
+    [defaultSortOption],
+  )
+
+  const sortQuery = useMemo(() => {
+    const rawSortQuery = searchParams[SORT_KEY]
+    return validateSortOptionQuery(
+      rawSortQuery ? rawSortQuery : defaultSortOption,
+    )
+  }, [searchParams, defaultSortOption, validateSortOptionQuery])
+
+  return sortQuery
+}

--- a/src/app/_hooks/useSortQuery.ts
+++ b/src/app/_hooks/useSortQuery.ts
@@ -46,9 +46,7 @@ export function useSortQuery({
     const rawSortQuery = searchParams[SORT_KEY]
     const validatedSortOption = validateSortOptionQuery(rawSortQuery)
 
-    return validatedSortOption !== null
-      ? validatedSortOption
-      : defaultSortOption
+    return validatedSortOption ? validatedSortOption : defaultSortOption
   }, [searchParams, defaultSortOption])
 
   return { sortQuery }

--- a/src/app/_hooks/useSortQuery.ts
+++ b/src/app/_hooks/useSortQuery.ts
@@ -1,39 +1,55 @@
-import { useCallback, useMemo } from 'react'
+import { useMemo } from 'react'
 
-import {
-  DEFAULT_SORT_OPTION,
-  type SortOptionType,
-} from '@/components/SortListbox'
-
-import { NextServerSearchParams } from '@/types/searchParams'
+import { type NextServerSearchParams } from '@/types/searchParams'
+import { type SortOptionType } from '@/types/sortTypes'
 
 import { SORT_KEY } from '@/constants/searchParams'
+import {
+  DEFAULT_SORT_OPTION,
+  VALID_SORT_OPTIONS,
+} from '@/constants/sortConstants'
 
-export function useSortQuery(
-  searchParams: NextServerSearchParams,
-  defaultSortOption: SortOptionType = DEFAULT_SORT_OPTION,
-): SortOptionType {
-  const validateSortOptionQuery = useCallback(
-    (sortQuery: string | string[]): SortOptionType => {
-      const validSortOptions: SortOptionType[] = ['newest', 'oldest']
-      const queryValue = Array.isArray(sortQuery) ? sortQuery[0] : sortQuery
-      const normalizedQuery = queryValue.toLowerCase()
+type UseSortQueryProps = {
+  searchParams: NextServerSearchParams
+  defaultSortOption?: SortOptionType
+}
 
-      if (validSortOptions.includes(normalizedQuery as SortOptionType)) {
-        return normalizedQuery as SortOptionType
-      }
+type UseSortQueryResult = { sortQuery: SortOptionType }
 
-      return defaultSortOption
-    },
-    [defaultSortOption],
-  )
+function validateSortOptionQuery(
+  sortQuery: NextServerSearchParams['sort'],
+): SortOptionType | null {
+  if (!sortQuery) {
+    return null
+  }
 
+  const queryValue = Array.isArray(sortQuery) ? sortQuery[0] : sortQuery
+
+  if (!queryValue) {
+    return null
+  }
+
+  const normalizedQuery = queryValue.toLowerCase()
+
+  if (VALID_SORT_OPTIONS.includes(normalizedQuery as SortOptionType)) {
+    return normalizedQuery as SortOptionType
+  }
+
+  return null
+}
+
+export function useSortQuery({
+  searchParams,
+  defaultSortOption = DEFAULT_SORT_OPTION,
+}: UseSortQueryProps): UseSortQueryResult {
   const sortQuery = useMemo(() => {
     const rawSortQuery = searchParams[SORT_KEY]
-    return validateSortOptionQuery(
-      rawSortQuery ? rawSortQuery : defaultSortOption,
-    )
-  }, [searchParams, defaultSortOption, validateSortOptionQuery])
+    const validatedSortOption = validateSortOptionQuery(rawSortQuery)
 
-  return sortQuery
+    return validatedSortOption !== null
+      ? validatedSortOption
+      : defaultSortOption
+  }, [searchParams, defaultSortOption])
+
+  return { sortQuery }
 }

--- a/src/app/_types/sortTypes.ts
+++ b/src/app/_types/sortTypes.ts
@@ -12,6 +12,6 @@ export type SortableByDate = {
 
 export type SortEntriesParams<T> = {
   entries: T[]
-  dateField: 'startDate' | 'publishedOn'
+  dateField: keyof SortableByDate
   sortOption?: SortOptionType
 }

--- a/src/app/_types/sortTypes.ts
+++ b/src/app/_types/sortTypes.ts
@@ -1,0 +1,17 @@
+export type SortOptionType = 'newest' | 'oldest'
+
+export type SortSetting = {
+  id: SortOptionType
+  name: string
+}
+
+export type SortableByDate = {
+  publishedOn?: string
+  startDate?: string
+}
+
+export type SortEntriesParams<T> = {
+  entries: T[]
+  dateField: 'startDate' | 'publishedOn'
+  sortOption?: SortOptionType
+}

--- a/src/app/_utils/sortEntriesByDate.ts
+++ b/src/app/_utils/sortEntriesByDate.ts
@@ -1,21 +1,32 @@
-import { SortType } from '@/components/SortListbox'
+import {
+  DEFAULT_SORT_OPTION,
+  type SortOptionType,
+} from '@/components/SortListbox'
 
-interface SortableByDate {
-  startDate: string
+type SortableByDate = {
+  publishedOn?: string
+  startDate?: string
 }
 
-export function sortEntriesByDate<T extends SortableByDate>(
-  entries: T[],
-  sortType: SortType,
-): T[] {
-  return [...entries].sort((a, b) => {
-    const dateA = new Date(a.startDate)
-    const dateB = new Date(b.startDate)
+type SortEntriesParams<T> = {
+  entries: T[]
+  sortOption: SortOptionType
+  dateField: 'startDate' | 'publishedOn'
+}
 
-    switch (sortType) {
-      case SortType.Newest:
+export function sortEntriesByDate<T extends SortableByDate>({
+  entries,
+  sortOption = DEFAULT_SORT_OPTION,
+  dateField = 'publishedOn',
+}: SortEntriesParams<T>): T[] {
+  return [...entries].sort((a, b) => {
+    const dateA = new Date(a[dateField] || 0)
+    const dateB = new Date(b[dateField] || 0)
+
+    switch (sortOption) {
+      case 'newest':
         return dateB.valueOf() - dateA.valueOf()
-      case SortType.Oldest:
+      case 'oldest':
         return dateA.valueOf() - dateB.valueOf()
       default:
         return 0

--- a/src/app/_utils/sortEntriesByDate.ts
+++ b/src/app/_utils/sortEntriesByDate.ts
@@ -1,24 +1,19 @@
+import { type SortableByDate, type SortEntriesParams } from '@/types/sortTypes'
+
 import {
   DEFAULT_SORT_OPTION,
-  type SortOptionType,
-} from '@/components/SortListbox'
-
-type SortableByDate = {
-  publishedOn?: string
-  startDate?: string
-}
-
-type SortEntriesParams<T> = {
-  entries: T[]
-  sortOption: SortOptionType
-  dateField: 'startDate' | 'publishedOn'
-}
+  VALID_SORT_OPTIONS,
+} from '@/constants/sortConstants'
 
 export function sortEntriesByDate<T extends SortableByDate>({
   entries,
-  sortOption = DEFAULT_SORT_OPTION,
   dateField = 'publishedOn',
+  sortOption = DEFAULT_SORT_OPTION,
 }: SortEntriesParams<T>): T[] {
+  if (!VALID_SORT_OPTIONS.includes(sortOption)) {
+    sortOption = DEFAULT_SORT_OPTION
+  }
+
   return [...entries].sort((a, b) => {
     const dateA = new Date(a[dateField] || 0)
     const dateB = new Date(b[dateField] || 0)

--- a/src/app/blog/page.tsx
+++ b/src/app/blog/page.tsx
@@ -8,7 +8,7 @@ import { usePagination } from '@/hooks/usePagination'
 import { useSortQuery } from '@/hooks/useSortQuery'
 
 import { BlogSearchInput } from '@/components/BlogSearchInput'
-import { BlogSortController } from '@/components/BlogSortController'
+import { BlogSort } from '@/components/BlogSort'
 import { Card } from '@/components/Card'
 import { CardLayout } from '@/components/CardLayout'
 import { NoResultsMessage } from '@/components/NoResultsMessage'
@@ -157,7 +157,7 @@ export default function Blog({ searchParams }: Props) {
       >
         <div className="flex w-full justify-end gap-3">
           <BlogSearchInput searchQuery={cleanSearchQuery} />
-          <BlogSortController />
+          <BlogSort />
         </div>
 
         {sortedAndFilteredPosts.length === 0 ? (

--- a/src/app/blog/page.tsx
+++ b/src/app/blog/page.tsx
@@ -23,7 +23,7 @@ const NoSSRPagination = dynamic(
 )
 
 import { type BlogPostData } from '@/types/blogPostTypes'
-import { NextServerSearchParams } from '@/types/searchParams'
+import { type NextServerSearchParams } from '@/types/searchParams'
 
 import { getCollectionConfig, getCMSFieldOptions } from '@/utils/cmsConfigUtils'
 import { createMetadata } from '@/utils/createMetadata'
@@ -104,11 +104,11 @@ export default function Blog({ searchParams }: Props) {
     throw new Error('Featured post not found')
   }
 
-  const sortQuery = useSortQuery(searchParams)
-
   const cleanSearchQuery = searchParams[SEARCH_KEY]
     ? searchParams[SEARCH_KEY].toString().toLowerCase()
     : ''
+
+  const { sortQuery } = useSortQuery({ searchParams })
 
   const sortedAndFilteredPosts = useMemo(() => {
     const filteredPosts = posts.filter((post) =>

--- a/src/app/events/EventsClient.tsx
+++ b/src/app/events/EventsClient.tsx
@@ -4,15 +4,14 @@ import { useEffect, useState } from 'react'
 
 import { Card } from '@/components/Card'
 import { CardLayout } from '@/components/CardLayout'
-import {
-  DEFAULT_SORT_OPTION,
-  type SortOptionType,
-  SortListbox,
-} from '@/components/SortListbox'
+import { SortListbox } from '@/components/SortListbox'
 
-import { EventData } from '@/types/eventTypes'
+import { type EventData } from '@/types/eventTypes'
+import { type SortOptionType } from '@/types/sortTypes'
 
 import { sortEntriesByDate } from '@/utils/sortEntriesByDate'
+
+import { DEFAULT_SORT_OPTION } from '@/constants/sortConstants'
 
 type EventsClientProps = {
   events: EventData[]

--- a/src/app/events/EventsClient.tsx
+++ b/src/app/events/EventsClient.tsx
@@ -4,7 +4,11 @@ import { useEffect, useState } from 'react'
 
 import { Card } from '@/components/Card'
 import { CardLayout } from '@/components/CardLayout'
-import { SortType, SortListbox } from '@/components/SortListbox'
+import {
+  DEFAULT_SORT_OPTION,
+  type SortOptionType,
+  SortListbox,
+} from '@/components/SortListbox'
 
 import { EventData } from '@/types/eventTypes'
 
@@ -15,19 +19,20 @@ type EventsClientProps = {
 }
 
 export function EventsClient({ events }: EventsClientProps) {
-  const [sortType, setSortType] = useState<SortType>(SortType.Newest)
+  const [sortOption, setSortOption] =
+    useState<SortOptionType>(DEFAULT_SORT_OPTION)
   const [sortedEvents, setSortedEvents] = useState<EventData[]>([])
 
   useEffect(() => {
     if (events.length > 0) {
-      const sorted = sortEntriesByDate(events, sortType)
+      const sorted = sortEntriesByDate({
+        entries: events,
+        sortOption,
+        dateField: 'startDate',
+      })
       setSortedEvents(sorted)
     }
-  }, [sortType, events])
-
-  function handleSortTypeChange(selectedOption: SortType) {
-    setSortType(selectedOption)
-  }
+  }, [sortOption, events])
 
   if (events.length === 0) {
     return <p>No events found.</p>
@@ -35,7 +40,7 @@ export function EventsClient({ events }: EventsClientProps) {
 
   return (
     <div className="flex flex-col items-end gap-6">
-      <SortListbox onSortTypeChange={handleSortTypeChange} />
+      <SortListbox sortOption={sortOption} onSortOptionChange={setSortOption} />
       <CardLayout>
         {sortedEvents.map((event) => (
           <Card key={event.slug} title={event.title} />


### PR DESCRIPTION
- Included `SORT_KEY`
- Validated and normalized the `sortQuery` parameter
- Refactored `sortEntriesByDate` function to support dynamic date fields
- Implemented dynamic sorting control for blog posts

## Notes:

- I'm aware that we'll have to split and extend the `SortSettings` when we include options like sorting by name, etc.
- I did not refactor `Events` page to use the `searchParams` - We can pick it up in a different PR


<img width="1039" alt="Screenshot 2024-05-08 at 15 43 41" src="https://github.com/FilecoinFoundationWeb/filecoin-foundation/assets/26620750/1b62b0c4-ebaa-4432-bcdc-625e2891a51c">
