### PR TITLE
Desktop Navigation

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
         "@babel/core": "^7.23.5",
         "@babel/preset-react": "^7.23.3",
         "@headlessui/react": "^1.7.19",
+        "@headlessui/tailwindcss": "^0.2.0",
         "@phosphor-icons/react": "^2.1.4",
         "@tailwindcss/typography": "^0.5.10",
         "autoprefixer": "^10.4.16",
@@ -2048,6 +2049,17 @@
       "peerDependencies": {
         "react": "^16 || ^17 || ^18",
         "react-dom": "^16 || ^17 || ^18"
+      }
+    },
+    "node_modules/@headlessui/tailwindcss": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/@headlessui/tailwindcss/-/tailwindcss-0.2.0.tgz",
+      "integrity": "sha512-fpL830Fln1SykOCboExsWr3JIVeQKieLJ3XytLe/tt1A0XzqUthOftDmjcCYLW62w7mQI7wXcoPXr3tZ9QfGxw==",
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "tailwindcss": "^3.0"
       }
     },
     "node_modules/@humanwhocodes/config-array": {

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "@babel/core": "^7.23.5",
     "@babel/preset-react": "^7.23.3",
     "@headlessui/react": "^1.7.19",
+    "@headlessui/tailwindcss": "^0.2.0",
     "@phosphor-icons/react": "^2.1.4",
     "@tailwindcss/typography": "^0.5.10",
     "autoprefixer": "^10.4.16",

--- a/src/app/_components/CustomLink.tsx
+++ b/src/app/_components/CustomLink.tsx
@@ -2,6 +2,8 @@ import Link from 'next/link'
 
 import type { Route } from 'next'
 
+import { isInternalLink } from '@/utils/linkUtils'
+
 type CustomLinkProps = {
   href: string
   className?: string
@@ -14,9 +16,9 @@ export function CustomLink({
   children,
   ...rest
 }: CustomLinkProps) {
-  const isInternalLink = href.startsWith('/') || href.startsWith('#')
+  const isInternal = isInternalLink(href)
 
-  if (isInternalLink) {
+  if (isInternal) {
     return (
       <Link href={href as Route} className={className} {...rest}>
         {children}

--- a/src/app/_components/DesktopNavigation.tsx
+++ b/src/app/_components/DesktopNavigation.tsx
@@ -15,7 +15,7 @@ import { NavigationPopover } from '@/components/NavigationPopover'
 import { PATHS } from '@/constants/paths'
 import { desktopNavigationItems } from '@/data/components/navigationData'
 
-export type SubNavItemProps = {
+export type SubMainNavItemProps = {
   href: string | Route
   label: string
   description?: string
@@ -28,17 +28,17 @@ type InternalLinkProps = {
   isActive?: boolean
 }
 
-function SubNavItem({
+function SubMainNavItem({
   href,
   label,
   description,
   linkType = 'internal',
-}: SubNavItemProps) {
+}: SubMainNavItemProps) {
   const external = linkType !== 'internal'
 
-  const baseClasses =
+  const baseStyles =
     'group w-full rounded-lg focus:outline focus:outline-2 focus:outline-brand-100'
-  const styleClasses = {
+  const extendedStyles = {
     internal: 'inline-block bg-brand-800 p-4 hover:bg-brand-700',
     externalPrimary:
       'inline-block border border-brand-500 bg-brand-700 p-4 hover:border-brand-400 focus:border-transparent',
@@ -46,7 +46,7 @@ function SubNavItem({
       'inline-flex items-center justify-center gap-1 bg-brand-800 px-3 py-5 text-brand-300 hover:bg-brand-700',
   }
 
-  const linkClasses = clsx(baseClasses, styleClasses[linkType])
+  const linkClasses = clsx(baseStyles, extendedStyles[linkType])
   const commonProps = {
     className: linkClasses,
     'aria-label': `${label} page (${external ? 'external link' : 'internal link'})`,
@@ -70,19 +70,22 @@ function SubNavItem({
   )
 }
 
-function getNavItemBaseStyles(isActive: boolean) {
+function getMainNavItemBaseStyles(isActive: boolean) {
   return clsx(
     'rounded-xl py-1.5 text-base hover:bg-brand-700 focus:outline focus:outline-2 focus:outline-brand-100',
     isActive ? 'text-brand-400' : 'text-brand-300',
   )
 }
 
-function NavItem({ label, href, isActive = false }: InternalLinkProps) {
+function MainNavItem({ label, href, isActive = false }: InternalLinkProps) {
   return (
     <li>
       <Link
         href={href}
-        className={clsx(getNavItemBaseStyles(isActive), 'inline-block px-4')}
+        className={clsx(
+          getMainNavItemBaseStyles(isActive),
+          'inline-block px-4',
+        )}
       >
         {label}
       </Link>
@@ -109,7 +112,7 @@ export function DesktopNavigation() {
       className="relative z-10 hidden lg:flex lg:items-center lg:gap-0.5"
       aria-label="Navigation items"
     >
-      <NavItem
+      <MainNavItem
         label={PATHS.ABOUT.label}
         href={PATHS.ABOUT.path}
         isActive={pathname === PATHS.ABOUT.path}
@@ -118,23 +121,23 @@ export function DesktopNavigation() {
       <NavigationPopover
         as="li"
         label="Get Involved"
-        navItemBaseStyles={getNavItemBaseStyles(isGetInvolvedActive)}
+        mainNavItemBaseStyles={getMainNavItemBaseStyles(isGetInvolvedActive)}
       >
         <div className="grid w-screen max-w-2xl grid-cols-2 gap-4">
           <div className="space-y-4">
             {getInvolvedInternalItems.map((item) => (
-              <SubNavItem key={item.href} {...item} linkType="internal" />
+              <SubMainNavItem key={item.href} {...item} linkType="internal" />
             ))}
           </div>
           <div className="space-y-4">
             {getInvolvedExternalItems.map((item) => (
-              <SubNavItem
+              <SubMainNavItem
                 key={item.href}
                 {...item}
                 linkType="externalPrimary"
               />
             ))}
-            <SubNavItem {...learnMoreItem} linkType="externalSecondary" />
+            <SubMainNavItem {...learnMoreItem} linkType="externalSecondary" />
           </div>
         </div>
       </NavigationPopover>
@@ -142,16 +145,16 @@ export function DesktopNavigation() {
       <NavigationPopover
         as="li"
         label="Community"
-        navItemBaseStyles={getNavItemBaseStyles(isCommunityActive)}
+        mainNavItemBaseStyles={getMainNavItemBaseStyles(isCommunityActive)}
       >
         <div className="w-80 space-y-4">
           {communityItems.map((item) => (
-            <SubNavItem key={item.label} {...item} linkType="internal" />
+            <SubMainNavItem key={item.label} {...item} linkType="internal" />
           ))}
         </div>
       </NavigationPopover>
 
-      <NavItem
+      <MainNavItem
         label={PATHS.BLOG.label}
         href={PATHS.BLOG.path}
         isActive={pathname === PATHS.BLOG.path}

--- a/src/app/_components/DesktopNavigation.tsx
+++ b/src/app/_components/DesktopNavigation.tsx
@@ -1,0 +1,181 @@
+'use client'
+
+import Link from 'next/link'
+import { usePathname } from 'next/navigation'
+
+import { ArrowUpRight } from '@phosphor-icons/react'
+import clsx from 'clsx'
+import { Route } from 'next'
+
+import { Icon } from '@/components/Icon'
+import { NavigationPopover } from '@/components/NavigationPopover'
+
+import { PATHS } from '@/constants/paths'
+
+const getInvolvedItems = [
+  {
+    label: PATHS.EVENTS.label,
+    href: PATHS.EVENTS.path,
+    description: 'Overview of upcoming and past events',
+  },
+  {
+    label: PATHS.GRANTS.label,
+    href: PATHS.GRANTS.path,
+    description:
+      'Information on funding opportunities supporting projects that contribute to the growth of the Filecoin Network',
+  },
+  {
+    label: 'Become a Storage Provider',
+    href: 'https://destor.com/destor-network/overview',
+    description: 'Dive right in and become an essential part of the ecosystem',
+  },
+  {
+    label: 'Contribute to the Filecoin Project',
+    href: 'https://docs.filecoin.io/basics/project-and-community/ways-to-contribute',
+    description:
+      'Shape the future of Filecoin by contributing to its code, research, or docs.',
+  },
+]
+
+const communityItems = [
+  {
+    label: PATHS.ECOSYSTEM.label,
+    href: PATHS.ECOSYSTEM.path,
+    description: 'Learn about various ecosystem projects or submit your own',
+  },
+  {
+    label: PATHS.GOVERNANCE.label,
+    href: PATHS.GOVERNANCE.path,
+    description:
+      'Learn about Filecoin Improvement Proposals and other governance mechanisms',
+  },
+]
+
+const learnMoreItem = {
+  label: 'Learn more about Filecoin',
+  href: 'https://docs.filecoin.io/',
+}
+
+type LinkProps = {
+  label: string
+  description: string
+  href: string
+}
+
+function InternalLink({ label, description, href }: LinkProps) {
+  return (
+    <Link
+      href={href as Route}
+      className="inline-block w-full rounded-lg bg-brand-800 p-4 hover:bg-brand-700 focus:outline focus:outline-2 focus:outline-brand-100"
+      aria-label={`${label} page (internal link)`}
+    >
+      <p className="pb-1 font-bold">{label}</p>
+      <p className="text-brand-300">{description}</p>
+    </Link>
+  )
+}
+
+function ExternalLink({ label, description, href }: LinkProps) {
+  return (
+    <a
+      href={href}
+      target="_blank"
+      rel="noopener noreferrer"
+      className="group inline-block w-full rounded-lg border border-brand-500 bg-brand-700 p-4 hover:border-brand-400 focus:border-transparent focus:outline focus:outline-2 focus:outline-brand-100"
+      aria-label={`${label} (opens a new window)`}
+    >
+      <div className="flex gap-1">
+        <p className="pb-2 font-bold">{label}</p>
+        <span className="text-brand-400 group-hover:text-brand-100">
+          <Icon component={ArrowUpRight} size={20} />
+        </span>
+      </div>
+
+      <p className="text-brand-300">{description}</p>
+    </a>
+  )
+}
+
+const getInvolvedInternalItems = getInvolvedItems.filter((item) =>
+  item.href.startsWith('/'),
+)
+
+const getInvolvedExternalItems = getInvolvedItems.filter(
+  (item) => item.href.startsWith('https://') || item.href.startsWith('http://'),
+)
+
+export function DesktopNavigation() {
+  const pathname = usePathname()
+
+  return (
+    <ul
+      className="relative z-10 hidden items-center gap-0.5 lg:flex"
+      aria-label="Navigation items"
+    >
+      <li>
+        <Link
+          href={PATHS.ABOUT.path}
+          className={clsx(
+            'text-hover:bg-brand-700 inline-block rounded-xl px-4 py-1.5 focus:outline focus:outline-2 focus:outline-brand-100',
+            pathname.startsWith(PATHS.ABOUT.path)
+              ? 'text-brand-400'
+              : 'text-brand-300',
+          )}
+        >
+          {PATHS.ABOUT.label}
+        </Link>
+      </li>
+
+      <NavigationPopover as="li" label="Get Involved">
+        <div className="grid w-screen max-w-2xl grid-cols-2 gap-4">
+          <div className="space-y-4">
+            {getInvolvedInternalItems.map((item) => (
+              <InternalLink key={item.href} {...item} />
+            ))}
+          </div>
+          <div className="space-y-4">
+            {getInvolvedExternalItems.map((item) => (
+              <ExternalLink key={item.href} {...item} />
+            ))}
+            <a
+              href={learnMoreItem.href}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="group inline-flex w-full justify-center gap-1 rounded-lg bg-brand-800 px-3 py-5 hover:bg-brand-700 focus:outline focus:outline-2 focus:outline-brand-100"
+              aria-label={`${learnMoreItem.label} (opens a new window)`}
+            >
+              <span className="font-bold text-brand-300">
+                {learnMoreItem.label}
+              </span>
+              <span className="text-brand-400 group-hover:text-brand-100">
+                <Icon component={ArrowUpRight} size={20} />
+              </span>
+            </a>
+          </div>
+        </div>
+      </NavigationPopover>
+
+      <NavigationPopover as="li" label="Community">
+        <div className="w-80 space-y-4">
+          {communityItems.map((item) => (
+            <InternalLink key={item.label} {...item} />
+          ))}
+        </div>
+      </NavigationPopover>
+
+      <li>
+        <Link
+          href={PATHS.BLOG.path}
+          className={clsx(
+            'inline-block rounded-xl px-4 py-1.5 text-brand-300 hover:bg-brand-700 focus:outline focus:outline-2 focus:outline-brand-100',
+            pathname.startsWith(PATHS.BLOG.path)
+              ? 'text-brand-400'
+              : 'text-brand-300',
+          )}
+        >
+          {PATHS.BLOG.label}
+        </Link>
+      </li>
+    </ul>
+  )
+}

--- a/src/app/_components/DesktopNavigation.tsx
+++ b/src/app/_components/DesktopNavigation.tsx
@@ -18,7 +18,8 @@ import { desktopNavigationItems } from '@/data/components/navigationData'
 export type SubLinkProps = {
   href: string | Route
   label: string
-  description: string
+  description?: string
+  linkType?: 'internal' | 'externalPrimary' | 'externalSecondary'
 }
 
 type InternalLinkProps = {
@@ -27,38 +28,49 @@ type InternalLinkProps = {
   isActive?: boolean
 }
 
-function InternalSubLink({ label, description, href }: SubLinkProps) {
-  return (
-    <Link
-      href={href as Route}
-      className="inline-block w-full rounded-lg bg-brand-800 p-4 hover:bg-brand-700 focus:outline focus:outline-2 focus:outline-brand-100"
-      aria-label={`${label} page (internal link)`}
-    >
+function SubLink({
+  href,
+  label,
+  description,
+  linkType = 'internal',
+}: SubLinkProps) {
+  const external = linkType !== 'internal'
+
+  const baseClasses =
+    'group w-full rounded-lg focus:outline focus:outline-2 focus:outline-brand-100'
+  const styleClasses = {
+    internal: 'inline-block bg-brand-800 p-4 hover:bg-brand-700',
+    externalPrimary:
+      'inline-block border border-brand-500 bg-brand-700 p-4 hover:border-brand-400 focus:border-transparent',
+    externalSecondary:
+      'inline-flex items-center justify-center gap-1 bg-brand-800 px-3 py-5 text-brand-300 hover:bg-brand-700',
+  }
+
+  const linkClasses = clsx(baseClasses, styleClasses[linkType])
+  const commonProps = {
+    className: linkClasses,
+    'aria-label': `${label} page (${external ? 'external link' : 'internal link'})`,
+  }
+
+  return external ? (
+    <a href={href} {...commonProps} rel="noopener noreferrer">
+      <div className="inline-flex items-center gap-1">
+        <p className="font-bold">{label}</p>
+        <span className="text-brand-400 group-hover:text-brand-100">
+          <Icon component={ArrowUpRight} size={20} />
+        </span>
+      </div>
+      {description && <p className="mt-4 text-brand-300">{description}</p>}
+    </a>
+  ) : (
+    <Link href={href as Route} {...commonProps}>
       <p className="mb-1 font-bold">{label}</p>
       <p className="text-brand-300">{description}</p>
     </Link>
   )
 }
 
-function ExternalSubLink({ label, description, href }: SubLinkProps) {
-  return (
-    <a
-      href={href}
-      rel="noopener noreferrer"
-      className="group inline-block w-full rounded-lg border border-brand-500 bg-brand-700 p-4 hover:border-brand-400 focus:border-transparent focus:outline focus:outline-2 focus:outline-brand-100"
-    >
-      <div className="mb-4 inline-flex items-center gap-1">
-        <p className="font-bold">{label}</p>
-        <span className="text-brand-400 group-hover:text-brand-100">
-          <Icon component={ArrowUpRight} size={20} />
-        </span>
-      </div>
-      <p className="text-brand-300">{description}</p>
-    </a>
-  )
-}
-
-function InternalLink({ label, href, isActive }: InternalLinkProps) {
+function NavItem({ label, href, isActive }: InternalLinkProps) {
   return (
     <li>
       <Link
@@ -85,6 +97,7 @@ export function DesktopNavigation() {
     externalItems: getInvolvedExternalItems,
     isActive: isGetInvolvedActive,
   } = useActiveItems(getInvolvedItems)
+
   const { isActive: isCommunityActive } = useActiveItems(communityItems)
 
   return (
@@ -92,7 +105,7 @@ export function DesktopNavigation() {
       className="relative z-10 hidden lg:flex lg:items-center lg:gap-0.5"
       aria-label="Navigation items"
     >
-      <InternalLink
+      <NavItem
         label={PATHS.ABOUT.label}
         href={PATHS.ABOUT.path}
         isActive={pathname === PATHS.ABOUT.path}
@@ -106,24 +119,14 @@ export function DesktopNavigation() {
         <div className="grid w-screen max-w-2xl grid-cols-2 gap-4">
           <div className="space-y-4">
             {getInvolvedInternalItems.map((item) => (
-              <InternalSubLink key={item.href} {...item} />
+              <SubLink key={item.href} {...item} linkType="internal" />
             ))}
           </div>
           <div className="space-y-4">
             {getInvolvedExternalItems.map((item) => (
-              <ExternalSubLink key={item.href} {...item} />
+              <SubLink key={item.href} {...item} linkType="externalPrimary" />
             ))}
-            <a
-              href={learnMoreItem.href}
-              rel="noopener noreferrer"
-              className="group inline-flex w-full items-center justify-center gap-1 rounded-lg bg-brand-800 px-3 py-5 text-brand-300 hover:bg-brand-700 focus:outline focus:outline-2 focus:outline-brand-100"
-              aria-label={`${learnMoreItem.label} (opens a new window)`}
-            >
-              <p className="font-bold">{learnMoreItem.label}</p>
-              <span className="text-brand-400 group-hover:text-brand-100">
-                <Icon component={ArrowUpRight} size={20} />
-              </span>
-            </a>
+            <SubLink {...learnMoreItem} linkType="externalSecondary" />
           </div>
         </div>
       </NavigationPopover>
@@ -131,12 +134,12 @@ export function DesktopNavigation() {
       <NavigationPopover as="li" label="Community" isActive={isCommunityActive}>
         <div className="w-80 space-y-4">
           {communityItems.map((item) => (
-            <InternalSubLink key={item.label} {...item} />
+            <SubLink key={item.label} {...item} linkType="internal" />
           ))}
         </div>
       </NavigationPopover>
 
-      <InternalLink
+      <NavItem
         label={PATHS.BLOG.label}
         href={PATHS.BLOG.path}
         isActive={pathname === PATHS.BLOG.path}

--- a/src/app/_components/DesktopNavigation.tsx
+++ b/src/app/_components/DesktopNavigation.tsx
@@ -58,13 +58,13 @@ const learnMoreItem = {
   href: 'https://docs.filecoin.io/',
 }
 
-type LinkProps = {
-  label: string
+type SubLinkProps = {
+  label: string | Route
   description: string
   href: string
 }
 
-function InternalLink({ label, description, href }: LinkProps) {
+function InternalSubLink({ label, description, href }: SubLinkProps) {
   return (
     <Link
       href={href as Route}
@@ -77,7 +77,7 @@ function InternalLink({ label, description, href }: LinkProps) {
   )
 }
 
-function ExternalLink({ label, description, href }: LinkProps) {
+function ExternalSubLink({ label, description, href }: SubLinkProps) {
   return (
     <a
       href={href}
@@ -96,6 +96,28 @@ function ExternalLink({ label, description, href }: LinkProps) {
   )
 }
 
+type LinkProps = {
+  label: string
+  href: Route
+  isActive?: boolean
+}
+
+function InternalLink({ label, href, isActive }: LinkProps) {
+  return (
+    <li>
+      <Link
+        href={href}
+        className={clsx(
+          'inline-block rounded-xl px-4 py-1.5 hover:bg-brand-700 focus:outline focus:outline-2 focus:outline-brand-100',
+          isActive ? 'text-brand-400' : 'text-brand-300',
+        )}
+      >
+        {label}
+      </Link>
+    </li>
+  )
+}
+
 const getInvolvedInternalItems = getInvolvedItems.filter((item) =>
   isInternalLink(item.href),
 )
@@ -107,35 +129,39 @@ const getInvolvedExternalItems = getInvolvedItems.filter((item) =>
 export function DesktopNavigation() {
   const pathname = usePathname()
 
+  const isGetInvolvedActive = getInvolvedInternalItems
+    .map((item) => item.href)
+    .includes(pathname)
+
+  const isCommunityActive = communityItems
+    .map((item) => item.href as string)
+    .includes(pathname)
+
   return (
     <ul
       className="relative z-10 hidden items-center gap-0.5 lg:flex"
       aria-label="Navigation items"
     >
-      <li>
-        <Link
-          href={PATHS.ABOUT.path}
-          className={clsx(
-            'inline-block rounded-xl px-4 py-1.5 hover:bg-brand-700 focus:outline focus:outline-2 focus:outline-brand-100',
-            pathname.startsWith(PATHS.ABOUT.path)
-              ? 'text-brand-400'
-              : 'text-brand-300',
-          )}
-        >
-          {PATHS.ABOUT.label}
-        </Link>
-      </li>
+      <InternalLink
+        label={PATHS.ABOUT.label}
+        href={PATHS.ABOUT.path}
+        isActive={pathname.startsWith(PATHS.ABOUT.path)}
+      />
 
-      <NavigationPopover as="li" label="Get Involved">
+      <NavigationPopover
+        as="li"
+        label="Get Involved"
+        isActive={isGetInvolvedActive}
+      >
         <div className="grid w-screen max-w-2xl grid-cols-2 gap-4">
           <div className="space-y-4">
             {getInvolvedInternalItems.map((item) => (
-              <InternalLink key={item.href} {...item} />
+              <InternalSubLink key={item.href} {...item} />
             ))}
           </div>
           <div className="space-y-4">
             {getInvolvedExternalItems.map((item) => (
-              <ExternalLink key={item.href} {...item} />
+              <ExternalSubLink key={item.href} {...item} />
             ))}
             <a
               href={learnMoreItem.href}
@@ -155,27 +181,19 @@ export function DesktopNavigation() {
         </div>
       </NavigationPopover>
 
-      <NavigationPopover as="li" label="Community">
+      <NavigationPopover as="li" label="Community" isActive={isCommunityActive}>
         <div className="w-80 space-y-4">
           {communityItems.map((item) => (
-            <InternalLink key={item.label} {...item} />
+            <InternalSubLink key={item.label} {...item} />
           ))}
         </div>
       </NavigationPopover>
 
-      <li>
-        <Link
-          href={PATHS.BLOG.path}
-          className={clsx(
-            'inline-block rounded-xl px-4 py-1.5 text-brand-300 hover:bg-brand-700 focus:outline focus:outline-2 focus:outline-brand-100',
-            pathname.startsWith(PATHS.BLOG.path)
-              ? 'text-brand-400'
-              : 'text-brand-300',
-          )}
-        >
-          {PATHS.BLOG.label}
-        </Link>
-      </li>
+      <InternalLink
+        label={PATHS.BLOG.label}
+        href={PATHS.BLOG.path}
+        isActive={pathname.startsWith(PATHS.BLOG.path)}
+      />
     </ul>
   )
 }

--- a/src/app/_components/DesktopNavigation.tsx
+++ b/src/app/_components/DesktopNavigation.tsx
@@ -139,7 +139,7 @@ export function DesktopNavigation() {
 
   return (
     <ul
-      className="relative z-10 hidden items-center gap-0.5 lg:flex"
+      className="relative z-10 hidden lg:flex lg:items-center lg:gap-0.5"
       aria-label="Navigation items"
     >
       <InternalLink

--- a/src/app/_components/DesktopNavigation.tsx
+++ b/src/app/_components/DesktopNavigation.tsx
@@ -15,25 +15,25 @@ import { NavigationPopover } from '@/components/NavigationPopover'
 import { PATHS } from '@/constants/paths'
 import { desktopNavigationItems } from '@/data/components/navigationData'
 
-export type SubMainNavItemProps = {
+export type SubNavItemProps = {
   href: string | Route
   label: string
   description?: string
   linkType?: 'internal' | 'externalPrimary' | 'externalSecondary'
 }
 
-type InternalLinkProps = {
+type MainNavItemProps = {
   href: Route
   label: string
   isActive?: boolean
 }
 
-function SubMainNavItem({
+function SubNavItem({
   href,
   label,
   description,
   linkType = 'internal',
-}: SubMainNavItemProps) {
+}: SubNavItemProps) {
   const external = linkType !== 'internal'
 
   const baseStyles =
@@ -85,7 +85,7 @@ function getMainNavItemStyles(isActive: boolean, isPopover = false) {
   )
 }
 
-function MainNavItem({ label, href, isActive = false }: InternalLinkProps) {
+function MainNavItem({ label, href, isActive = false }: MainNavItemProps) {
   return (
     <li>
       <Link href={href} className={getMainNavItemStyles(isActive)}>
@@ -128,18 +128,18 @@ export function DesktopNavigation() {
         <div className="grid w-screen max-w-2xl grid-cols-2 gap-4">
           <div className="space-y-4">
             {getInvolvedInternalItems.map((item) => (
-              <SubMainNavItem key={item.href} {...item} linkType="internal" />
+              <SubNavItem key={item.href} {...item} linkType="internal" />
             ))}
           </div>
           <div className="space-y-4">
             {getInvolvedExternalItems.map((item) => (
-              <SubMainNavItem
+              <SubNavItem
                 key={item.href}
                 {...item}
                 linkType="externalPrimary"
               />
             ))}
-            <SubMainNavItem {...learnMoreItem} linkType="externalSecondary" />
+            <SubNavItem {...learnMoreItem} linkType="externalSecondary" />
           </div>
         </div>
       </NavigationPopover>
@@ -151,7 +151,7 @@ export function DesktopNavigation() {
       >
         <div className="w-80 space-y-4">
           {communityItems.map((item) => (
-            <SubMainNavItem key={item.label} {...item} linkType="internal" />
+            <SubNavItem key={item.label} {...item} linkType="internal" />
           ))}
         </div>
       </NavigationPopover>

--- a/src/app/_components/DesktopNavigation.tsx
+++ b/src/app/_components/DesktopNavigation.tsx
@@ -84,9 +84,9 @@ function ExternalLink({ label, description, href }: LinkProps) {
       rel="noopener noreferrer"
       className="group inline-block w-full rounded-lg border border-brand-500 bg-brand-700 p-4 hover:border-brand-400 focus:border-transparent focus:outline focus:outline-2 focus:outline-brand-100"
     >
-      <div className="flex gap-1">
-        <p className="pb-2 font-bold">{label}</p>
-        <span className="text-brand-400 group-hover:text-brand-100">
+      <div className="mb-4 flex gap-1">
+        <p className="font-bold">{label}</p>
+        <span className="mt-0.5 text-brand-400 group-hover:text-brand-100">
           <Icon component={ArrowUpRight} size={20} />
         </span>
       </div>
@@ -147,7 +147,7 @@ export function DesktopNavigation() {
               <span className="font-bold text-brand-300">
                 {learnMoreItem.label}
               </span>
-              <span className="text-brand-400 group-hover:text-brand-100">
+              <span className="mt-0.5 text-brand-400 group-hover:text-brand-100">
                 <Icon component={ArrowUpRight} size={20} />
               </span>
             </a>

--- a/src/app/_components/DesktopNavigation.tsx
+++ b/src/app/_components/DesktopNavigation.tsx
@@ -10,6 +10,8 @@ import { Route } from 'next'
 import { Icon } from '@/components/Icon'
 import { NavigationPopover } from '@/components/NavigationPopover'
 
+import { isInternalLink, isExternalLink } from '@/utils/linkUtils'
+
 import { PATHS } from '@/constants/paths'
 
 const getInvolvedItems = [
@@ -95,11 +97,11 @@ function ExternalLink({ label, description, href }: LinkProps) {
 }
 
 const getInvolvedInternalItems = getInvolvedItems.filter((item) =>
-  item.href.startsWith('/'),
+  isInternalLink(item.href),
 )
 
-const getInvolvedExternalItems = getInvolvedItems.filter(
-  (item) => item.href.startsWith('https://') || item.href.startsWith('http://'),
+const getInvolvedExternalItems = getInvolvedItems.filter((item) =>
+  isExternalLink(item.href),
 )
 
 export function DesktopNavigation() {

--- a/src/app/_components/DesktopNavigation.tsx
+++ b/src/app/_components/DesktopNavigation.tsx
@@ -15,17 +15,17 @@ import { NavigationPopover } from '@/components/NavigationPopover'
 import { PATHS } from '@/constants/paths'
 import { desktopNavigationItems } from '@/data/components/navigationData'
 
+type MainNavItemProps = {
+  href: Route
+  label: string
+  isActive?: boolean
+}
+
 export type SubNavItemProps = {
   href: string | Route
   label: string
   description?: string
   linkType?: 'internal' | 'externalPrimary' | 'externalSecondary'
-}
-
-type MainNavItemProps = {
-  href: Route
-  label: string
-  isActive?: boolean
 }
 
 function SubNavItem({

--- a/src/app/_components/DesktopNavigation.tsx
+++ b/src/app/_components/DesktopNavigation.tsx
@@ -7,28 +7,25 @@ import { ArrowUpRight } from '@phosphor-icons/react'
 import clsx from 'clsx'
 import { Route } from 'next'
 
+import { useActiveItems } from '@/hooks/useNavigationStatus'
+
 import { Icon } from '@/components/Icon'
 import { NavigationPopover } from '@/components/NavigationPopover'
-
-import { isInternalLink, isExternalLink } from '@/utils/linkUtils'
 
 import { PATHS } from '@/constants/paths'
 import { desktopNavigationItems } from '@/data/components/navigationData'
 
-type SubLinkProps = {
-  label: string | Route
+export type SubLinkProps = {
+  href: string | Route
+  label: string
   description: string
-  href: string
 }
 
 type InternalLinkProps = {
-  label: string
   href: Route
+  label: string
   isActive?: boolean
 }
-
-const { getInvolvedItems, communityItems, learnMoreItem } =
-  desktopNavigationItems
 
 function InternalSubLink({ label, description, href }: SubLinkProps) {
   return (
@@ -77,24 +74,18 @@ function InternalLink({ label, href, isActive }: InternalLinkProps) {
   )
 }
 
-const getInvolvedInternalItems = getInvolvedItems.filter((item) =>
-  isInternalLink(item.href),
-)
-
-const getInvolvedExternalItems = getInvolvedItems.filter((item) =>
-  isExternalLink(item.href),
-)
+const { getInvolvedItems, communityItems, learnMoreItem } =
+  desktopNavigationItems
 
 export function DesktopNavigation() {
   const pathname = usePathname()
 
-  const isGetInvolvedActive = getInvolvedInternalItems.some(
-    (item) => item.href === pathname,
-  )
-
-  const isCommunityActive = communityItems.some(
-    (item) => item.href === pathname,
-  )
+  const {
+    internalItems: getInvolvedInternalItems,
+    externalItems: getInvolvedExternalItems,
+    isActive: isGetInvolvedActive,
+  } = useActiveItems(getInvolvedItems)
+  const { isActive: isCommunityActive } = useActiveItems(communityItems)
 
   return (
     <ul

--- a/src/app/_components/DesktopNavigation.tsx
+++ b/src/app/_components/DesktopNavigation.tsx
@@ -13,51 +13,7 @@ import { NavigationPopover } from '@/components/NavigationPopover'
 import { isInternalLink, isExternalLink } from '@/utils/linkUtils'
 
 import { PATHS } from '@/constants/paths'
-import { FILECOIN_DOCS_URLS } from '@/constants/siteMetadata'
-
-const getInvolvedItems = [
-  {
-    label: PATHS.EVENTS.label,
-    href: PATHS.EVENTS.path,
-    description: 'Overview of upcoming and past events',
-  },
-  {
-    label: PATHS.GRANTS.label,
-    href: PATHS.GRANTS.path,
-    description:
-      'Information on funding opportunities supporting projects that contribute to the growth of the Filecoin Network',
-  },
-  {
-    label: 'Become a Storage Provider',
-    href: 'https://destor.com/destor-network/overview',
-    description: 'Dive right in and become an essential part of the ecosystem',
-  },
-  {
-    label: 'Contribute to the Filecoin Project',
-    href: FILECOIN_DOCS_URLS.waysToContribute,
-    description:
-      'Shape the future of Filecoin by contributing to its code, research, or docs.',
-  },
-]
-
-const communityItems = [
-  {
-    label: PATHS.ECOSYSTEM.label,
-    href: PATHS.ECOSYSTEM.path,
-    description: 'Learn about various ecosystem projects or submit your own',
-  },
-  {
-    label: PATHS.GOVERNANCE.label,
-    href: PATHS.GOVERNANCE.path,
-    description:
-      'Learn about Filecoin Improvement Proposals and other governance mechanisms',
-  },
-]
-
-const learnMoreItem = {
-  label: 'Learn more about Filecoin',
-  href: FILECOIN_DOCS_URLS.site,
-}
+import { desktopNavigationItems } from '@/data/components/navigationData'
 
 type SubLinkProps = {
   label: string | Route
@@ -70,6 +26,9 @@ type InternalLinkProps = {
   href: Route
   isActive?: boolean
 }
+
+const { getInvolvedItems, communityItems, learnMoreItem } =
+  desktopNavigationItems
 
 function InternalSubLink({ label, description, href }: SubLinkProps) {
   return (

--- a/src/app/_components/DesktopNavigation.tsx
+++ b/src/app/_components/DesktopNavigation.tsx
@@ -15,7 +15,7 @@ import { NavigationPopover } from '@/components/NavigationPopover'
 import { PATHS } from '@/constants/paths'
 import { desktopNavigationItems } from '@/data/components/navigationData'
 
-export type SubLinkProps = {
+export type SubNavItemProps = {
   href: string | Route
   label: string
   description?: string
@@ -28,12 +28,12 @@ type InternalLinkProps = {
   isActive?: boolean
 }
 
-function SubLink({
+function SubNavItem({
   href,
   label,
   description,
   linkType = 'internal',
-}: SubLinkProps) {
+}: SubNavItemProps) {
   const external = linkType !== 'internal'
 
   const baseClasses =
@@ -119,14 +119,18 @@ export function DesktopNavigation() {
         <div className="grid w-screen max-w-2xl grid-cols-2 gap-4">
           <div className="space-y-4">
             {getInvolvedInternalItems.map((item) => (
-              <SubLink key={item.href} {...item} linkType="internal" />
+              <SubNavItem key={item.href} {...item} linkType="internal" />
             ))}
           </div>
           <div className="space-y-4">
             {getInvolvedExternalItems.map((item) => (
-              <SubLink key={item.href} {...item} linkType="externalPrimary" />
+              <SubNavItem
+                key={item.href}
+                {...item}
+                linkType="externalPrimary"
+              />
             ))}
-            <SubLink {...learnMoreItem} linkType="externalSecondary" />
+            <SubNavItem {...learnMoreItem} linkType="externalSecondary" />
           </div>
         </div>
       </NavigationPopover>
@@ -134,7 +138,7 @@ export function DesktopNavigation() {
       <NavigationPopover as="li" label="Community" isActive={isCommunityActive}>
         <div className="w-80 space-y-4">
           {communityItems.map((item) => (
-            <SubLink key={item.label} {...item} linkType="internal" />
+            <SubNavItem key={item.label} {...item} linkType="internal" />
           ))}
         </div>
       </NavigationPopover>

--- a/src/app/_components/DesktopNavigation.tsx
+++ b/src/app/_components/DesktopNavigation.tsx
@@ -116,7 +116,7 @@ export function DesktopNavigation() {
         <Link
           href={PATHS.ABOUT.path}
           className={clsx(
-            'text-hover:bg-brand-700 inline-block rounded-xl px-4 py-1.5 focus:outline focus:outline-2 focus:outline-brand-100',
+            'inline-block rounded-xl px-4 py-1.5 hover:bg-brand-700 focus:outline focus:outline-2 focus:outline-brand-100',
             pathname.startsWith(PATHS.ABOUT.path)
               ? 'text-brand-400'
               : 'text-brand-300',

--- a/src/app/_components/DesktopNavigation.tsx
+++ b/src/app/_components/DesktopNavigation.tsx
@@ -13,6 +13,7 @@ import { NavigationPopover } from '@/components/NavigationPopover'
 import { isInternalLink, isExternalLink } from '@/utils/linkUtils'
 
 import { PATHS } from '@/constants/paths'
+import { FILECOIN_DOCS_URLS } from '@/constants/siteMetadata'
 
 const getInvolvedItems = [
   {
@@ -33,7 +34,7 @@ const getInvolvedItems = [
   },
   {
     label: 'Contribute to the Filecoin Project',
-    href: 'https://docs.filecoin.io/basics/project-and-community/ways-to-contribute',
+    href: FILECOIN_DOCS_URLS.waysToContribute,
     description:
       'Shape the future of Filecoin by contributing to its code, research, or docs.',
   },
@@ -55,13 +56,19 @@ const communityItems = [
 
 const learnMoreItem = {
   label: 'Learn more about Filecoin',
-  href: 'https://docs.filecoin.io/',
+  href: FILECOIN_DOCS_URLS.site,
 }
 
 type SubLinkProps = {
   label: string | Route
   description: string
   href: string
+}
+
+type InternalLinkProps = {
+  label: string
+  href: Route
+  isActive?: boolean
 }
 
 function InternalSubLink({ label, description, href }: SubLinkProps) {
@@ -71,7 +78,7 @@ function InternalSubLink({ label, description, href }: SubLinkProps) {
       className="inline-block w-full rounded-lg bg-brand-800 p-4 hover:bg-brand-700 focus:outline focus:outline-2 focus:outline-brand-100"
       aria-label={`${label} page (internal link)`}
     >
-      <p className="pb-1 font-bold">{label}</p>
+      <p className="mb-1 font-bold">{label}</p>
       <p className="text-brand-300">{description}</p>
     </Link>
   )
@@ -84,25 +91,18 @@ function ExternalSubLink({ label, description, href }: SubLinkProps) {
       rel="noopener noreferrer"
       className="group inline-block w-full rounded-lg border border-brand-500 bg-brand-700 p-4 hover:border-brand-400 focus:border-transparent focus:outline focus:outline-2 focus:outline-brand-100"
     >
-      <div className="mb-4 flex gap-1">
+      <div className="mb-4 inline-flex items-center gap-1">
         <p className="font-bold">{label}</p>
-        <span className="mt-0.5 text-brand-400 group-hover:text-brand-100">
+        <span className="text-brand-400 group-hover:text-brand-100">
           <Icon component={ArrowUpRight} size={20} />
         </span>
       </div>
-
       <p className="text-brand-300">{description}</p>
     </a>
   )
 }
 
-type LinkProps = {
-  label: string
-  href: Route
-  isActive?: boolean
-}
-
-function InternalLink({ label, href, isActive }: LinkProps) {
+function InternalLink({ label, href, isActive }: InternalLinkProps) {
   return (
     <li>
       <Link
@@ -129,13 +129,13 @@ const getInvolvedExternalItems = getInvolvedItems.filter((item) =>
 export function DesktopNavigation() {
   const pathname = usePathname()
 
-  const isGetInvolvedActive = getInvolvedInternalItems
-    .map((item) => item.href)
-    .includes(pathname)
+  const isGetInvolvedActive = getInvolvedInternalItems.some(
+    (item) => item.href === pathname,
+  )
 
-  const isCommunityActive = communityItems
-    .map((item) => item.href as string)
-    .includes(pathname)
+  const isCommunityActive = communityItems.some(
+    (item) => item.href === pathname,
+  )
 
   return (
     <ul
@@ -145,7 +145,7 @@ export function DesktopNavigation() {
       <InternalLink
         label={PATHS.ABOUT.label}
         href={PATHS.ABOUT.path}
-        isActive={pathname.startsWith(PATHS.ABOUT.path)}
+        isActive={pathname === PATHS.ABOUT.path}
       />
 
       <NavigationPopover
@@ -165,15 +165,12 @@ export function DesktopNavigation() {
             ))}
             <a
               href={learnMoreItem.href}
-              target="_blank"
               rel="noopener noreferrer"
-              className="group inline-flex w-full justify-center gap-1 rounded-lg bg-brand-800 px-3 py-5 hover:bg-brand-700 focus:outline focus:outline-2 focus:outline-brand-100"
+              className="group inline-flex w-full items-center justify-center gap-1 rounded-lg bg-brand-800 px-3 py-5 text-brand-300 hover:bg-brand-700 focus:outline focus:outline-2 focus:outline-brand-100"
               aria-label={`${learnMoreItem.label} (opens a new window)`}
             >
-              <span className="font-bold text-brand-300">
-                {learnMoreItem.label}
-              </span>
-              <span className="mt-0.5 text-brand-400 group-hover:text-brand-100">
+              <p className="font-bold">{learnMoreItem.label}</p>
+              <span className="text-brand-400 group-hover:text-brand-100">
                 <Icon component={ArrowUpRight} size={20} />
               </span>
             </a>
@@ -192,7 +189,7 @@ export function DesktopNavigation() {
       <InternalLink
         label={PATHS.BLOG.label}
         href={PATHS.BLOG.path}
-        isActive={pathname.startsWith(PATHS.BLOG.path)}
+        isActive={pathname === PATHS.BLOG.path}
       />
     </ul>
   )

--- a/src/app/_components/DesktopNavigation.tsx
+++ b/src/app/_components/DesktopNavigation.tsx
@@ -70,15 +70,19 @@ function SubNavItem({
   )
 }
 
-function NavItem({ label, href, isActive }: InternalLinkProps) {
+function getNavItemBaseStyles(isActive: boolean) {
+  return clsx(
+    'rounded-xl py-1.5 text-base hover:bg-brand-700 focus:outline focus:outline-2 focus:outline-brand-100',
+    isActive ? 'text-brand-400' : 'text-brand-300',
+  )
+}
+
+function NavItem({ label, href, isActive = false }: InternalLinkProps) {
   return (
     <li>
       <Link
         href={href}
-        className={clsx(
-          'inline-block rounded-xl px-4 py-1.5 hover:bg-brand-700 focus:outline focus:outline-2 focus:outline-brand-100',
-          isActive ? 'text-brand-400' : 'text-brand-300',
-        )}
+        className={clsx(getNavItemBaseStyles(isActive), 'inline-block px-4')}
       >
         {label}
       </Link>
@@ -114,7 +118,7 @@ export function DesktopNavigation() {
       <NavigationPopover
         as="li"
         label="Get Involved"
-        isActive={isGetInvolvedActive}
+        navItemBaseStyles={getNavItemBaseStyles(isGetInvolvedActive)}
       >
         <div className="grid w-screen max-w-2xl grid-cols-2 gap-4">
           <div className="space-y-4">
@@ -135,7 +139,11 @@ export function DesktopNavigation() {
         </div>
       </NavigationPopover>
 
-      <NavigationPopover as="li" label="Community" isActive={isCommunityActive}>
+      <NavigationPopover
+        as="li"
+        label="Community"
+        navItemBaseStyles={getNavItemBaseStyles(isCommunityActive)}
+      >
         <div className="w-80 space-y-4">
           {communityItems.map((item) => (
             <SubNavItem key={item.label} {...item} linkType="internal" />

--- a/src/app/_components/DesktopNavigation.tsx
+++ b/src/app/_components/DesktopNavigation.tsx
@@ -70,9 +70,17 @@ function SubMainNavItem({
   )
 }
 
-function getMainNavItemBaseStyles(isActive: boolean) {
+function getMainNavItemStyles(isActive: boolean, isPopover = false) {
+  const baseStyles =
+    'rounded-xl py-1.5 text-base hover:bg-brand-700 focus:outline focus:outline-2 focus:outline-brand-100'
+
+  const extendedStyles = isPopover
+    ? 'inline-flex items-center gap-2 pl-4 pr-3 ui-open:bg-brand-700 ui-open:text-brand-400'
+    : 'inline-block px-4'
+
   return clsx(
-    'rounded-xl py-1.5 text-base hover:bg-brand-700 focus:outline focus:outline-2 focus:outline-brand-100',
+    baseStyles,
+    extendedStyles,
     isActive ? 'text-brand-400' : 'text-brand-300',
   )
 }
@@ -80,13 +88,7 @@ function getMainNavItemBaseStyles(isActive: boolean) {
 function MainNavItem({ label, href, isActive = false }: InternalLinkProps) {
   return (
     <li>
-      <Link
-        href={href}
-        className={clsx(
-          getMainNavItemBaseStyles(isActive),
-          'inline-block px-4',
-        )}
-      >
+      <Link href={href} className={getMainNavItemStyles(isActive)}>
         {label}
       </Link>
     </li>
@@ -121,7 +123,7 @@ export function DesktopNavigation() {
       <NavigationPopover
         as="li"
         label="Get Involved"
-        mainNavItemBaseStyles={getMainNavItemBaseStyles(isGetInvolvedActive)}
+        mainNavItemStyles={getMainNavItemStyles(isGetInvolvedActive, true)}
       >
         <div className="grid w-screen max-w-2xl grid-cols-2 gap-4">
           <div className="space-y-4">
@@ -145,7 +147,7 @@ export function DesktopNavigation() {
       <NavigationPopover
         as="li"
         label="Community"
-        mainNavItemBaseStyles={getMainNavItemBaseStyles(isCommunityActive)}
+        mainNavItemStyles={getMainNavItemStyles(isCommunityActive, true)}
       >
         <div className="w-80 space-y-4">
           {communityItems.map((item) => (

--- a/src/app/_components/DesktopNavigation.tsx
+++ b/src/app/_components/DesktopNavigation.tsx
@@ -79,10 +79,8 @@ function ExternalLink({ label, description, href }: LinkProps) {
   return (
     <a
       href={href}
-      target="_blank"
       rel="noopener noreferrer"
       className="group inline-block w-full rounded-lg border border-brand-500 bg-brand-700 p-4 hover:border-brand-400 focus:border-transparent focus:outline focus:outline-2 focus:outline-brand-100"
-      aria-label={`${label} (opens a new window)`}
     >
       <div className="flex gap-1">
         <p className="pb-2 font-bold">{label}</p>

--- a/src/app/_components/DesktopNavigation.tsx
+++ b/src/app/_components/DesktopNavigation.tsx
@@ -7,7 +7,7 @@ import { ArrowUpRight } from '@phosphor-icons/react'
 import clsx from 'clsx'
 import { Route } from 'next'
 
-import { useActiveItems } from '@/hooks/useNavigationStatus'
+import { useNavigationItems } from '@/hooks/useNavigationItems'
 
 import { Icon } from '@/components/Icon'
 import { NavigationPopover } from '@/components/NavigationPopover'
@@ -105,9 +105,10 @@ export function DesktopNavigation() {
     internalItems: getInvolvedInternalItems,
     externalItems: getInvolvedExternalItems,
     isActive: isGetInvolvedActive,
-  } = useActiveItems(getInvolvedItems)
+  } = useNavigationItems(getInvolvedItems)
 
-  const { isActive: isCommunityActive } = useActiveItems(communityItems)
+  const { isActive: isCommunityActive, internalItems: communityInternalItems } =
+    useNavigationItems(communityItems)
 
   return (
     <ul
@@ -150,7 +151,7 @@ export function DesktopNavigation() {
         mainNavItemStyles={getMainNavItemStyles(isCommunityActive, true)}
       >
         <div className="w-80 space-y-4">
-          {communityItems.map((item) => (
+          {communityInternalItems.map((item) => (
             <SubNavItem key={item.label} {...item} linkType="internal" />
           ))}
         </div>

--- a/src/app/_components/Navigation.tsx
+++ b/src/app/_components/Navigation.tsx
@@ -1,25 +1,10 @@
 import Link from 'next/link'
 
+import { DesktopNavigation } from '@/components/DesktopNavigation'
 import { Logo } from '@/components/Logo'
 import { MobileNavigation } from '@/components/MobileNavigation'
-import { TextLink } from '@/components/TextLink'
 
 import { PATHS } from '@/constants/paths'
-
-const navigationItems = [
-  PATHS.ABOUT,
-  PATHS.GOVERNANCE,
-  PATHS.ECOSYSTEM,
-  PATHS.BLOG,
-]
-
-function NavigationLink({ label, path }: { label: string; path: string }) {
-  return (
-    <li className="whitespace-nowrap last:mr-0">
-      <TextLink href={path}>{label}</TextLink>
-    </li>
-  )
-}
 
 export function Navigation() {
   return (
@@ -34,12 +19,7 @@ export function Navigation() {
       </Link>
 
       <MobileNavigation />
-
-      <ul className="hidden gap-5 lg:flex">
-        {navigationItems.map((item) => (
-          <NavigationLink key={item.path} label={item.label} path={item.path} />
-        ))}
-      </ul>
+      <DesktopNavigation />
     </nav>
   )
 }

--- a/src/app/_components/NavigationPopover.tsx
+++ b/src/app/_components/NavigationPopover.tsx
@@ -4,7 +4,6 @@ import { cloneElement, Fragment } from 'react'
 
 import { Popover, Transition } from '@headlessui/react'
 import { CaretDown } from '@phosphor-icons/react'
-import clsx from 'clsx'
 
 import { Icon } from '@/components/Icon'
 

--- a/src/app/_components/NavigationPopover.tsx
+++ b/src/app/_components/NavigationPopover.tsx
@@ -4,7 +4,6 @@ import { cloneElement, Fragment } from 'react'
 
 import { Popover, Transition } from '@headlessui/react'
 import { CaretDown } from '@phosphor-icons/react'
-import clsx from 'clsx'
 
 import { Icon } from '@/components/Icon'
 
@@ -19,9 +18,7 @@ export function NavigationPopover({ label, children, as }: PopOverProps) {
     <Popover as={as}>
       <Popover.Button
         aria-label={`${label} (opens a navigation menu)`}
-        className={clsx(
-          'inline-flex items-center gap-2 rounded-xl py-1.5 pl-4 pr-3 text-base text-brand-300 hover:bg-brand-700 focus:outline focus:outline-2 focus:outline-brand-100 ui-open:bg-brand-700 ui-open:text-brand-400',
-        )}
+        className="inline-flex items-center gap-2 rounded-xl py-1.5 pl-4 pr-3 text-base text-brand-300 hover:bg-brand-700 focus:outline focus:outline-2 focus:outline-brand-100 ui-open:bg-brand-700 ui-open:text-brand-400"
       >
         <span>{label}</span>
         <span className="transition-transform ui-open:rotate-180">

--- a/src/app/_components/NavigationPopover.tsx
+++ b/src/app/_components/NavigationPopover.tsx
@@ -4,6 +4,7 @@ import { cloneElement, Fragment } from 'react'
 
 import { Popover, Transition } from '@headlessui/react'
 import { CaretDown } from '@phosphor-icons/react'
+import clsx from 'clsx'
 
 import { Icon } from '@/components/Icon'
 
@@ -11,14 +12,23 @@ type PopOverProps = {
   label: string
   children: React.ReactElement
   as: React.ElementType
+  isActive?: boolean
 }
 
-export function NavigationPopover({ label, children, as }: PopOverProps) {
+export function NavigationPopover({
+  label,
+  children,
+  as,
+  isActive,
+}: PopOverProps) {
   return (
     <Popover as={as}>
       <Popover.Button
         aria-label={`${label} (opens a navigation menu)`}
-        className="inline-flex items-center gap-2 rounded-xl py-1.5 pl-4 pr-3 text-base text-brand-300 hover:bg-brand-700 focus:outline focus:outline-2 focus:outline-brand-100 ui-open:bg-brand-700 ui-open:text-brand-400"
+        className={clsx(
+          'inline-flex items-center gap-2 rounded-xl py-1.5 pl-4 pr-3 text-base hover:bg-brand-700 focus:outline focus:outline-2 focus:outline-brand-100 ui-open:bg-brand-700 ui-open:text-brand-400',
+          isActive ? 'text-brand-400' : 'text-brand-300',
+        )}
       >
         <span>{label}</span>
         <span className="transition-transform ui-open:rotate-180">

--- a/src/app/_components/NavigationPopover.tsx
+++ b/src/app/_components/NavigationPopover.tsx
@@ -1,0 +1,59 @@
+'use client'
+
+import { cloneElement, Fragment } from 'react'
+
+import { Popover, Transition } from '@headlessui/react'
+import { CaretDown } from '@phosphor-icons/react'
+import clsx from 'clsx'
+
+import { Icon } from '@/components/Icon'
+
+type PopOverProps = {
+  label: string
+  children: React.ReactElement
+  as: React.ElementType
+}
+
+export function NavigationPopover({ label, children, as }: PopOverProps) {
+  return (
+    <Popover as={as}>
+      <Popover.Button
+        aria-label={`${label} (opens a navigation menu)`}
+        className={clsx(
+          'inline-flex items-center gap-2 rounded-xl py-1.5 pl-4 pr-3 text-base text-brand-300 hover:bg-brand-700 focus:outline focus:outline-2 focus:outline-brand-100 ui-open:bg-brand-700 ui-open:text-brand-400',
+        )}
+      >
+        <span>{label}</span>
+        <span className="transition-transform ui-open:rotate-180">
+          <Icon component={CaretDown} size={20} color="brand-400" />
+        </span>
+      </Popover.Button>
+      <Popover.Overlay className="fixed inset-0 -z-10" />
+      <Transition
+        as={Fragment}
+        enter="transition ease-out duration-200"
+        enterFrom="opacity-0 translate-y-1"
+        enterTo="opacity-100 translate-y-0"
+        leave="transition ease-in duration-150"
+        leaveFrom="opacity-100 translate-y-0"
+        leaveTo="opacity-0 translate-y-1"
+      >
+        <Popover.Panel className="absolute right-0 z-10 mt-6 xl:-right-6">
+          {(props) => {
+            const clonedChildren = cloneElement(children, {
+              onClick: function closeOnClickWithin() {
+                props.close()
+              },
+            })
+
+            return (
+              <div className="overflow-hidden rounded-2xl border border-brand-500 bg-brand-800 p-4">
+                {clonedChildren}
+              </div>
+            )
+          }}
+        </Popover.Panel>
+      </Transition>
+    </Popover>
+  )
+}

--- a/src/app/_components/NavigationPopover.tsx
+++ b/src/app/_components/NavigationPopover.tsx
@@ -10,24 +10,33 @@ import { Icon } from '@/components/Icon'
 
 type PopOverProps = {
   label: string
-  children: React.ReactElement
+  navItemBaseStyles: string
   as: React.ElementType
-  isActive?: boolean
+  children: React.ReactElement
+}
+
+const transitionProps = {
+  enter: 'transition ease-out duration-200',
+  enterFrom: 'opacity-0 translate-y-1',
+  enterTo: 'opacity-100 translate-y-0',
+  leave: 'transition ease-in duration-150',
+  leaveFrom: 'opacity-100 translate-y-0',
+  leaveTo: 'opacity-0 translate-y-1',
 }
 
 export function NavigationPopover({
   label,
-  children,
+  navItemBaseStyles,
   as,
-  isActive,
+  children,
 }: PopOverProps) {
   return (
     <Popover as={as}>
       <Popover.Button
         aria-label={`${label} (opens a navigation menu)`}
         className={clsx(
-          'inline-flex items-center gap-2 rounded-xl py-1.5 pl-4 pr-3 text-base hover:bg-brand-700 focus:outline focus:outline-2 focus:outline-brand-100 ui-open:bg-brand-700 ui-open:text-brand-400',
-          isActive ? 'text-brand-400' : 'text-brand-300',
+          navItemBaseStyles,
+          'inline-flex items-center gap-2 pl-4 pr-3 ui-open:bg-brand-700 ui-open:text-brand-400',
         )}
       >
         <span>{label}</span>
@@ -36,15 +45,7 @@ export function NavigationPopover({
         </span>
       </Popover.Button>
       <Popover.Overlay className="fixed inset-0 -z-10" />
-      <Transition
-        as={Fragment}
-        enter="transition ease-out duration-200"
-        enterFrom="opacity-0 translate-y-1"
-        enterTo="opacity-100 translate-y-0"
-        leave="transition ease-in duration-150"
-        leaveFrom="opacity-100 translate-y-0"
-        leaveTo="opacity-0 translate-y-1"
-      >
+      <Transition as={Fragment} {...transitionProps}>
         <Popover.Panel className="absolute right-0 z-10 mt-6 xl:-right-6">
           {(props) => {
             const clonedChildren = cloneElement(children, {

--- a/src/app/_components/NavigationPopover.tsx
+++ b/src/app/_components/NavigationPopover.tsx
@@ -10,7 +10,7 @@ import { Icon } from '@/components/Icon'
 
 type PopOverProps = {
   label: string
-  mainNavItemBaseStyles: string
+  mainNavItemStyles: string
   as: React.ElementType
   children: React.ReactElement
 }
@@ -26,7 +26,7 @@ const transitionProps = {
 
 export function NavigationPopover({
   label,
-  mainNavItemBaseStyles,
+  mainNavItemStyles,
   as,
   children,
 }: PopOverProps) {
@@ -34,10 +34,7 @@ export function NavigationPopover({
     <Popover as={as}>
       <Popover.Button
         aria-label={`${label} (opens a navigation menu)`}
-        className={clsx(
-          mainNavItemBaseStyles,
-          'inline-flex items-center gap-2 pl-4 pr-3 ui-open:bg-brand-700 ui-open:text-brand-400',
-        )}
+        className={mainNavItemStyles}
       >
         <span>{label}</span>
         <span className="transition-transform ui-open:rotate-180">

--- a/src/app/_components/NavigationPopover.tsx
+++ b/src/app/_components/NavigationPopover.tsx
@@ -10,7 +10,7 @@ import { Icon } from '@/components/Icon'
 
 type PopOverProps = {
   label: string
-  navItemBaseStyles: string
+  mainNavItemBaseStyles: string
   as: React.ElementType
   children: React.ReactElement
 }
@@ -26,7 +26,7 @@ const transitionProps = {
 
 export function NavigationPopover({
   label,
-  navItemBaseStyles,
+  mainNavItemBaseStyles,
   as,
   children,
 }: PopOverProps) {
@@ -35,7 +35,7 @@ export function NavigationPopover({
       <Popover.Button
         aria-label={`${label} (opens a navigation menu)`}
         className={clsx(
-          navItemBaseStyles,
+          mainNavItemBaseStyles,
           'inline-flex items-center gap-2 pl-4 pr-3 ui-open:bg-brand-700 ui-open:text-brand-400',
         )}
       >

--- a/src/app/_components/NavigationPopover.tsx
+++ b/src/app/_components/NavigationPopover.tsx
@@ -14,7 +14,7 @@ type PopOverProps = {
   children: React.ReactElement
 }
 
-const transitionProps = {
+const TransitionProps = {
   enter: 'transition ease-out duration-200',
   enterFrom: 'opacity-0 translate-y-1',
   enterTo: 'opacity-100 translate-y-0',
@@ -41,7 +41,7 @@ export function NavigationPopover({
         </span>
       </Popover.Button>
       <Popover.Overlay className="fixed inset-0 -z-10" />
-      <Transition as={Fragment} {...transitionProps}>
+      <Transition as={Fragment} {...TransitionProps}>
         <Popover.Panel className="absolute right-0 z-10 mt-6 xl:-right-6">
           {(props) => {
             const clonedChildren = cloneElement(children, {

--- a/src/app/_constants/paths.ts
+++ b/src/app/_constants/paths.ts
@@ -44,7 +44,7 @@ function createPathObject(
 
 export const PATHS = {
   ABOUT: createPathObject('/about', 'About'),
-  BLOG: createPathObject('/blog', 'News & Blog', true),
+  BLOG: createPathObject('/blog', 'Blog', true),
   ECOSYSTEM: createPathObject('/ecosystem', 'Ecosystem', true),
   EVENTS: createPathObject('/events', 'Events', true),
   GOVERNANCE: createPathObject('/governance', 'Governance'),

--- a/src/app/_constants/paths.ts
+++ b/src/app/_constants/paths.ts
@@ -45,7 +45,7 @@ function createPathObject(
 export const PATHS = {
   ABOUT: createPathObject('/about', 'About'),
   BLOG: createPathObject('/blog', 'Blog', true),
-  ECOSYSTEM: createPathObject('/ecosystem', 'Ecosystem', true),
+  ECOSYSTEM: createPathObject('/ecosystem', 'Ecosystem Explorer', true),
   EVENTS: createPathObject('/events', 'Events', true),
   GOVERNANCE: createPathObject('/governance', 'Governance'),
   GRANTS: createPathObject('/grants', 'Grants'),

--- a/src/app/_constants/siteMetadata.ts
+++ b/src/app/_constants/siteMetadata.ts
@@ -9,6 +9,12 @@ const FIL_PLUS_URLS = {
   slack: 'https://filecoinproject.slack.com/archives/C01DLAPKDGX',
 }
 
+const FILECOIN_DOCS_URLS = {
+  site: 'https://docs.filecoin.io/',
+  waysToContribute:
+    'https://docs.filecoin.io/basics/project-and-community/ways-to-contribute',
+}
+
 const FILECOIN_FOUNDATION_URLS = {
   annualReports: {
     latest: `${PATHS.BLOG.path}/filecoin-foundation-2023-annual-report/`,
@@ -89,8 +95,9 @@ const FILECOIN_URLS = {
 
 export {
   BASE_URL,
+  FIL_PLUS_URLS,
+  FILECOIN_DOCS_URLS,
   FILECOIN_FOUNDATION_URLS,
   FILECOIN_URLS,
-  FIL_PLUS_URLS,
   ORGANIZATION_NAME,
 }

--- a/src/app/_data/components/navigationData.ts
+++ b/src/app/_data/components/navigationData.ts
@@ -1,0 +1,49 @@
+import { PATHS } from '@/constants/paths'
+import { FILECOIN_DOCS_URLS } from '@/constants/siteMetadata'
+
+export const desktopNavigationItems = {
+  getInvolvedItems: [
+    {
+      label: PATHS.EVENTS.label,
+      href: PATHS.EVENTS.path,
+      description: 'Overview of upcoming and past events',
+    },
+    {
+      label: PATHS.GRANTS.label,
+      href: PATHS.GRANTS.path,
+      description:
+        'Information on funding opportunities supporting projects that contribute to the growth of the Filecoin Network',
+    },
+    {
+      label: 'Become a Storage Provider',
+      href: 'https://destor.com/destor-network/overview',
+      description:
+        'Dive right in and become an essential part of the ecosystem',
+    },
+    {
+      label: 'Contribute to the Filecoin Project',
+      href: FILECOIN_DOCS_URLS.waysToContribute,
+      description:
+        'Shape the future of Filecoin by contributing to its code, research, or docs.',
+    },
+  ],
+  communityItems: [
+    {
+      label: PATHS.ECOSYSTEM.label,
+      href: PATHS.ECOSYSTEM.path,
+      description: 'Learn about various ecosystem projects or submit your own',
+    },
+    {
+      label: PATHS.GOVERNANCE.label,
+      href: PATHS.GOVERNANCE.path,
+      description:
+        'Learn about Filecoin Improvement Proposals and other governance mechanisms',
+    },
+  ],
+  learnMoreItem: {
+    label: 'Learn more about Filecoin',
+    href: FILECOIN_DOCS_URLS.site,
+  },
+}
+
+export default desktopNavigationItems

--- a/src/app/_hooks/useNavigationItems.ts
+++ b/src/app/_hooks/useNavigationItems.ts
@@ -4,7 +4,7 @@ import { type SubNavItemProps } from '@/components/DesktopNavigation'
 
 import { isInternalLink, isExternalLink } from '@/utils/linkUtils'
 
-export function useActiveItems(items: SubNavItemProps[]) {
+export function useNavigationItems(items: SubNavItemProps[]) {
   const pathname = usePathname()
   const internalItems = items.filter((item) => isInternalLink(item.href))
   const externalItems = items.filter((item) => isExternalLink(item.href))

--- a/src/app/_hooks/useNavigationStatus.ts
+++ b/src/app/_hooks/useNavigationStatus.ts
@@ -1,0 +1,14 @@
+import { usePathname } from 'next/navigation'
+
+import { type SubLinkProps } from '@/components/DesktopNavigation'
+
+import { isInternalLink, isExternalLink } from '@/utils/linkUtils'
+
+export function useActiveItems(items: SubLinkProps[]) {
+  const pathname = usePathname()
+  const internalItems = items.filter((item) => isInternalLink(item.href))
+  const externalItems = items.filter((item) => isExternalLink(item.href))
+  const isActive = internalItems.some((item) => item.href === pathname)
+
+  return { internalItems, externalItems, isActive }
+}

--- a/src/app/_hooks/useNavigationStatus.ts
+++ b/src/app/_hooks/useNavigationStatus.ts
@@ -1,10 +1,10 @@
 import { usePathname } from 'next/navigation'
 
-import { type SubLinkProps } from '@/components/DesktopNavigation'
+import { type SubNavItemProps } from '@/components/DesktopNavigation'
 
 import { isInternalLink, isExternalLink } from '@/utils/linkUtils'
 
-export function useActiveItems(items: SubLinkProps[]) {
+export function useActiveItems(items: SubNavItemProps[]) {
   const pathname = usePathname()
   const internalItems = items.filter((item) => isInternalLink(item.href))
   const externalItems = items.filter((item) => isExternalLink(item.href))

--- a/src/app/_utils/linkUtils.ts
+++ b/src/app/_utils/linkUtils.ts
@@ -2,8 +2,8 @@ import { Route } from 'next'
 
 type Link = string | Route
 
-export function isExternalLink(href: Link) {
-  return href.startsWith('http://') || href.startsWith('https://')
+export function isExternalLink(href: string) {
+  return !isInternalLink(href)
 }
 
 export function isInternalLink(href: Link) {

--- a/src/app/_utils/linkUtils.ts
+++ b/src/app/_utils/linkUtils.ts
@@ -1,0 +1,11 @@
+import { Route } from 'next'
+
+type Link = string | Route
+
+export function isExternalLink(href: Link) {
+  return href.startsWith('http://') || href.startsWith('https://')
+}
+
+export function isInternalLink(href: Link) {
+  return href.startsWith('/') || href.startsWith('#')
+}

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -71,5 +71,8 @@ module.exports = {
       },
     },
   },
-  plugins: [require('@tailwindcss/typography')],
+  plugins: [
+    require('@tailwindcss/typography'),
+    require('@headlessui/tailwindcss'),
+  ],
 }


### PR DESCRIPTION
This PR adds popover menus to the navigation component on larger screens.

It relies on Headless UI's [popover](https://headlessui.com/v1/react/popover), as well as [@headlessui-tailwindcss](https://github.com/tailwindlabs/headlessui/tree/main/packages/%40headlessui-tailwindcss) for styling elements with the `ui-open` modifiers, as shown [here](https://github.com/FilecoinFoundationWeb/filecoin-foundation/pull/118/commits/b5baa90ff5eeaecbae929fcf6df96883e29c8966#diff-d17350a5f2a1c03d1dcc0d3b9c8cb3e82c1ad6a3ba6a6b545f4163f13dab26a1R27)

The popover menus are keyboard accessible, meaning they can be opened/closed using tabs and Enter.

This PR also changes the label of the blog path - from `News & Blog` to `Blog` - to match the designs.

---

_Folded_
![CleanShot 2024-05-13 at 11 32 58](https://github.com/FilecoinFoundationWeb/filecoin-foundation/assets/20277959/f6d13d95-9ce9-4e85-9f15-420c0143a23b)

_Unfolded_
![CleanShot 2024-05-13 at 11 33 21](https://github.com/FilecoinFoundationWeb/filecoin-foundation/assets/20277959/ebc788ac-4d04-4754-b16c-97f03e5377c2)
