### PR TITLE
Edit Events categories

### DIFF
--- a/public/admin/config.yml
+++ b/public/admin/config.yml
@@ -553,12 +553,12 @@ collections:
         widget: "select"
         required: false
         options:
-          - label: "Hosted by FF"
+          - label: "Hosted"
             value: "hosted"
-          - label: "Supported by FF"
-            value: "supported"
-          - label: "Sponsored by FF"
+          - label: "Sponsored"
             value: "sponsored"
+          - label: "Supported"
+            value: "supported"
       - *meta_config
 
   - name: grants

--- a/src/app/_data/cmsConfigSchema.json
+++ b/src/app/_data/cmsConfigSchema.json
@@ -1894,16 +1894,16 @@
           "required": false,
           "options": [
             {
-              "label": "Hosted by FF",
+              "label": "Hosted",
               "value": "hosted"
             },
             {
-              "label": "Supported by FF",
-              "value": "supported"
+              "label": "Sponsored",
+              "value": "sponsored"
             },
             {
-              "label": "Sponsored by FF",
-              "value": "sponsored"
+              "label": "Supported",
+              "value": "supported"
             }
           ]
         },


### PR DESCRIPTION
Following the UX recommendation not to include `by FF` since we're effectively on the Filecoin Foundation site.