### PR TITLE
Ecosystem page header

### DIFF
--- a/cypress/e2e/ecosystem_page_spec.cy.ts
+++ b/cypress/e2e/ecosystem_page_spec.cy.ts
@@ -2,5 +2,5 @@ import { PATHS } from '../../src/app/_constants/paths'
 import { testPageMetadata } from '../support/test-utils'
 
 describe('Ecosystem Page', function () {
-  testPageMetadata(PATHS.ECOSYSTEM)
+  testPageMetadata(PATHS.ECOSYSTEM, true)
 })

--- a/src/app/_components/PageHeader.tsx
+++ b/src/app/_components/PageHeader.tsx
@@ -31,6 +31,8 @@ export function PageHeader({
   metaData,
   isFeatured = false,
 }: PageHeaderProps) {
+  // const imageStyles = `block rounded-lg ${image?.imageStyle ? image.imageStyle : 'object-cover'}`
+
   return (
     <header className="grid grid-rows-[auto,auto] gap-4">
       {isFeatured && <SectionDivider title="Featured" />}
@@ -78,6 +80,12 @@ export function PageHeader({
           </div>
         )}
       </div>
+
+      {/* {image && (
+        <div className="relative h-32 w-full rounded-lg border border-brand-100 sm:h-60 md:h-auto md:w-1/2">
+          <Image fill src={image.url} alt={image.alt} className={imageStyles} />
+        </div>
+      )} */}
     </header>
   )
 }

--- a/src/app/_components/PageHeader.tsx
+++ b/src/app/_components/PageHeader.tsx
@@ -1,5 +1,7 @@
 import Image from 'next/image'
 
+import clsx from 'clsx'
+
 import { Button } from '@/components/Button'
 import {
   type DescriptionTextType,
@@ -20,6 +22,7 @@ type PageHeaderProps = {
   image?: ImageProps
   metaData?: Array<string | null | undefined>
   isFeatured?: boolean
+  containImageSize?: boolean
 }
 
 export function PageHeader({
@@ -30,9 +33,8 @@ export function PageHeader({
   image,
   metaData,
   isFeatured = false,
+  containImageSize = false,
 }: PageHeaderProps) {
-  // const imageStyles = `block rounded-lg ${image?.imageStyle ? image.imageStyle : 'object-cover'}`
-
   return (
     <header className="grid grid-rows-[auto,auto] gap-4">
       {isFeatured && <SectionDivider title="Featured" />}
@@ -75,17 +77,14 @@ export function PageHeader({
               fill
               src={image.url}
               alt={image.alt}
-              className="block rounded-lg object-cover"
+              className={clsx(
+                'block rounded-lg',
+                containImageSize ? 'object-contain' : 'object-cover',
+              )}
             />
           </div>
         )}
       </div>
-
-      {/* {image && (
-        <div className="relative h-32 w-full rounded-lg border border-brand-100 sm:h-60 md:h-auto md:w-1/2">
-          <Image fill src={image.url} alt={image.alt} className={imageStyles} />
-        </div>
-      )} */}
     </header>
   )
 }

--- a/src/app/_types/sharedProps/imageType.ts
+++ b/src/app/_types/sharedProps/imageType.ts
@@ -1,5 +1,4 @@
 export type ImageProps = {
   url: string
   alt: string
-  imageStyle?: 'object-contain'
 }

--- a/src/app/_types/sharedProps/imageType.ts
+++ b/src/app/_types/sharedProps/imageType.ts
@@ -1,4 +1,5 @@
 export type ImageProps = {
   url: string
   alt: string
+  imageStyle?: 'object-contain'
 }

--- a/src/app/ecosystem/page.tsx
+++ b/src/app/ecosystem/page.tsx
@@ -18,10 +18,15 @@ import { FILECOIN_FOUNDATION_URLS } from '@/constants/siteMetadata'
 import { featuredPartners } from './data/featuredPartners'
 import { EcosystemClient } from './EcosystemClient'
 
-const { header, seo } = attributes
+const { featured_post: featuredProjectSlug, header, seo } = attributes
+
 export const metadata = createMetadata(seo, PATHS.ECOSYSTEM.path)
 
 const ecosystemProjects = getEcosystemProjectsData()
+
+const featuredProject = ecosystemProjects.find(
+  (project) => project.slug === featuredProjectSlug,
+)
 
 const ecosystemPageBaseData = generateWebPageStructuredData({
   title: seo.title,
@@ -36,6 +41,14 @@ export default function Ecosystem() {
       <PageHeader
         title={header.title}
         description={header.description}
+        {...(featuredProject
+          ? {
+              image: {
+                ...featuredProject?.image,
+                imageStyle: 'object-contain',
+              },
+            }
+          : {})}
         cta={{
           href: FILECOIN_FOUNDATION_URLS.ecosystem.submitOrUpdateProjectForm,
           text: 'Submit or Update Your Project',

--- a/src/app/ecosystem/page.tsx
+++ b/src/app/ecosystem/page.tsx
@@ -18,12 +18,11 @@ import { FILECOIN_FOUNDATION_URLS } from '@/constants/siteMetadata'
 import { featuredPartners } from './data/featuredPartners'
 import { EcosystemClient } from './EcosystemClient'
 
-const { featured_post: featuredProjectSlug, header, seo } = attributes
+const { featured_post: featuredProjectSlug, seo } = attributes
 
 export const metadata = createMetadata(seo, PATHS.ECOSYSTEM.path)
 
 const ecosystemProjects = getEcosystemProjectsData()
-
 const featuredProject = ecosystemProjects.find(
   (project) => project.slug === featuredProjectSlug,
 )
@@ -35,23 +34,22 @@ const ecosystemPageBaseData = generateWebPageStructuredData({
 })
 
 export default function Ecosystem() {
+  if (!featuredProject) {
+    throw new Error('Featured project not found')
+  }
+
   return (
     <PageLayout>
       <StructuredDataScript structuredData={ecosystemPageBaseData} />
       <PageHeader
-        title={header.title}
-        description={header.description}
-        {...(featuredProject
-          ? {
-              image: {
-                ...featuredProject?.image,
-                imageStyle: 'object-contain',
-              },
-            }
-          : {})}
+        isFeatured
+        containImageSize
+        title={featuredProject.title}
+        description={featuredProject.description}
+        image={featuredProject.image}
         cta={{
-          href: FILECOIN_FOUNDATION_URLS.ecosystem.submitOrUpdateProjectForm,
-          text: 'Submit or Update Your Project',
+          href: `${PATHS.ECOSYSTEM.path}/${featuredProjectSlug}`,
+          text: 'Learn More About the Project',
         }}
       />
 

--- a/src/content/pages/ecosystem.md
+++ b/src/content/pages/ecosystem.md
@@ -2,6 +2,7 @@
 header:
   title: "Filecoin Ecosystem Explorer"
   description: "Explore the interactive showcase of diverse projects that make up the Filecoin ecosystem. Given the network’s dynamic growth, this is not an exhaustive list but serves as a launching pad for exploring the ecosystem. If you’re a part of the Filecoin ecosystem and don’t see your project listed, share your details."
+featured_post: "democracys-library"
 seo:
   title: "Filecoin Ecosystem Explorer"
   description: "Explore the interactive showcase of diverse projects that make up the Filecoin ecosystem. Given the network’s dynamic growth, this is not an exhaustive list but serves as a launching pad for exploring the ecosystem. If you’re a part of the Filecoin ecosystem and don’t see your project listed, share your details."


### PR DESCRIPTION
## Changes
- included `featured_post` property in `ecosystem.md`

## Note
- Image styles in `PageHeader` required changes - we had `object-cover` which worked well for the Blog page image, but it doesn't work for Ecosystem page image (it need `object-contain`). I'm not too happy with the solution, but I opened the PR to get your thoughts on it. Other option could be to pass an independent prop `imageStyle` and keep it separate from the `ImageType` - let me know thoughts. 🙏

## Visuals
![Screenshot 2024-05-16 at 09 47 30](https://github.com/FilecoinFoundationWeb/filecoin-foundation/assets/50910606/a5a5ffc6-f8d8-4323-8d0d-b04d687f8bd3)

