### PR TITLE
Fix social links

### DIFF
--- a/src/app/_components/Social.tsx
+++ b/src/app/_components/Social.tsx
@@ -21,16 +21,16 @@ export function Social() {
         return (
           <li key={key} className="inline-flex">
             <a
-              aria-label={`${label} (opens in new window)`}
               href={href}
-              target="_blank"
               rel="noopener noreferrer"
+              title={label}
               className={clsx(
                 'text-brand-100 outline-white hover:text-brand-400 focus:outline-2',
                 touchTarget.class,
               )}
             >
               <Icon component={icon} size={32} weight="light" />
+              <span className="sr-only">{label}</span>
             </a>
           </li>
         )

--- a/src/app/_data/cmsConfigSchema.json
+++ b/src/app/_data/cmsConfigSchema.json
@@ -1507,7 +1507,7 @@
           "multiple": true,
           "options": [
             {
-              "label": "AI Productivity and Utilities",
+              "label": "AI Productivity & Utilities",
               "value": "ai-productivity-and-utilities"
             },
             {


### PR DESCRIPTION
- Don't open links in new tab
- Add `label` under `sr-only`
- Include a `title` attribute [>>](https://kittygiraudel.com/2020/12/10/accessible-icon-links/#:~:text=As%20a%20last%20touch%2C%20I%20would%20recommend%20adding%20the%20text%20content%20in%20the%20title%20attribute%20on%20the%20link%20as%20well.%20This%20does%20not%20enhance%20accessibility%20per%20se%2C%20but%20it%20emits%20a%20small%20tooltip%20when%20hovering%20the%20link%2C%20which%20can%20be%20handy%20for%20non%2Dobvious%20iconography.)