### PR TITLE
Rework Card Layout

### DIFF
--- a/src/app/_components/CardGrid.tsx
+++ b/src/app/_components/CardGrid.tsx
@@ -9,7 +9,7 @@ type GridColumnConfig =
   | 'mdThree'
   | 'lgThree'
 
-type CardLayoutProps = {
+type CardGridProps = {
   cols: GridColumnConfig
   as?: React.ElementType
   children: React.ReactNode
@@ -26,11 +26,7 @@ const extendedGridStyles: Record<GridColumnConfig, string> = {
   lgThree: 'lg:grid-cols-3 lg:gap-6',
 }
 
-export function CardLayout({
-  cols,
-  as: Tag = 'ul',
-  children,
-}: CardLayoutProps) {
+export function CardGrid({ cols, as: Tag = 'ul', children }: CardGridProps) {
   return (
     <Tag className={clsx(baseGridStyles, extendedGridStyles[cols])}>
       {children}

--- a/src/app/_components/CardLayout.tsx
+++ b/src/app/_components/CardLayout.tsx
@@ -10,12 +10,13 @@ type LayoutOption =
   | 'lgThree'
 
 type CardLayoutProps = {
-  children: React.ReactNode
-  as?: React.ElementType
   cols: LayoutOption
+  as?: React.ElementType
+  children: React.ReactNode
 }
 
-const layoutStyles: Record<LayoutOption, string> = {
+const baseGridStyles = 'grid grid-cols-1 gap-4'
+const extendedGridStyles: Record<LayoutOption, string> = {
   smTwoLgThree: 'sm:grid-cols-2 sm:gap-6 lg:grid-cols-3',
   smTwo: 'sm:grid-cols-2 sm:gap-6',
   mdTwo: 'md:grid-cols-2 md:gap-6',
@@ -31,7 +32,7 @@ export function CardLayout({
   children,
 }: CardLayoutProps) {
   return (
-    <Tag className={clsx('grid grid-cols-1 gap-4', layoutStyles[cols])}>
+    <Tag className={clsx(baseGridStyles, extendedGridStyles[cols])}>
       {children}
     </Tag>
   )

--- a/src/app/_components/CardLayout.tsx
+++ b/src/app/_components/CardLayout.tsx
@@ -1,6 +1,6 @@
 import clsx from 'clsx'
 
-type LayoutOption =
+type GridColumnConfig =
   | 'smTwoLgThree'
   | 'smTwo'
   | 'mdTwo'
@@ -10,13 +10,13 @@ type LayoutOption =
   | 'lgThree'
 
 type CardLayoutProps = {
-  cols: LayoutOption
+  cols: GridColumnConfig
   as?: React.ElementType
   children: React.ReactNode
 }
 
 const baseGridStyles = 'grid grid-cols-1 gap-4'
-const extendedGridStyles: Record<LayoutOption, string> = {
+const extendedGridStyles: Record<GridColumnConfig, string> = {
   smTwoLgThree: 'sm:grid-cols-2 sm:gap-6 lg:grid-cols-3',
   smTwo: 'sm:grid-cols-2 sm:gap-6',
   mdTwo: 'md:grid-cols-2 md:gap-6',
@@ -27,8 +27,8 @@ const extendedGridStyles: Record<LayoutOption, string> = {
 }
 
 export function CardLayout({
-  as: Tag = 'ul',
   cols,
+  as: Tag = 'ul',
   children,
 }: CardLayoutProps) {
   return (

--- a/src/app/_components/CardLayout.tsx
+++ b/src/app/_components/CardLayout.tsx
@@ -1,27 +1,37 @@
 import clsx from 'clsx'
 
+type LayoutOption =
+  | 'smTwoLgThree'
+  | 'smTwo'
+  | 'mdTwo'
+  | 'lgTwo'
+  | 'smThree'
+  | 'mdThree'
+  | 'lgThree'
+
 type CardLayoutProps = {
   children: React.ReactNode
   as?: React.ElementType
-  type?: 'default' | 'blogPost' | 'governance' | 'grants' | 'home'
+  cols: LayoutOption
+}
+
+const layoutStyles: Record<LayoutOption, string> = {
+  smTwoLgThree: 'sm:grid-cols-2 sm:gap-6 lg:grid-cols-3',
+  smTwo: 'sm:grid-cols-2 sm:gap-6',
+  mdTwo: 'md:grid-cols-2 md:gap-6',
+  lgTwo: 'lg:grid-cols-2 lg:gap-6',
+  smThree: 'sm:grid-cols-3 sm:gap-6',
+  mdThree: 'md:grid-cols-3 md:gap-6',
+  lgThree: 'lg:grid-cols-3 lg:gap-6',
 }
 
 export function CardLayout({
   as: Tag = 'ul',
-  type = 'default',
+  cols,
   children,
 }: CardLayoutProps) {
-  const baseLayoutStyles = 'grid gap-4 sm:gap-6'
-  const extendedLayoutStyles = {
-    default: 'sm:grid-cols-2 lg:grid-cols-3',
-    blogPost: 'lg:grid-cols-2 lg:grid-rows-2',
-    governance: 'grid-cols-1 sm:grid-cols-2',
-    grants: 'gap-8 sm:grid-cols-3',
-    home: 'grid-cols-1 sm:grid-cols-2 sm:grid-rows-2',
-  }
-
   return (
-    <Tag className={clsx(baseLayoutStyles, extendedLayoutStyles[type])}>
+    <Tag className={clsx('grid grid-cols-1 gap-4', layoutStyles[cols])}>
       {children}
     </Tag>
   )

--- a/src/app/_components/FeaturedBlogPosts.tsx
+++ b/src/app/_components/FeaturedBlogPosts.tsx
@@ -15,7 +15,7 @@ export function FeaturedBlogPosts() {
   }
 
   return (
-    <CardLayout type="blogPost">
+    <CardLayout cols="smTwo">
       {featuredBlogPosts.map(({ title, description, slug, image }) => (
         <Card
           key={slug}

--- a/src/app/_components/FeaturedBlogPosts.tsx
+++ b/src/app/_components/FeaturedBlogPosts.tsx
@@ -1,5 +1,5 @@
 import { Card } from '@/components/Card'
-import { CardLayout } from '@/components/CardLayout'
+import { CardGrid } from '@/components/CardGrid'
 
 import { getBlogPostsData } from '@/utils/getBlogPostData'
 
@@ -15,7 +15,7 @@ export function FeaturedBlogPosts() {
   }
 
   return (
-    <CardLayout cols="smTwo">
+    <CardGrid cols="smTwo">
       {featuredBlogPosts.map(({ title, description, slug, image }) => (
         <Card
           key={slug}
@@ -29,6 +29,6 @@ export function FeaturedBlogPosts() {
           }}
         />
       ))}
-    </CardLayout>
+    </CardGrid>
   )
 }

--- a/src/app/_components/FeaturedEcosystemProjects.tsx
+++ b/src/app/_components/FeaturedEcosystemProjects.tsx
@@ -19,7 +19,7 @@ export function FeaturedEcosystemProjects({
   }
 
   return (
-    <CardLayout>
+    <CardLayout cols="smTwoLgThree">
       {ecosystemProjects.map(({ slug, title, description, image }) => (
         <Card
           key={slug}

--- a/src/app/_components/FeaturedEcosystemProjects.tsx
+++ b/src/app/_components/FeaturedEcosystemProjects.tsx
@@ -1,7 +1,7 @@
 import { MagnifyingGlass } from '@phosphor-icons/react/dist/ssr'
 
 import { Card } from '@/components/Card'
-import { CardLayout } from '@/components/CardLayout'
+import { CardGrid } from '@/components/CardGrid'
 
 import { EcosystemProjectData } from '@/types/ecosystemProjectTypes'
 
@@ -19,7 +19,7 @@ export function FeaturedEcosystemProjects({
   }
 
   return (
-    <CardLayout cols="smTwoLgThree">
+    <CardGrid cols="smTwoLgThree">
       {ecosystemProjects.map(({ slug, title, description, image }) => (
         <Card
           key={slug}
@@ -36,6 +36,6 @@ export function FeaturedEcosystemProjects({
           }}
         />
       ))}
-    </CardLayout>
+    </CardGrid>
   )
 }

--- a/src/app/_components/FeaturedGrantGraduates.tsx
+++ b/src/app/_components/FeaturedGrantGraduates.tsx
@@ -17,7 +17,7 @@ export function FeaturedGrantsGraduates({
   }
 
   return (
-    <CardLayout type="blogPost">
+    <CardLayout cols="smTwo">
       {grantGraduates.map(({ title, description, slug }) => (
         <Card
           key={slug}

--- a/src/app/_components/FeaturedGrantGraduates.tsx
+++ b/src/app/_components/FeaturedGrantGraduates.tsx
@@ -1,5 +1,5 @@
 import { Card } from '@/components/Card'
-import { CardLayout } from '@/components/CardLayout'
+import { CardGrid } from '@/components/CardGrid'
 
 import { EcosystemProjectData } from '@/types/ecosystemProjectTypes'
 
@@ -17,7 +17,7 @@ export function FeaturedGrantsGraduates({
   }
 
   return (
-    <CardLayout cols="smTwo">
+    <CardGrid cols="smTwo">
       {grantGraduates.map(({ title, description, slug }) => (
         <Card
           key={slug}
@@ -30,6 +30,6 @@ export function FeaturedGrantsGraduates({
           }}
         />
       ))}
-    </CardLayout>
+    </CardGrid>
   )
 }

--- a/src/app/_components/GovernanceCalendarCards.tsx
+++ b/src/app/_components/GovernanceCalendarCards.tsx
@@ -7,7 +7,7 @@ import useSWR from 'swr'
 import { z } from 'zod'
 
 import { Badge } from '@/components/Badge'
-import { CardLayout } from '@/components/CardLayout'
+import { CardGrid } from '@/components/CardGrid'
 import { Heading } from '@/components/Heading'
 import { TextLink } from '@/components/TextLink'
 
@@ -90,7 +90,7 @@ export function GovernanceCalendarCards() {
   }
 
   return (
-    <CardLayout cols="lgTwo">
+    <CardGrid cols="lgTwo">
       {events.items.map((event) => {
         const { id, start, end, htmlLink, summary } = event
 
@@ -124,6 +124,6 @@ export function GovernanceCalendarCards() {
           </li>
         )
       })}
-    </CardLayout>
+    </CardGrid>
   )
 }

--- a/src/app/_components/GovernanceCalendarCards.tsx
+++ b/src/app/_components/GovernanceCalendarCards.tsx
@@ -90,7 +90,7 @@ export function GovernanceCalendarCards() {
   }
 
   return (
-    <CardLayout type="blogPost">
+    <CardLayout cols="lgTwo">
       {events.items.map((event) => {
         const { id, start, end, htmlLink, summary } = event
 

--- a/src/app/about/page.tsx
+++ b/src/app/about/page.tsx
@@ -78,7 +78,7 @@ export default function About() {
       />
 
       <PageSection kicker="What We Do" title="Focus Areas">
-        <CardLayout>
+        <CardLayout cols="lgThree">
           {focusAreasData.map(({ title, description }) => (
             <Card
               key={title}
@@ -91,7 +91,7 @@ export default function About() {
       </PageSection>
 
       <PageSection kicker="Who We Are" title="Board Members">
-        <CardLayout type="blogPost">
+        <CardLayout cols="mdTwo">
           {boardMembersData.map(({ name, title, linkedin }) => (
             <Card
               key={name}
@@ -113,7 +113,7 @@ export default function About() {
         title="Advisors"
         description="Leaders from across web3 and the open-source technology communities have come together to foster the Filecoin ecosystem."
       >
-        <CardLayout type="blogPost">
+        <CardLayout cols="mdTwo">
           {advisorsData.map(({ name, title, linkedin }) => (
             <Card
               key={name}
@@ -131,7 +131,7 @@ export default function About() {
       </PageSection>
 
       <PageSection kicker="Insights" title="Reports">
-        <CardLayout type="blogPost">
+        <CardLayout cols="mdTwo">
           {reportsData.map(({ title, description, link }, index) => (
             <div
               key={title}

--- a/src/app/about/page.tsx
+++ b/src/app/about/page.tsx
@@ -3,7 +3,7 @@ import clsx from 'clsx'
 import { WebPage, WithContext } from 'schema-dts'
 
 import { Card } from '@/components/Card'
-import { CardLayout } from '@/components/CardLayout'
+import { CardGrid } from '@/components/CardGrid'
 import { PageHeader } from '@/components/PageHeader'
 import { PageLayout } from '@/components/PageLayout'
 import { PageSection } from '@/components/PageSection'
@@ -78,7 +78,7 @@ export default function About() {
       />
 
       <PageSection kicker="What We Do" title="Focus Areas">
-        <CardLayout cols="lgThree">
+        <CardGrid cols="lgThree">
           {focusAreasData.map(({ title, description }) => (
             <Card
               key={title}
@@ -87,11 +87,11 @@ export default function About() {
               borderColor="brand-300"
             />
           ))}
-        </CardLayout>
+        </CardGrid>
       </PageSection>
 
       <PageSection kicker="Who We Are" title="Board Members">
-        <CardLayout cols="mdTwo">
+        <CardGrid cols="mdTwo">
           {boardMembersData.map(({ name, title, linkedin }) => (
             <Card
               key={name}
@@ -105,7 +105,7 @@ export default function About() {
               }}
             />
           ))}
-        </CardLayout>
+        </CardGrid>
       </PageSection>
 
       <PageSection
@@ -113,7 +113,7 @@ export default function About() {
         title="Advisors"
         description="Leaders from across web3 and the open-source technology communities have come together to foster the Filecoin ecosystem."
       >
-        <CardLayout cols="mdTwo">
+        <CardGrid cols="mdTwo">
           {advisorsData.map(({ name, title, linkedin }) => (
             <Card
               key={name}
@@ -127,11 +127,11 @@ export default function About() {
               }}
             />
           ))}
-        </CardLayout>
+        </CardGrid>
       </PageSection>
 
       <PageSection kicker="Insights" title="Reports">
-        <CardLayout cols="mdTwo">
+        <CardGrid cols="mdTwo">
           {reportsData.map(({ title, description, link }, index) => (
             <div
               key={title}
@@ -150,7 +150,7 @@ export default function About() {
               />
             </div>
           ))}
-        </CardLayout>
+        </CardGrid>
       </PageSection>
     </PageLayout>
   )

--- a/src/app/blog/page.tsx
+++ b/src/app/blog/page.tsx
@@ -150,7 +150,7 @@ export default function Blog({ searchParams }: Props) {
           <NoResultsMessage />
         ) : (
           <>
-            <CardLayout type="blogPost">
+            <CardLayout cols="smTwo">
               {paginatedResults.map((post) => {
                 const {
                   slug,

--- a/src/app/blog/page.tsx
+++ b/src/app/blog/page.tsx
@@ -8,7 +8,7 @@ import { useSearch } from '@/hooks/useSearch'
 import { useSort } from '@/hooks/useSort'
 
 import { Card } from '@/components/Card'
-import { CardLayout } from '@/components/CardLayout'
+import { CardGrid } from '@/components/CardGrid'
 import { NoResultsMessage } from '@/components/NoResultsMessage'
 import { PageHeader } from '@/components/PageHeader'
 import { PageLayout } from '@/components/PageLayout'
@@ -150,7 +150,7 @@ export default function Blog({ searchParams }: Props) {
           <NoResultsMessage />
         ) : (
           <>
-            <CardLayout cols="smTwo">
+            <CardGrid cols="smTwo">
               {paginatedResults.map((post) => {
                 const {
                   slug,
@@ -178,7 +178,7 @@ export default function Blog({ searchParams }: Props) {
                   />
                 )
               })}
-            </CardLayout>
+            </CardGrid>
 
             <div className="mx-auto mt-1 w-full sm:mt-6 sm:w-auto">
               <NoSSRPagination

--- a/src/app/ecosystem/page.tsx
+++ b/src/app/ecosystem/page.tsx
@@ -105,7 +105,7 @@ export default function Ecosystem({ searchParams }: Props) {
           <NoResultsMessage />
         ) : (
           <>
-            <CardLayout type="home">
+            <CardLayout cols="smTwo">
               {paginatedResults.map((project) => {
                 const { slug, title, description, image, category } = project
 

--- a/src/app/ecosystem/page.tsx
+++ b/src/app/ecosystem/page.tsx
@@ -5,7 +5,7 @@ import { useSearch } from '@/hooks/useSearch'
 import { useSort } from '@/hooks/useSort'
 
 import { Card } from '@/components/Card'
-import { CardLayout } from '@/components/CardLayout'
+import { CardGrid } from '@/components/CardGrid'
 import { CTASection } from '@/components/CTASection'
 import { NoResultsMessage } from '@/components/NoResultsMessage'
 import { PageHeader } from '@/components/PageHeader'
@@ -105,7 +105,7 @@ export default function Ecosystem({ searchParams }: Props) {
           <NoResultsMessage />
         ) : (
           <>
-            <CardLayout cols="smTwo">
+            <CardGrid cols="smTwo">
               {paginatedResults.map((project) => {
                 const { slug, title, description, image, category } = project
 
@@ -124,7 +124,7 @@ export default function Ecosystem({ searchParams }: Props) {
                   />
                 )
               })}
-            </CardLayout>
+            </CardGrid>
 
             <div className="mx-auto mt-1 w-full sm:mt-6 sm:w-auto">
               <NoSSRPagination

--- a/src/app/events/page.tsx
+++ b/src/app/events/page.tsx
@@ -157,7 +157,7 @@ export default function Events({ searchParams }: Props) {
           <NoResultsMessage />
         ) : (
           <>
-            <CardLayout type="home">
+            <CardLayout cols="smTwo">
               {paginatedResults.map((event) => {
                 const { slug, title, image, involvement, startDate, endDate } =
                   event
@@ -197,7 +197,7 @@ export default function Events({ searchParams }: Props) {
         kicker="Get Involved"
         title="Get in Touch With the Events Team"
       >
-        <CardLayout>
+        <CardLayout cols="mdThree">
           {getInvolvedData.map(({ title, description, cta }) => (
             <Card
               key={title}

--- a/src/app/events/page.tsx
+++ b/src/app/events/page.tsx
@@ -8,7 +8,7 @@ import { useSearch } from '@/hooks/useSearch'
 import { useSort } from '@/hooks/useSort'
 
 import { Card } from '@/components/Card'
-import { CardLayout } from '@/components/CardLayout'
+import { CardGrid } from '@/components/CardGrid'
 import { NoResultsMessage } from '@/components/NoResultsMessage'
 import { PageHeader } from '@/components/PageHeader'
 import { PageLayout } from '@/components/PageLayout'
@@ -157,7 +157,7 @@ export default function Events({ searchParams }: Props) {
           <NoResultsMessage />
         ) : (
           <>
-            <CardLayout cols="smTwo">
+            <CardGrid cols="smTwo">
               {paginatedResults.map((event) => {
                 const { slug, title, image, involvement, startDate, endDate } =
                   event
@@ -181,7 +181,7 @@ export default function Events({ searchParams }: Props) {
                   />
                 )
               })}
-            </CardLayout>
+            </CardGrid>
 
             <div className="mx-auto mt-1 w-full sm:mt-6 sm:w-auto">
               <NoSSRPagination
@@ -197,7 +197,7 @@ export default function Events({ searchParams }: Props) {
         kicker="Get Involved"
         title="Get in Touch With the Events Team"
       >
-        <CardLayout cols="mdThree">
+        <CardGrid cols="mdThree">
           {getInvolvedData.map(({ title, description, cta }) => (
             <Card
               key={title}
@@ -206,7 +206,7 @@ export default function Events({ searchParams }: Props) {
               cta={cta}
             />
           ))}
-        </CardLayout>
+        </CardGrid>
       </PageSection>
     </PageLayout>
   )

--- a/src/app/governance/page.tsx
+++ b/src/app/governance/page.tsx
@@ -1,4 +1,4 @@
-import { CardLayout } from '@/components/CardLayout'
+import { CardGrid } from '@/components/CardGrid'
 import { CTASection } from '@/components/CTASection'
 import { GovernanceCalendarCards } from '@/components/GovernanceCalendarCards'
 import { HomeExploreSectionCard } from '@/components/HomeExploreSectionCard'
@@ -41,7 +41,7 @@ export default function Governance() {
       />
 
       <PageSection kicker="Learn More" title="Quickstart">
-        <CardLayout cols="smTwo">
+        <CardGrid cols="smTwo">
           {governanceDocsData.map((card) => {
             const {
               heading: { title, icon },
@@ -66,7 +66,7 @@ export default function Governance() {
               </HomeExploreSectionCard>
             )
           })}
-        </CardLayout>
+        </CardGrid>
       </PageSection>
 
       <PageSection

--- a/src/app/governance/page.tsx
+++ b/src/app/governance/page.tsx
@@ -41,7 +41,7 @@ export default function Governance() {
       />
 
       <PageSection kicker="Learn More" title="Quickstart">
-        <CardLayout type="governance">
+        <CardLayout cols="smTwo">
           {governanceDocsData.map((card) => {
             const {
               heading: { title, icon },

--- a/src/app/grants/page.tsx
+++ b/src/app/grants/page.tsx
@@ -52,7 +52,7 @@ export default function Grants() {
         title="Grants and Funding Opportunities"
         description="The Foundation is seeking proposals for developer and data tooling, integrations, research and protocols, storage, retrieval, and the Filecoin Virtual Machine (FVM). These grants fall under the following categories:"
       >
-        <CardLayout>
+        <CardLayout cols="lgThree">
           {opportunitiesData.map((card) => {
             const { title, description, icon } = card
 
@@ -83,7 +83,7 @@ export default function Grants() {
         kicker="Application Process"
         title="The Filecoin Grants Process"
       >
-        <CardLayout type="grants">
+        <CardLayout cols="smThree">
           {applicationProcessData.map((card) => {
             const { step, title, description } = card
 
@@ -104,7 +104,7 @@ export default function Grants() {
         title="Submission Criteria"
         description="Generally, all projects must meet the following requirements:"
       >
-        <CardLayout>
+        <CardLayout cols="lgThree">
           {submissionCriteriaData.map((data) => {
             const { title, description, icon } = data
 

--- a/src/app/grants/page.tsx
+++ b/src/app/grants/page.tsx
@@ -1,4 +1,4 @@
-import { CardLayout } from '@/components/CardLayout'
+import { CardGrid } from '@/components/CardGrid'
 import { CTASection } from '@/components/CTASection'
 import { FeaturedGrantsGraduates } from '@/components/FeaturedGrantGraduates'
 import { GrantsApplicationProcessCard } from '@/components/GrantsApplicationProcessCard'
@@ -52,7 +52,7 @@ export default function Grants() {
         title="Grants and Funding Opportunities"
         description="The Foundation is seeking proposals for developer and data tooling, integrations, research and protocols, storage, retrieval, and the Filecoin Virtual Machine (FVM). These grants fall under the following categories:"
       >
-        <CardLayout cols="lgThree">
+        <CardGrid cols="lgThree">
           {opportunitiesData.map((card) => {
             const { title, description, icon } = card
 
@@ -72,7 +72,7 @@ export default function Grants() {
               </GrantsSectionCard>
             )
           })}
-        </CardLayout>
+        </CardGrid>
       </PageSection>
 
       <PageSection kicker="Past Examples" title="Grant Graduates">
@@ -83,7 +83,7 @@ export default function Grants() {
         kicker="Application Process"
         title="The Filecoin Grants Process"
       >
-        <CardLayout cols="smThree">
+        <CardGrid cols="smThree">
           {applicationProcessData.map((card) => {
             const { step, title, description } = card
 
@@ -96,7 +96,7 @@ export default function Grants() {
               />
             )
           })}
-        </CardLayout>
+        </CardGrid>
       </PageSection>
 
       <PageSection
@@ -104,7 +104,7 @@ export default function Grants() {
         title="Submission Criteria"
         description="Generally, all projects must meet the following requirements:"
       >
-        <CardLayout cols="lgThree">
+        <CardGrid cols="lgThree">
           {submissionCriteriaData.map((data) => {
             const { title, description, icon } = data
 
@@ -124,7 +124,7 @@ export default function Grants() {
               </GrantsSectionCard>
             )
           })}
-        </CardLayout>
+        </CardGrid>
       </PageSection>
 
       <CTASection

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -47,7 +47,7 @@ export default function Home() {
       />
 
       <PageSection kicker="Explore" title="The Filecoin Ecosystem">
-        <CardLayout type="home">
+        <CardLayout cols="smTwo">
           {filecoinEcosystemData.map((card) => {
             const {
               heading: { title, icon },

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,5 +1,5 @@
 import { Button } from '@/components/Button'
-import { CardLayout } from '@/components/CardLayout'
+import { CardGrid } from '@/components/CardGrid'
 import { CTASection } from '@/components/CTASection'
 import { FeaturedBlogPosts } from '@/components/FeaturedBlogPosts'
 import { FeaturedEcosystemProjects } from '@/components/FeaturedEcosystemProjects'
@@ -47,7 +47,7 @@ export default function Home() {
       />
 
       <PageSection kicker="Explore" title="The Filecoin Ecosystem">
-        <CardLayout cols="smTwo">
+        <CardGrid cols="smTwo">
           {filecoinEcosystemData.map((card) => {
             const {
               heading: { title, icon },
@@ -72,7 +72,7 @@ export default function Home() {
               </HomeExploreSectionCard>
             )
           })}
-        </CardLayout>
+        </CardGrid>
       </PageSection>
 
       <PageSection


### PR DESCRIPTION
This PR updates `CardLayout` by moving away from page-specific layout names such as `home` and using utility names such as `lgTwo`.

`lgTwo` means the grid starts with one column until the screen reaches the `lg` breakpoint, at which point it becomes two columns.

The `cols` prop now sets the grid behaviour, instead of `layout` before. I couldn't find a default layout among all the ones we are using, so the `cols` prop is now mandatory.

**A note on the events page:** The current event cards on the website are different from the ones on Figma. Hence, the layout is also different. When we update these cards, we can easily update the layout, too.