### PR TITLE
Governance Page - make event card clickable

### DIFF
--- a/src/app/_components/Card.tsx
+++ b/src/app/_components/Card.tsx
@@ -43,6 +43,21 @@ const imageSizes = {
     '(max-width: 639px) 320px, (max-width: 767px) 276px, (max-width: 1023px) 340px, 304px',
 }
 
+function Link({ href, ariaLabel, icon: Icon, text }: CTAProps) {
+  return (
+    <CustomLink
+      href={href}
+      aria-label={ariaLabel}
+      className="absolute inset-0 rounded-lg focus:outline-2 focus:outline-brand-100"
+    >
+      <span className="absolute bottom-4 left-4 inline-flex items-center gap-2 text-brand-300">
+        {Icon && <Icon size={24} />}
+        <span>{text}</span>
+      </span>
+    </CustomLink>
+  )
+}
+
 export function Card({
   title,
   tag,
@@ -104,20 +119,11 @@ export function Card({
             </p>
           )}
 
-          {cta && (
-            <CustomLink
-              href={cta.href}
-              aria-label={cta.ariaLabel}
-              className="absolute inset-0 rounded-lg focus:outline-2 focus:outline-brand-100"
-            >
-              <span className="absolute bottom-4 left-4 inline-flex items-center gap-2 text-brand-300">
-                {cta.icon && <Icon component={cta.icon} />}
-                <span>{cta.text}</span>
-              </span>
-            </CustomLink>
-          )}
+          {cta && <Link {...cta} />}
         </div>
       </div>
     </Tag>
   )
 }
+
+Card.Link = Link

--- a/src/app/_components/GovernanceCalendarCards.tsx
+++ b/src/app/_components/GovernanceCalendarCards.tsx
@@ -7,6 +7,7 @@ import useSWR from 'swr'
 import { z } from 'zod'
 
 import { Badge } from '@/components/Badge'
+import { Card } from '@/components/Card'
 import { CardGrid } from '@/components/CardGrid'
 import { Heading } from '@/components/Heading'
 import { TextLink } from '@/components/TextLink'
@@ -100,30 +101,28 @@ export function GovernanceCalendarCards() {
         return (
           <li
             key={id}
-            className="relative flex flex-col rounded-lg border border-blue-500 p-1 sm:flex-row"
+            className="flex flex-col rounded-lg border border-blue-500 p-1 sm:flex-row"
           >
             <Calendar startDate={start.dateTime} />
-            <div className="mb-12 flex flex-1 flex-col gap-3 p-4 sm:mb-8">
-              <div className="flex gap-2">
-                <Badge
-                  borderColor="brand-100"
-                  icon={Clock}
-                >{`UTC ${startTime} - ${endTime}`}</Badge>
-                <Badge>Zoom</Badge>
+            <div className="relative">
+              <div className="relative mb-12 flex flex-1 flex-col gap-3 p-4 sm:mb-8">
+                <div className="flex gap-2">
+                  <Badge
+                    borderColor="brand-100"
+                    icon={Clock}
+                  >{`UTC ${startTime} - ${endTime}`}</Badge>
+                  <Badge>Zoom</Badge>
+                </div>
+                <Heading tag="h3" variant="lg">
+                  {summary}
+                </Heading>
               </div>
-              <Heading tag="h3" variant="lg">
-                {summary}
-              </Heading>
+              <Card.Link
+                href={htmlLink}
+                icon={CalendarPlus}
+                text="Add to Google Calendar"
+              />
             </div>
-            <TextLink
-              className="absolute inset-0 rounded-lg text-base focus:outline-2 focus:outline-brand-100"
-              href={htmlLink}
-            >
-              <span className="absolute bottom-4 left-5 flex gap-2 sm:left-40">
-                <CalendarPlus size={24} />
-                Add to Google Calendar
-              </span>
-            </TextLink>
           </li>
         )
       })}

--- a/src/app/_components/GovernanceCalendarCards.tsx
+++ b/src/app/_components/GovernanceCalendarCards.tsx
@@ -105,7 +105,7 @@ export function GovernanceCalendarCards() {
           >
             <Calendar startDate={start.dateTime} />
             <div className="relative">
-              <div className="relative mb-12 flex flex-1 flex-col gap-3 p-4 sm:mb-8">
+              <div className="relative flex flex-1 flex-col gap-3 p-4">
                 <div className="flex gap-2">
                   <Badge
                     borderColor="brand-100"
@@ -117,11 +117,13 @@ export function GovernanceCalendarCards() {
                   {summary}
                 </Heading>
               </div>
-              <Card.Link
-                href={htmlLink}
-                icon={CalendarPlus}
-                text="Add to Google Calendar"
-              />
+              <div className="mb-10 mt-3">
+                <Card.Link
+                  href={htmlLink}
+                  icon={CalendarPlus}
+                  text="Add to Google Calendar"
+                />
+              </div>
             </div>
           </li>
         )

--- a/src/app/_components/GovernanceCalendarCards.tsx
+++ b/src/app/_components/GovernanceCalendarCards.tsx
@@ -100,27 +100,30 @@ export function GovernanceCalendarCards() {
         return (
           <li
             key={id}
-            className="flex flex-col rounded-lg border border-blue-500 p-1 sm:flex-row"
+            className="relative flex flex-col rounded-lg border border-blue-500 p-1 sm:flex-row"
           >
             <Calendar startDate={start.dateTime} />
-            <div className="flex flex-1 flex-col items-start justify-between gap-6 p-4">
-              <div className="flex flex-col gap-3">
-                <div className="flex gap-2">
-                  <Badge
-                    borderColor="brand-100"
-                    icon={Clock}
-                  >{`UTC ${startTime} - ${endTime}`}</Badge>
-                  <Badge>Zoom</Badge>
-                </div>
-                <Heading tag="h3" variant="lg">
-                  {summary}
-                </Heading>
+            <div className="mb-12 flex flex-1 flex-col gap-3 p-4 sm:mb-8">
+              <div className="flex gap-2">
+                <Badge
+                  borderColor="brand-100"
+                  icon={Clock}
+                >{`UTC ${startTime} - ${endTime}`}</Badge>
+                <Badge>Zoom</Badge>
               </div>
-              <TextLink className="flex gap-2 text-base" href={htmlLink}>
+              <Heading tag="h3" variant="lg">
+                {summary}
+              </Heading>
+            </div>
+            <TextLink
+              className="absolute inset-0 rounded-lg text-base focus:outline-2 focus:outline-brand-100"
+              href={htmlLink}
+            >
+              <span className="absolute bottom-4 left-5 flex gap-2 sm:left-40">
                 <CalendarPlus size={24} />
                 Add to Google Calendar
-              </TextLink>
-            </div>
+              </span>
+            </TextLink>
           </li>
         )
       })}

--- a/src/app/_components/HomeExploreSectionCard.tsx
+++ b/src/app/_components/HomeExploreSectionCard.tsx
@@ -1,4 +1,4 @@
-import { CustomLink } from '@/components/CustomLink'
+import { Card } from '@/components/Card'
 import { type HeadingProps, Heading } from '@/components/Heading'
 
 import { type CTAProps } from '@/types/sharedProps/ctaType'
@@ -20,14 +20,7 @@ export function HomeExploreSectionCard({
         <Heading {...heading} />
         <p>{children}</p>
       </div>
-      <CustomLink
-        href={cta.href}
-        className="absolute inset-0 rounded-lg focus:outline-2 focus:outline-brand-100"
-      >
-        <span className="absolute bottom-4 left-4 text-brand-300">
-          {cta.text}
-        </span>
-      </CustomLink>
+      <Card.Link {...cta} />
     </div>
   )
 }


### PR DESCRIPTION
## Changes
- this PR includes refactoring to `GovernanceCalendarCards` component to make the whole card clickable, not just the link.


## Visuals


https://github.com/FilecoinFoundationWeb/filecoin-foundation/assets/50910606/5c3d5761-465d-485d-98b9-6aa6b9cd1c42

