### PR TITLE
Remove Validation Checks for Populated Fields

### DIFF
--- a/src/app/_utils/validateFrontMatter.ts
+++ b/src/app/_utils/validateFrontMatter.ts
@@ -4,15 +4,8 @@ export function validateFrontMatter(
   data: any,
   fields: CMSFieldConfig[],
 ): boolean {
-  const missingFieldsToSkipCheck: string[] = [
-    'body',
-    'categories',
-    'category',
-    'location',
-    'seo',
-    'subcategories',
-  ]
-  const extraFieldsToSkipCheck: string[] = ['slug', 'metadata']
+  const missingFieldsToSkipCheck: string[] = ['body', 'location']
+  const extraFieldsToSkipCheck: string[] = ['slug']
 
   const missingFields: string[] = fields
     .filter(


### PR DESCRIPTION
These fields were previously excluded from validation checks because we still hadn't populated all blog posts, events, and ecosystem projects with these required fields. Now that we have, we can remove them and the the validation function do its job. The only one left to remove will be `location`.