### PR TITLE
Test

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -16,7 +16,7 @@ const nextConfig = {
       '/': [
         '.git/**',
         '.github/**',
-        // '.next/**',
+        '.next/cache/**',
         '.vscode/**',
         'cypress/**',
         'public/**',

--- a/next.config.js
+++ b/next.config.js
@@ -16,7 +16,7 @@ const nextConfig = {
       '/': [
         '.git/**',
         '.github/**',
-        '.next/**',
+        // '.next/**',
         '.vscode/**',
         'cypress/**',
         'public/**',


### PR DESCRIPTION
- Updated `outputFileTracingExcludes` configuration to include `.next/cache/**` instead of `.next/**`
- This change resolves a 500 error encountered when accessing `/blog`, `/events`, and `/ecosystem-projects`
- Needs more research

<img width="600" alt="Screenshot 2024-05-29 at 12 16 59" src="https://github.com/FilecoinFoundationWeb/filecoin-foundation/assets/26620750/925f27e1-3ba0-4e11-8785-3a1158b36a2e">
