### PR TITLE
Card images optimisation

### DIFF
--- a/src/app/_components/BlogPostHeader.tsx
+++ b/src/app/_components/BlogPostHeader.tsx
@@ -44,7 +44,10 @@ export function BlogPostHeader({
             src={image.url}
             alt={image.alt}
             className="rounded-lg object-cover"
-            sizes={buildImageSizeProp({ md: '100vw', fallbackSize: '700px' })}
+            sizes={buildImageSizeProp({
+              startSize: '100vw',
+              md: '680px',
+            })}
           />
         </div>
       ) : (

--- a/src/app/_components/Card.tsx
+++ b/src/app/_components/Card.tsx
@@ -8,15 +8,12 @@ import { Meta, type MetaDataType } from '@/components/Meta'
 
 import { type CTAProps } from '@/types/sharedProps/ctaType'
 
-import { buildImageSizeProp } from '@/utils/buildImageSizeProp'
-
 type CardProps = {
   title: string | React.ReactNode
   tag?: string
   metaData?: MetaDataType
   description?: string
   cta?: CTAProps
-  entryType?: 'blogPost' | 'ecosystemProject'
   image?: DynamicImageProps & { padding?: boolean }
   borderColor?: 'brand-300' | 'brand-400' | 'brand-500' | 'brand-600'
   textIsClamped?: boolean
@@ -28,22 +25,6 @@ const borderStyles = {
   'brand-400': 'border-brand-400',
   'brand-500': 'border-brand-500',
   'brand-600': 'border-brand-600',
-}
-
-const imageSizes = {
-  blogPost: buildImageSizeProp({
-    sm: '320px',
-    md: '584px',
-    lg: '712px',
-    xl: '472px',
-    fallbackSize: '500px',
-  }),
-  ecosystemProject: buildImageSizeProp({
-    sm: '320px',
-    md: '276px',
-    lg: '340px',
-    fallbackSize: '304px',
-  }),
 }
 
 function Link({ href, ariaLabel, icon: Icon, text }: CTAProps) {
@@ -61,6 +42,25 @@ function Link({ href, ariaLabel, icon: Icon, text }: CTAProps) {
   )
 }
 
+function CardImage({ image }: Pick<CardProps, 'image'>) {
+  if (!image) {
+    return null
+  }
+
+  const { padding, fallback, ...rest } = image
+
+  return (
+    <div className={clsx('relative aspect-video', padding && 'mx-4 my-2')}>
+      <DynamicImage
+        {...rest}
+        fill
+        className={imageStyle}
+        fallback={{ ...fallback, className: imageStyle }}
+      />
+    </div>
+  )
+}
+
 const imageStyle = 'rounded-lg px-1 pt-1'
 
 export function Card({
@@ -69,14 +69,11 @@ export function Card({
   metaData,
   description,
   cta,
-  entryType = 'blogPost',
   image,
   borderColor = 'brand-500',
   textIsClamped = false,
   as: Tag = 'li',
 }: CardProps) {
-  const dynamicImageWithPadding = image && image.src && image.padding
-
   return (
     <Tag
       className={clsx(
@@ -84,22 +81,7 @@ export function Card({
         borderStyles[borderColor],
       )}
     >
-      {image && (
-        <div
-          className={clsx(
-            'relative aspect-video',
-            dynamicImageWithPadding && 'mx-6 mt-6',
-          )}
-        >
-          <DynamicImage
-            {...image}
-            fill
-            sizes={imageSizes[entryType]}
-            className={imageStyle}
-            fallback={{ ...image.fallback, className: imageStyle }}
-          />
-        </div>
-      )}
+      <CardImage image={image} />
 
       <div className="flex flex-col p-4">
         {tag && (

--- a/src/app/_components/Card.tsx
+++ b/src/app/_components/Card.tsx
@@ -1,14 +1,12 @@
-import Image from 'next/image'
-
 import clsx from 'clsx'
 
 import { Badge } from '@/components/Badge'
 import { CustomLink } from '@/components/CustomLink'
+import { DynamicImage, type DynamicImageProps } from '@/components/DynamicImage'
 import { Heading } from '@/components/Heading'
 import { Meta, type MetaDataType } from '@/components/Meta'
 
 import { type CTAProps } from '@/types/sharedProps/ctaType'
-import { type ImageProps } from '@/types/sharedProps/imageType'
 
 import { buildImageSizeProp } from '@/utils/buildImageSizeProp'
 
@@ -19,7 +17,7 @@ type CardProps = {
   description?: string
   cta?: CTAProps
   entryType?: 'blogPost' | 'ecosystemProject'
-  image?: ImageProps
+  image?: DynamicImageProps & { padding?: boolean }
   borderColor?: 'brand-300' | 'brand-400' | 'brand-500' | 'brand-600'
   textIsClamped?: boolean
   as?: React.ElementType
@@ -30,11 +28,6 @@ const borderStyles = {
   'brand-400': 'border-brand-400',
   'brand-500': 'border-brand-500',
   'brand-600': 'border-brand-600',
-}
-
-const imageStyles = {
-  blogPost: 'object-cover',
-  ecosystemProject: 'object-contain',
 }
 
 const imageSizes = {
@@ -68,6 +61,8 @@ function Link({ href, ariaLabel, icon: Icon, text }: CTAProps) {
   )
 }
 
+const imageStyle = 'rounded-lg px-1 pt-1'
+
 export function Card({
   title,
   tag,
@@ -80,6 +75,8 @@ export function Card({
   textIsClamped = false,
   as: Tag = 'li',
 }: CardProps) {
+  const dynamicImageWithPadding = image && image.src && image.padding
+
   return (
     <Tag
       className={clsx(
@@ -87,20 +84,23 @@ export function Card({
         borderStyles[borderColor],
       )}
     >
-      {image?.url && (
-        <div className="relative block aspect-video">
-          <Image
+      {image && (
+        <div
+          className={clsx(
+            'relative aspect-video',
+            dynamicImageWithPadding && 'mx-6 mt-6',
+          )}
+        >
+          <DynamicImage
+            {...image}
             fill
-            src={image.url}
-            alt={image.alt}
             sizes={imageSizes[entryType]}
-            className={clsx(
-              'block rounded-lg px-1 pt-1',
-              imageStyles[entryType],
-            )}
+            className={imageStyle}
+            fallback={{ ...image.fallback, className: imageStyle }}
           />
         </div>
       )}
+
       <div className="flex flex-col p-4">
         {tag && (
           <span className="mb-4">

--- a/src/app/_components/Card.tsx
+++ b/src/app/_components/Card.tsx
@@ -42,6 +42,8 @@ function Link({ href, ariaLabel, icon: Icon, text }: CTAProps) {
   )
 }
 
+const imageStyle = 'rounded-lg px-1 pt-1'
+
 function CardImage({ image }: Pick<CardProps, 'image'>) {
   if (!image) {
     return null
@@ -60,8 +62,6 @@ function CardImage({ image }: Pick<CardProps, 'image'>) {
     </div>
   )
 }
-
-const imageStyle = 'rounded-lg px-1 pt-1'
 
 export function Card({
   title,

--- a/src/app/_components/DynamicImage.tsx
+++ b/src/app/_components/DynamicImage.tsx
@@ -4,11 +4,13 @@ import clsx from 'clsx'
 
 import { StaticImage, type StaticImageProps } from '@/components/StaticImage'
 
+import { ImageObjectFit } from '@/types/sharedProps/imageType'
+
 export type DynamicImageProps = {
   src: string
   fallback: StaticImageProps
-  objectFit?: 'contain' | 'cover'
-} & Omit<ImageProps, 'objectFit'>
+} & ImageObjectFit &
+  Omit<ImageProps, 'objectFit'>
 
 export function DynamicImage({
   src,

--- a/src/app/_components/FeaturedBlogPosts.tsx
+++ b/src/app/_components/FeaturedBlogPosts.tsx
@@ -1,11 +1,13 @@
 import { Card } from '@/components/Card'
 import { CardGrid } from '@/components/CardGrid'
 
+import { buildImageSizeProp } from '@/utils/buildImageSizeProp'
 import { getBlogPostsData } from '@/utils/getBlogPostData'
 import { getMetaData } from '@/utils/getMetaData'
 
 import { sortEntriesByDate } from '@/_utils/sortEntriesByDate'
 import { PATHS } from '@/constants/paths'
+import { graphicsData } from '@/data/graphicsData'
 
 const blogPosts = getBlogPostsData()
 const MAX_POSTS = 4
@@ -33,11 +35,20 @@ export function FeaturedBlogPosts() {
             tag={category}
             title={title}
             description={description}
-            image={image}
             textIsClamped={true}
             cta={{
               href: `${PATHS.BLOG.path}/${slug}`,
               text: 'Learn More',
+            }}
+            image={{
+              src: image.url,
+              alt: image.alt,
+              fallback: graphicsData.imageFallback,
+              sizes: buildImageSizeProp({
+                startSize: '100vw',
+                sm: '350px',
+                md: '480px',
+              }),
             }}
           />
         ),

--- a/src/app/_components/FeaturedEcosystemProjects.tsx
+++ b/src/app/_components/FeaturedEcosystemProjects.tsx
@@ -5,7 +5,10 @@ import { CardGrid } from '@/components/CardGrid'
 
 import { EcosystemProjectData } from '@/types/ecosystemProjectTypes'
 
+import { buildImageSizeProp } from '@/utils/buildImageSizeProp'
+
 import { PATHS } from '@/constants/paths'
+import { graphicsData } from '@/data/graphicsData'
 
 type FeaturedEcosystemProjectsProps = {
   ecosystemProjects: EcosystemProjectData[]
@@ -25,14 +28,25 @@ export function FeaturedEcosystemProjects({
           key={slug}
           title={title}
           description={description}
-          entryType="ecosystemProject"
-          image={image}
           borderColor="brand-300"
           textIsClamped={true}
           cta={{
             href: `${PATHS.ECOSYSTEM.path}/${slug}`,
             text: 'Learn More',
             icon: MagnifyingGlass,
+          }}
+          image={{
+            src: image.url,
+            alt: image.alt,
+            fallback: graphicsData.imageFallback,
+            padding: true,
+            objectFit: 'contain',
+            sizes: buildImageSizeProp({
+              startSize: '100vw',
+              sm: '320px',
+              md: '440px',
+              lg: '280px',
+            }),
           }}
         />
       ))}

--- a/src/app/_components/FeaturedGrantGraduates.tsx
+++ b/src/app/_components/FeaturedGrantGraduates.tsx
@@ -5,7 +5,10 @@ import { CardGrid } from '@/components/CardGrid'
 
 import { EcosystemProjectData } from '@/types/ecosystemProjectTypes'
 
+import { buildImageSizeProp } from '@/utils/buildImageSizeProp'
+
 import { PATHS } from '@/constants/paths'
+import { graphicsData } from '@/data/graphicsData'
 
 type FeaturedGrantsGraduatesProps = {
   grantGraduates: EcosystemProjectData[]
@@ -26,11 +29,22 @@ export function FeaturedGrantsGraduates({
           title={title}
           description={description}
           textIsClamped={true}
-          image={image}
           cta={{
             href: `${PATHS.ECOSYSTEM.path}/${slug}`,
             text: 'Read More',
             icon: BookOpen,
+          }}
+          image={{
+            src: image.url,
+            alt: image.alt,
+            fallback: graphicsData.imageFallback,
+            objectFit: 'contain',
+            padding: true,
+            sizes: buildImageSizeProp({
+              startSize: '100vw',
+              sm: '175px',
+              md: '250px',
+            }),
           }}
         />
       ))}

--- a/src/app/_components/FocusAreaCard.tsx
+++ b/src/app/_components/FocusAreaCard.tsx
@@ -20,10 +20,9 @@ export function FocusAreaCard({
         {...image}
         className="aspect-video w-full rounded object-cover sm:w-60 md:w-80 lg:w-full"
         sizes={buildImageSizeProp({
-          sm: '100vw',
-          md: '250px',
-          lg: '320px',
-          fallbackSize: '300px',
+          startSize: '100vw',
+          sm: '240px',
+          md: '320px',
         })}
       />
 

--- a/src/app/_components/KeyMemberCard.tsx
+++ b/src/app/_components/KeyMemberCard.tsx
@@ -1,9 +1,8 @@
-import Image from 'next/image'
-
 import { LinkedinLogo } from '@phosphor-icons/react/dist/ssr'
 
 import { Heading } from '@/components/Heading'
 import { Icon } from '@/components/Icon'
+import { StaticImage } from '@/components/StaticImage'
 import { TextLink } from '@/components/TextLink'
 
 import type { MemberData } from '@/types/memberType'
@@ -18,10 +17,10 @@ export function KeyMemberCard({
 }: KeyMemberCardProps) {
   return (
     <li className="relative flex rounded-lg border border-brand-500 p-1">
-      <Image
-        src={image}
+      <StaticImage
+        data={image}
         alt={`Photo of ${name}`}
-        sizes="128px"
+        sizes="150px"
         className="aspect-[3/4] w-32 rounded object-cover"
       />
 

--- a/src/app/_components/PageHeader.tsx
+++ b/src/app/_components/PageHeader.tsx
@@ -41,6 +41,43 @@ function Title({ children }: TitleProps) {
   )
 }
 
+function PageHeaderImage({ image }: Pick<PageHeaderProps, 'image'>) {
+  const { type, ...rest } = image
+
+  if (type === 'static') {
+    const staticImage = rest as StaticImageProps
+
+    return (
+      <div className={sharedContainerStyle}>
+        <StaticImage
+          {...staticImage}
+          priority
+          quality={100}
+          className={sharedImageStyle}
+        />
+      </div>
+    )
+  }
+
+  if (type === 'dynamic') {
+    const dynamicImage = rest as DynamicImageProps
+
+    return (
+      <div className={clsx('relative', sharedContainerStyle)}>
+        <DynamicImage
+          {...dynamicImage}
+          fill
+          priority
+          quality={100}
+          className={sharedImageStyle}
+          fallback={{ ...dynamicImage.fallback, className: sharedImageStyle }}
+          sizes={buildImageSizeProp({ startSize: '100vw', lg: '480px' })}
+        />
+      </div>
+    )
+  }
+}
+
 export function PageHeader({
   title,
   description,
@@ -84,33 +121,7 @@ export function PageHeader({
           </div>
         </div>
 
-        {image.type === 'static' && (
-          <div className={sharedContainerStyle}>
-            <StaticImage
-              {...image}
-              priority
-              quality={100}
-              className={sharedImageStyle}
-            />
-          </div>
-        )}
-
-        {image.type === 'dynamic' && (
-          <div className={clsx('relative', sharedContainerStyle)}>
-            <DynamicImage
-              {...image}
-              fill
-              priority
-              quality={100}
-              className={sharedImageStyle}
-              fallback={{ ...image.fallback, className: sharedImageStyle }}
-              sizes={buildImageSizeProp({
-                lg: '100vw',
-                fallbackSize: '50vw',
-              })}
-            />
-          </div>
-        )}
+        <PageHeaderImage image={image} />
       </div>
     </header>
   )

--- a/src/app/_components/StaticImage.tsx
+++ b/src/app/_components/StaticImage.tsx
@@ -2,10 +2,12 @@ import Image, { type StaticImageData, type ImageProps } from 'next/image'
 
 import clsx from 'clsx'
 
+import { ImageObjectFit } from '@/types/sharedProps/imageType'
+
 export type StaticImageProps = {
   data: StaticImageData
-  objectFit?: 'contain' | 'cover'
-} & Omit<ImageProps, 'src' | keyof StaticImageData>
+} & ImageObjectFit &
+  Omit<ImageProps, 'src' | keyof StaticImageData>
 
 export function StaticImage({
   data,

--- a/src/app/_types/sharedProps/imageType.ts
+++ b/src/app/_types/sharedProps/imageType.ts
@@ -2,3 +2,7 @@ export type ImageProps = {
   url: string
   alt: string
 }
+
+export type ImageObjectFit = {
+  objectFit?: 'contain' | 'cover'
+}

--- a/src/app/_utils/buildImageSizeProp.ts
+++ b/src/app/_utils/buildImageSizeProp.ts
@@ -5,7 +5,7 @@ const screens = theme.screens
 type Breakpoint = keyof typeof screens
 
 type Width = `${number}px` | `${number}vw`
-type Args = Partial<Record<Breakpoint, Width>> & { fallbackSize: Width }
+type Args = { startSize: Width } & Partial<Record<Breakpoint, Width>>
 
 function getScreenWidthNumber(screenSize: Breakpoint) {
   const widthAsString = screens[screenSize].replace('px', '')
@@ -15,7 +15,7 @@ function getScreenWidthNumber(screenSize: Breakpoint) {
 }
 
 export function buildImageSizeProp(args: Args) {
-  const { fallbackSize, ...breakpointWidthPairs } = args
+  const { startSize, ...breakpointWidthPairs } = args
 
   const breakpointWidthPairsArray = Object.entries(
     breakpointWidthPairs,
@@ -35,11 +35,11 @@ export function buildImageSizeProp(args: Args) {
   const mediaQueriesArray = sortedBreakpointWidthPairsArray.map(
     ([screen, width]) => {
       const screenWidthNumber = getScreenWidthNumber(screen)
-      const mediaQuery = `(max-width: ${screenWidthNumber - 1}px)`
+      const mediaQuery = `(min-width: ${screenWidthNumber}px)`
 
       return `${mediaQuery} ${width}`
     },
   )
 
-  return `${mediaQueriesArray.join(', ')}, ${fallbackSize}`
+  return `${mediaQueriesArray.join(', ')}, ${startSize}`
 }

--- a/src/app/blog/page.tsx
+++ b/src/app/blog/page.tsx
@@ -143,7 +143,7 @@ export default function Blog({ searchParams }: Props) {
               ) : (
                 <>
                   <CardGrid cols="smTwo">
-                    {paginatedResults.map((post) => {
+                    {paginatedResults.map((post, i) => {
                       const {
                         slug,
                         category,
@@ -153,19 +153,26 @@ export default function Blog({ searchParams }: Props) {
                         publishedOn,
                       } = post
 
+                      const isFirstTwo = i < 2
+
                       return (
                         <Card
                           key={slug}
                           tag={category}
                           title={title}
                           description={description}
-                          image={image}
                           textIsClamped={true}
                           metaData={getMetaData(publishedOn)}
                           cta={{
                             href: `${PATHS.BLOG.path}/${slug}`,
                             text: 'Read Post',
                             icon: BookOpen,
+                          }}
+                          image={{
+                            src: image.url,
+                            alt: image.alt,
+                            fallback: graphicsData.imageFallback,
+                            priority: isFirstTwo,
                           }}
                         />
                       )

--- a/src/app/blog/page.tsx
+++ b/src/app/blog/page.tsx
@@ -22,6 +22,7 @@ import { StructuredDataScript } from '@/components/StructuredDataScript'
 
 import { type NextServerSearchParams } from '@/types/searchParams'
 
+import { buildImageSizeProp } from '@/utils/buildImageSizeProp'
 import { getCategorySettings } from '@/utils/categoryUtils'
 import { createMetadata } from '@/utils/createMetadata'
 import { getBlogPostsData } from '@/utils/getBlogPostData'
@@ -153,7 +154,7 @@ export default function Blog({ searchParams }: Props) {
                         publishedOn,
                       } = post
 
-                      const isFirstTwo = i < 2
+                      const isFirstTwoImages = i < 2
 
                       return (
                         <Card
@@ -172,7 +173,13 @@ export default function Blog({ searchParams }: Props) {
                             src: image.url,
                             alt: image.alt,
                             fallback: graphicsData.imageFallback,
-                            priority: isFirstTwo,
+                            priority: isFirstTwoImages,
+                            sizes: buildImageSizeProp({
+                              startSize: '100vw',
+                              sm: '350px',
+                              md: '470px',
+                              lg: '360px',
+                            }),
                           }}
                         />
                       )

--- a/src/app/ecosystem/[slug]/page.tsx
+++ b/src/app/ecosystem/[slug]/page.tsx
@@ -83,15 +83,15 @@ export default function EcosystemProject({ params }: EcosystemProjectProps) {
                 alt={image.alt}
                 className="object-contain object-left-bottom"
                 sizes={buildImageSizeProp({
-                  sm: '100vw',
-                  lg: '50vw',
-                  xl: '700px',
-                  fallbackSize: '600px',
+                  startSize: '100vw',
+                  md: '730px',
+                  lg: '660px',
+                  xl: '600px',
                 })}
               />
             </div>
           ) : (
-            <StaticImage priority {...graphicsData.logoFallback} />
+            <StaticImage priority {...graphicsData.imageFallback} />
           )}
         </header>
 

--- a/src/app/ecosystem/page.tsx
+++ b/src/app/ecosystem/page.tsx
@@ -150,22 +150,31 @@ export default function Ecosystem({ searchParams }: Props) {
               ) : (
                 <>
                   <CardGrid cols="smTwo">
-                    {paginatedResults.map((project) => {
+                    {paginatedResults.map((project, i) => {
                       const { slug, title, description, image, category } =
                         project
+
+                      const isFirstTwo = i < 2
 
                       return (
                         <Card
                           key={slug}
                           title={title}
                           description={description}
-                          image={image}
                           tag={categoryData[category]}
                           entryType="ecosystemProject"
                           cta={{
                             href: `${PATHS.ECOSYSTEM.path}/${slug}`,
                             text: 'Learn More',
                             icon: BookOpen,
+                          }}
+                          image={{
+                            src: image.url,
+                            alt: image.alt,
+                            padding: true,
+                            priority: isFirstTwo,
+                            objectFit: 'contain',
+                            fallback: graphicsData.logoFallback,
                           }}
                         />
                       )

--- a/src/app/ecosystem/page.tsx
+++ b/src/app/ecosystem/page.tsx
@@ -23,6 +23,7 @@ import { StructuredDataScript } from '@/components/StructuredDataScript'
 
 import { NextServerSearchParams } from '@/types/searchParams'
 
+import { buildImageSizeProp } from '@/utils/buildImageSizeProp'
 import {
   getCategoryDataFromDirectory,
   getCategorySettingsFromMap,
@@ -154,7 +155,7 @@ export default function Ecosystem({ searchParams }: Props) {
                       const { slug, title, description, image, category } =
                         project
 
-                      const isFirstTwo = i < 2
+                      const isFirstTwoImages = i < 2
 
                       return (
                         <Card
@@ -162,7 +163,6 @@ export default function Ecosystem({ searchParams }: Props) {
                           title={title}
                           description={description}
                           tag={categoryData[category]}
-                          entryType="ecosystemProject"
                           cta={{
                             href: `${PATHS.ECOSYSTEM.path}/${slug}`,
                             text: 'Learn More',
@@ -172,9 +172,15 @@ export default function Ecosystem({ searchParams }: Props) {
                             src: image.url,
                             alt: image.alt,
                             padding: true,
-                            priority: isFirstTwo,
+                            priority: isFirstTwoImages,
                             objectFit: 'contain',
-                            fallback: graphicsData.logoFallback,
+                            fallback: graphicsData.imageFallback,
+                            sizes: buildImageSizeProp({
+                              startSize: '100vw',
+                              sm: '320px',
+                              md: '440px',
+                              lg: '280px',
+                            }),
                           }}
                         />
                       )

--- a/src/app/events/page.tsx
+++ b/src/app/events/page.tsx
@@ -175,7 +175,7 @@ export default function Events({ searchParams }: Props) {
               ) : (
                 <>
                   <CardGrid cols="smTwo">
-                    {paginatedResults.map((event) => {
+                    {paginatedResults.map((event, i) => {
                       const {
                         slug,
                         title,
@@ -186,6 +186,7 @@ export default function Events({ searchParams }: Props) {
                       } = event
 
                       const metaData = prepareMetaData(startDate, endDate)
+                      const isFirstTwo = i < 2
 
                       return (
                         <Card
@@ -193,13 +194,19 @@ export default function Events({ searchParams }: Props) {
                           title={title}
                           tag={involvement}
                           metaData={metaData}
-                          image={image}
                           borderColor="brand-400"
                           textIsClamped={true}
                           cta={{
                             href: `${PATHS.EVENTS.path}/${slug}`,
                             text: 'View Event Details',
                             icon: MagnifyingGlass,
+                          }}
+                          image={{
+                            src: image.url,
+                            alt: image.alt,
+                            priority: isFirstTwo,
+                            padding: true,
+                            fallback: graphicsData.imageFallback,
                           }}
                         />
                       )

--- a/src/app/events/page.tsx
+++ b/src/app/events/page.tsx
@@ -186,7 +186,7 @@ export default function Events({ searchParams }: Props) {
                       } = event
 
                       const metaData = prepareMetaData(startDate, endDate)
-                      const isFirstTwo = i < 2
+                      const isFirstTwoImages = i < 2
 
                       return (
                         <Card
@@ -204,9 +204,15 @@ export default function Events({ searchParams }: Props) {
                           image={{
                             src: image.url,
                             alt: image.alt,
-                            priority: isFirstTwo,
+                            priority: isFirstTwoImages,
                             padding: true,
                             fallback: graphicsData.imageFallback,
+                            sizes: buildImageSizeProp({
+                              startSize: '100vw',
+                              sm: '320px',
+                              md: '440px',
+                              lg: '330px',
+                            }),
                           }}
                         />
                       )
@@ -234,7 +240,7 @@ export default function Events({ searchParams }: Props) {
             <StaticImage
               {...graphicsData.events2}
               className="h-full rounded-lg object-cover"
-              sizes={buildImageSizeProp({ md: '50vw', fallbackSize: '100vw' })}
+              sizes={buildImageSizeProp({ startSize: '100vw', md: '480px' })}
             />
           </div>
           {getInvolvedData.map(({ title, description, cta }) => (
@@ -251,7 +257,7 @@ export default function Events({ searchParams }: Props) {
             <StaticImage
               {...graphicsData.events3}
               className="h-full rounded-lg object-cover"
-              sizes={buildImageSizeProp({ md: '100vw', fallbackSize: '50vw' })}
+              sizes={buildImageSizeProp({ startSize: '100vw', md: '480px' })}
             />
           </div>
         </CardGrid>


### PR DESCRIPTION
This PR optimises images in `Card`  and `Card`-related components:

1. `Card` components now use `DynamicImage` or `StaticImage`
2. `Card` components with dynamic images have a `sizes` prop
3. `buildImageSizeProp` now uses `min-width` to match Tailwind media queries and provide a similar developer experience when using breakpoints
4. All fallback images are now the same: We don't use "Logo Coming Soon" anymore, only the one with the Filecoin logo
5. `Card` entries with logo now have some padding, thanks to the `padding` prop
6. Images in `PageHeader` and `Card` are reworked to avoid passing custom non-valid props, such as `padding` or `type`, to the final `Image` (which created warnings in the console)

[Notion](https://www.notion.so/filecoin/FF-V4-IMAGES-Handle-images-in-Card-component-Other-Cards-3a2993d3b62c4955acfd570eee5117f1?pvs=4)