### PR TITLE
Hot Fixes

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -30,6 +30,13 @@ const nextConfig = {
     return [
       {
         source:
+          '/blog/ecosystem-spotlight-ghostdrive%E2%80%99s-secure-decentralized-storage-now-on-mobile',
+        destination:
+          '/blog/ecosystem-spotlight-ghostdrives-secure-decentralized-storage-now-on-mobile',
+        permanent: true,
+      },
+      {
+        source:
           '/blog/guest-post-if-the-library-of-alexandra-were-built-better/',
         destination:
           '/blog/guest-post-if-the-library-of-alexandria-were-built-better',
@@ -118,45 +125,41 @@ const nextConfig = {
 
 module.exports = nextConfig
 
-
 // Injected content via Sentry wizard below
 
-const { withSentryConfig } = require("@sentry/nextjs");
+const { withSentryConfig } = require('@sentry/nextjs')
 
-module.exports = withSentryConfig(
-  module.exports,
-  {
-    // For all available options, see:
-    // https://github.com/getsentry/sentry-webpack-plugin#options
+module.exports = withSentryConfig(module.exports, {
+  // For all available options, see:
+  // https://github.com/getsentry/sentry-webpack-plugin#options
 
-    org: "filecoin-foundation-qk",
-    project: "filecoin-foundation-site",
+  org: 'filecoin-foundation-qk',
+  project: 'filecoin-foundation-site',
 
-    // Only print logs for uploading source maps in CI
-    silent: !process.env.CI,
+  // Only print logs for uploading source maps in CI
+  silent: !process.env.CI,
 
-    // For all available options, see:
-    // https://docs.sentry.io/platforms/javascript/guides/nextjs/manual-setup/
+  // For all available options, see:
+  // https://docs.sentry.io/platforms/javascript/guides/nextjs/manual-setup/
 
-    // Upload a larger set of source maps for prettier stack traces (increases build time)
-    widenClientFileUpload: true,
+  // Upload a larger set of source maps for prettier stack traces (increases build time)
+  widenClientFileUpload: true,
 
-    // Uncomment to route browser requests to Sentry through a Next.js rewrite to circumvent ad-blockers.
-    // This can increase your server load as well as your hosting bill.
-    // Note: Check that the configured route will not match with your Next.js middleware, otherwise reporting of client-
-    // side errors will fail.
-    // tunnelRoute: "/monitoring",
+  // Uncomment to route browser requests to Sentry through a Next.js rewrite to circumvent ad-blockers.
+  // This can increase your server load as well as your hosting bill.
+  // Note: Check that the configured route will not match with your Next.js middleware, otherwise reporting of client-
+  // side errors will fail.
+  // tunnelRoute: "/monitoring",
 
-    // Hides source maps from generated client bundles
-    hideSourceMaps: true,
+  // Hides source maps from generated client bundles
+  hideSourceMaps: true,
 
-    // Automatically tree-shake Sentry logger statements to reduce bundle size
-    disableLogger: true,
+  // Automatically tree-shake Sentry logger statements to reduce bundle size
+  disableLogger: true,
 
-    // Enables automatic instrumentation of Vercel Cron Monitors. (Does not yet work with App Router route handlers.)
-    // See the following for more information:
-    // https://docs.sentry.io/product/crons/
-    // https://vercel.com/docs/cron-jobs
-    automaticVercelMonitors: true,
-  }
-);
+  // Enables automatic instrumentation of Vercel Cron Monitors. (Does not yet work with App Router route handlers.)
+  // See the following for more information:
+  // https://docs.sentry.io/product/crons/
+  // https://vercel.com/docs/cron-jobs
+  automaticVercelMonitors: true,
+})

--- a/src/app/_components/GrantsApplicationProcessCard.tsx
+++ b/src/app/_components/GrantsApplicationProcessCard.tsx
@@ -3,7 +3,7 @@ import { Heading } from '@/components/Heading'
 type GrantsApplicationProcessCardProps = {
   step: number
   title: string
-  description: string
+  description: React.ReactNode
   as?: React.ElementType
 }
 
@@ -33,7 +33,6 @@ export function GrantsApplicationProcessCard({
         <Heading tag="h3" variant="lg">
           {title}
         </Heading>
-
         <p>{description}</p>
       </div>
     </Tag>

--- a/src/app/governance/page.tsx
+++ b/src/app/governance/page.tsx
@@ -34,10 +34,6 @@ export default function Governance() {
         title={header.title}
         description={header.description}
         image={{ type: 'static', ...graphicsData.governance2 }}
-        cta={{
-          href: FILECOIN_FOUNDATION_URLS.governance.docs,
-          text: 'Learn More',
-        }}
       />
 
       <PageSection kicker="Learn More" title="Quickstart">

--- a/src/app/grants/data/applicationProcessData.tsx
+++ b/src/app/grants/data/applicationProcessData.tsx
@@ -1,9 +1,22 @@
+import { TextLink } from '@/components/TextLink'
+
 export const applicationProcessData = [
   {
     step: 1,
     title: 'Submit a Proposal',
-    description:
-      'Create a new issue using the proposal template on GitHub. The Foundation prioritizes projects that make a direct positive impact on the Filecoin ecosystem. ',
+    description: (
+      <>
+        After reviewing the{' '}
+        <TextLink href="https://github.com/filecoin-project/devgrants">
+          grant criteria
+        </TextLink>
+        , create a new issue using the proposal template on{' '}
+        <TextLink href="https://github.com/filecoin-project/devgrants/issues/new/choose">
+          GitHub
+        </TextLink>{' '}
+        .
+      </>
+    ),
   },
   {
     step: 2,
@@ -15,6 +28,6 @@ export const applicationProcessData = [
     step: 3,
     title: 'Agreement and Funding',
     description:
-      'Accepted applications are formalized with an agreement between the Foundation and grant application. Grants are paid out after each project milestone is completed, reviewed, and approved. ',
+      'Accepted applications are formalized with an agreement between Filecoin Foundation and grant application.',
   },
 ]

--- a/src/app/grants/data/opportunitiesData.tsx
+++ b/src/app/grants/data/opportunitiesData.tsx
@@ -4,13 +4,13 @@ export const opportunitiesData = [
   {
     title: 'Open Grants',
     description:
-      'Open Grants support projects that improve Filecoin functionality and enhance network utility and directly contribute to the Foundation’s mission.',
+      "Open Grants support projects that drive the Filecoin ecosystem forward, including projects that enhance the network's utility or improve Filecoin functionality.",
     icon: Coins,
   },
   {
-    title: 'Microgrants',
+    title: 'Documentation Grants',
     description:
-      'Documentation enhancement microgrants are available to support the improvement of existing documentation or the creation of new resources related to the Filecoin network.',
+      'Grants are available to support the creation of new resources related to the Filecoin network or the improvement of existing documentation. Refer to GitHub for more details.',
     icon: Coin,
   },
   {

--- a/src/app/grants/page.tsx
+++ b/src/app/grants/page.tsx
@@ -149,7 +149,11 @@ export default function Grants() {
                 '',
               )}
             </TextLink>{' '}
-            or join our monthly office hours!
+            or join our{' '}
+            <TextLink href="https://calendly.com/filecoin-grants/office-hours-ama?month=2024-06">
+              monthly office hours
+            </TextLink>
+            !
           </>
         }
         cta={{


### PR DESCRIPTION
- Grants Page - Update Copy
- Governance Page - PageHeader - Remove CTA (Docs aren't finished yet.)
- Blog Post - [Ecosystem Spotlight: GhostDrive’s Secure, Decentralized Storage Now on Mobile](http://localhost:3000/blog/ecosystem-spotlight-ghostdrives-secure-decentralized-storage-now-on-mobile) used to have an apostrophe in the slug - Included a redirect