### PR TITLE
Integrate Plausible

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -24,6 +24,7 @@
         "js-yaml": "^4.1.0",
         "netlify-identity-widget": "^1.9.2",
         "next": "^14.2.3",
+        "next-plausible": "^3.12.0",
         "postcss": "^8.4.32",
         "react": "^18",
         "react-dom": "^18",
@@ -14181,6 +14182,19 @@
         "sass": {
           "optional": true
         }
+      }
+    },
+    "node_modules/next-plausible": {
+      "version": "3.12.0",
+      "resolved": "https://registry.npmjs.org/next-plausible/-/next-plausible-3.12.0.tgz",
+      "integrity": "sha512-SSkEqKQ6PgR8fx3sYfIAT69k2xuCUXO5ngkSS19CjxY97lAoZxsfZpYednxB4zo0mHYv87JzhPynrdBPlCBVHg==",
+      "funding": {
+        "url": "https://github.com/4lejandrito/next-plausible?sponsor=1"
+      },
+      "peerDependencies": {
+        "next": "^11.1.0 || ^12.0.0 || ^13.0.0 || ^14.0.0",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0",
+        "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0"
       }
     },
     "node_modules/next/node_modules/postcss": {

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "js-yaml": "^4.1.0",
     "netlify-identity-widget": "^1.9.2",
     "next": "^14.2.3",
+    "next-plausible": "^3.12.0",
     "postcss": "^8.4.32",
     "react": "^18",
     "react-dom": "^18",

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,4 +1,5 @@
 import { Metadata } from 'next'
+import PlausibleProvider from 'next-plausible'
 
 import '@/styles/globals.scss'
 
@@ -19,5 +20,9 @@ export type LayoutProps = {
 }
 
 export default function RootLayout({ children }: LayoutProps) {
-  return <SiteLayout>{children}</SiteLayout>
+  return (
+    <PlausibleProvider domain={BASE_URL}>
+      <SiteLayout>{children}</SiteLayout>
+    </PlausibleProvider>
+  )
 }


### PR DESCRIPTION
This PR integrates Plausible Analytics into our Next.js application using the `next-plausible` library. The `PlausibleProvider` is added to the `RootLayout`, ensuring that the analytics script is loaded across all pages and providing support for custom events tracking.

Following Plausible docs here [>>](https://plausible.io/docs/nextjs-integration)

## Changes

- Added `next-plausible` library to the project.
- Wrapped the `SiteLayout` component with `PlausibleProvider` in `RootLayout`.
- Configured Plausible Analytics to use our domain.

## Benefits

- Site-wide analytics tracking with Plausible.
- Simplified setup by using `PlausibleProvider` at the root level.
- Support for sending custom events easily.

## How to Test

1. Deploy the application.
2. Verify that Plausible Analytics is correctly tracking page views and events by checking the Plausible dashboard for our domain.

