### PR TITLE
Normalise Focus Style

### DIFF
--- a/src/app/_components/BreadCrumbs.tsx
+++ b/src/app/_components/BreadCrumbs.tsx
@@ -28,8 +28,6 @@ export function BreadCrumbs() {
     return label
   }
 
-  const baseStyles = 'hover:underline focus:outline-2 focus:outline-brand-100'
-
   return (
     <nav aria-label="breadcrumbs">
       <ol className="inline-flex items-center gap-2.5">
@@ -39,7 +37,7 @@ export function BreadCrumbs() {
             ? PATHS.HOME.path
             : (('/' + pathNames.slice(1, index + 1).join('/')) as Route)
           const isActive = pathname === href
-          const itemClasses = clsx(baseStyles, {
+          const itemClasses = clsx('focus:brand-outline hover:underline', {
             'text-brand-300': !isActive,
             'text-brand-400': isActive,
           })
@@ -48,11 +46,7 @@ export function BreadCrumbs() {
           return (
             <li key={href} className="inline-flex items-center gap-2.5 ">
               {!isRoot && (
-                <Icon
-                  component={CaretRight}
-                  color="brand-400"
-                  weight="bold"
-                />
+                <Icon component={CaretRight} color="brand-400" weight="bold" />
               )}
               <Link className={itemClasses} href={href}>
                 {label}

--- a/src/app/_components/Button.tsx
+++ b/src/app/_components/Button.tsx
@@ -40,10 +40,11 @@ export function Button({
   children,
   ...rest
 }: ButtonProps) {
-  const baseStyles =
-    'inline-flex items-center justify-center gap-2 rounded-lg border px-9 py-3 font-semibold transition hover:no-underline focus:outline-2 focus:outline-brand-100 sm:whitespace-nowrap'
-
-  className = clsx(baseStyles, variantStyles[variant], className)
+  className = clsx(
+    'focus:brand-outline inline-flex items-center justify-center gap-2 rounded-lg border px-9 py-3 font-semibold transition hover:no-underline sm:whitespace-nowrap',
+    variantStyles[variant],
+    className,
+  )
 
   return typeof rest.href === 'undefined' ? (
     <button className={className} {...rest}>

--- a/src/app/_components/Card.tsx
+++ b/src/app/_components/Card.tsx
@@ -33,7 +33,7 @@ function Link({ href, ariaLabel, icon: Icon, text }: CTAProps) {
     <CustomLink
       href={href}
       aria-label={ariaLabel}
-      className="absolute inset-0 rounded-lg focus:outline-2 focus:outline-brand-100"
+      className="focus:brand-outline absolute inset-0 rounded-lg"
     >
       <span className="absolute bottom-4 left-4 inline-flex items-center gap-2 text-brand-300">
         {Icon && <Icon size={24} />}

--- a/src/app/_components/CategorySelect.tsx
+++ b/src/app/_components/CategorySelect.tsx
@@ -43,7 +43,7 @@ export function CategorySelect({
           <li key={option.id}>
             <button
               className={clsx(
-                'inline-flex cursor-pointer items-baseline gap-2 text-pretty rounded-lg py-2 text-left font-bold hover:bg-brand-700 focus:outline focus:outline-2 focus:outline-brand-100',
+                'focus:brand-outline inline-flex cursor-pointer items-baseline gap-2 text-pretty rounded-lg py-2 text-left font-bold hover:bg-brand-700',
                 touchTarget.class,
                 {
                   'bg-brand-700 text-brand-400': isSelected,

--- a/src/app/_components/DesktopNavigation.tsx
+++ b/src/app/_components/DesktopNavigation.tsx
@@ -36,8 +36,7 @@ function SubNavItem({
 }: SubNavItemProps) {
   const external = linkType !== 'internal'
 
-  const baseStyles =
-    'group w-full rounded-lg focus:outline focus:outline-2 focus:outline-brand-100'
+  const baseStyles = 'focus:brand-outline group w-full rounded-lg'
   const extendedStyles = {
     internal: 'inline-block bg-brand-800 p-4 hover:bg-brand-700',
     externalPrimary:
@@ -77,7 +76,7 @@ const touchTargetMainNavItem = {
 
 function getMainNavItemStyles(isActive: boolean, isPopover = false) {
   const baseStyles =
-    'rounded-xl py-1.5 text-base hover:bg-brand-700 focus:outline focus:outline-2 focus:outline-brand-100'
+    'focus:brand-outline rounded-xl py-1.5 text-base hover:bg-brand-700'
 
   const extendedStyles = isPopover
     ? 'inline-flex items-center gap-2 pl-4 pr-3 ui-open:bg-brand-700 ui-open:text-brand-400'

--- a/src/app/_components/KeyMemberCard.tsx
+++ b/src/app/_components/KeyMemberCard.tsx
@@ -34,7 +34,7 @@ export function KeyMemberCard({
         <TextLink
           href={linkedin}
           aria-label={`Visit ${name}'s LinkedIn profile.`}
-          className="absolute inset-0 rounded-lg focus:outline focus:outline-2 focus:outline-brand-100"
+          className="focus:brand-outline absolute inset-0 rounded-lg"
         >
           <span className="absolute bottom-4 left-36 flex items-center gap-2 text-brand-300">
             <Icon component={LinkedinLogo} />

--- a/src/app/_components/ListboxButton.tsx
+++ b/src/app/_components/ListboxButton.tsx
@@ -18,7 +18,7 @@ export function ListboxButton({
       aria-haspopup="listbox"
       aria-expanded={open}
       aria-label={ariaLabel}
-      className="border-1 focus:brand-outline inline-flex w-full items-center justify-between gap-2 rounded-lg border border-brand-300 p-3 text-brand-300 hover:border-current hover:text-brand-400 md:min-w-40"
+      className="focus:brand-outline inline-flex w-full items-center justify-between gap-2 rounded-lg border border-brand-300 p-3 text-brand-300 hover:border-current hover:text-brand-400 md:min-w-40"
     >
       {children}
     </Listbox.Button>

--- a/src/app/_components/ListboxButton.tsx
+++ b/src/app/_components/ListboxButton.tsx
@@ -18,7 +18,7 @@ export function ListboxButton({
       aria-haspopup="listbox"
       aria-expanded={open}
       aria-label={ariaLabel}
-      className="border-1 inline-flex w-full items-center justify-between gap-2 rounded-lg border border-brand-300 p-3 text-brand-300 hover:border-current hover:text-brand-400 focus:outline-2 focus:outline-brand-100 md:min-w-40"
+      className="border-1 focus:brand-outline inline-flex w-full items-center justify-between gap-2 rounded-lg border border-brand-300 p-3 text-brand-300 hover:border-current hover:text-brand-400 md:min-w-40"
     >
       {children}
     </Listbox.Button>

--- a/src/app/_components/ListboxOption.tsx
+++ b/src/app/_components/ListboxOption.tsx
@@ -36,11 +36,15 @@ export function ListboxOption({ option, counts }: ListboxOptionProps) {
         <li
           className={clsx(
             'flex cursor-default items-center justify-between gap-12 px-5 py-2',
-            { 'bg-brand-700': active, 'bg-transparent': !active },
+            { 'bg-brand-500': active, 'bg-transparent': !active },
           )}
         >
           <OptionContent option={option} counts={counts} />
-          {selected && <Icon component={Check} size={20} />}
+          {selected && (
+            <span className="mb-px">
+              <Icon component={Check} size={20} />
+            </span>
+          )}
         </li>
       )}
     </Listbox.Option>

--- a/src/app/_components/ListboxOptions.tsx
+++ b/src/app/_components/ListboxOptions.tsx
@@ -16,7 +16,7 @@ export function ListboxOptions({
     <Listbox.Options
       aria-labelledby="listbox-button"
       className={clsx(
-        'focus:brand-outline absolute z-10 mt-2 overflow-hidden rounded-lg border border-brand-100 bg-brand-800 py-1 text-brand-100 focus-within:outline-2',
+        'focus:brand-outline absolute z-10 mt-2 overflow-hidden rounded-lg border border-brand-100 bg-brand-800 py-2 text-brand-100 focus-within:outline-2',
         positionClass,
       )}
     >

--- a/src/app/_components/ListboxOptions.tsx
+++ b/src/app/_components/ListboxOptions.tsx
@@ -16,7 +16,7 @@ export function ListboxOptions({
     <Listbox.Options
       aria-labelledby="listbox-button"
       className={clsx(
-        'absolute z-10 mt-2 overflow-hidden rounded-lg border border-brand-100 bg-brand-800 py-1 text-brand-100 focus-within:outline-2 focus:outline-2 focus:outline-brand-100',
+        'focus:brand-outline absolute z-10 mt-2 overflow-hidden rounded-lg border border-brand-100 bg-brand-800 py-1 text-brand-100 focus-within:outline-2',
         positionClass,
       )}
     >

--- a/src/app/_components/MobileNavigation.tsx
+++ b/src/app/_components/MobileNavigation.tsx
@@ -29,7 +29,7 @@ function IconButton({ icon: IconComponent, label, onClick }: IconButtonProps) {
   return (
     <button
       aria-label={label}
-      className="grid size-12 place-items-center rounded-lg border border-brand-300 text-brand-300 focus:outline-2 focus:outline-brand-100"
+      className="focus:brand-outline grid size-12 place-items-center rounded-lg border border-brand-300 text-brand-300"
       onClick={onClick}
     >
       <Icon component={IconComponent} />
@@ -106,7 +106,7 @@ export function MobileNavigation() {
         <div className="flex flex-col gap-12 px-6 py-8">
           <div className="flex items-center justify-between">
             <Link
-              className="flex-shrink-0 outline-white focus:outline-2"
+              className="focus:brand-outline flex-shrink-0"
               href={PATHS.HOME.path}
               aria-label="Go to homepage"
               onClick={() => setOpen(false)}

--- a/src/app/_components/Navigation.tsx
+++ b/src/app/_components/Navigation.tsx
@@ -10,7 +10,7 @@ export function Navigation() {
   return (
     <nav className="mb-6 flex justify-between gap-12 lg:items-center">
       <Link
-        className="flex-shrink-0 outline-white focus:outline-2"
+        className="focus:brand-outline flex-shrink-0"
         href={PATHS.HOME.path}
         aria-label="Go to homepage"
       >

--- a/src/app/_components/ResultsAndReset.tsx
+++ b/src/app/_components/ResultsAndReset.tsx
@@ -18,7 +18,7 @@ export function ResultsAndReset({ results }: ResultsAndResetProps) {
         </span>
       </span>
       <button
-        className="inline-flex whitespace-nowrap font-bold text-brand-300 underline focus:outline focus:outline-2 focus:outline-brand-100"
+        className="focus:brand-outline inline-flex whitespace-nowrap font-bold text-brand-300 underline"
         onClick={resetSearchParams}
       >
         Reset Filters

--- a/src/app/_components/SearchInput.tsx
+++ b/src/app/_components/SearchInput.tsx
@@ -22,7 +22,7 @@ export function SearchInput({
         <input
           id="search"
           name="search"
-          className="peer block w-full rounded-lg border border-brand-300 bg-brand-800 py-3 pl-10 pr-3 placeholder:text-brand-300 hover:border-brand-400 placeholder:hover:text-brand-400 focus:border-transparent focus:text-brand-100 focus:outline-none focus:ring-2 focus:ring-inset focus:ring-brand-100 placeholder:focus:text-brand-100"
+          className="focus:brand-outline peer block w-full rounded-lg border border-brand-300 bg-brand-800 py-3 pl-10 pr-3 placeholder:text-brand-300 hover:border-brand-400 placeholder:hover:text-brand-400 focus:text-brand-100 placeholder:focus:text-brand-100"
           placeholder="Search"
           type="search"
           value={searchQuery}

--- a/src/app/_components/Social.tsx
+++ b/src/app/_components/Social.tsx
@@ -25,7 +25,7 @@ export function Social() {
               rel="noopener noreferrer"
               title={label}
               className={clsx(
-                'text-brand-100 outline-white hover:text-brand-400 focus:outline-2',
+                'focus:brand-outline text-brand-100 hover:text-brand-400',
                 touchTarget.class,
               )}
             >

--- a/src/app/_components/TextLink.tsx
+++ b/src/app/_components/TextLink.tsx
@@ -8,7 +8,8 @@ type TextLinkProps = {
   children: React.ReactNode
 } & React.AnchorHTMLAttributes<HTMLAnchorElement>
 
-export const linkBaseStyles = `text-brand-300 hover:underline focus:outline-2 focus:outline-brand-100`
+export const linkBaseStyles =
+  'focus:brand-outline text-brand-300 hover:underline'
 
 export function TextLink({
   href,
@@ -16,10 +17,12 @@ export function TextLink({
   children,
   ...rest
 }: TextLinkProps) {
-  className = clsx(linkBaseStyles, className)
-
   return (
-    <CustomLink href={href} className={className} {...rest}>
+    <CustomLink
+      href={href}
+      className={clsx(linkBaseStyles, className)}
+      {...rest}
+    >
       {children}
     </CustomLink>
   )

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,3 +1,5 @@
+const plugin = require('tailwindcss/plugin')
+
 /** @type {import('tailwindcss').Config} */
 module.exports = {
   content: ['./src/**/**/*.{js,ts,jsx,tsx,mdx}'],
@@ -84,5 +86,14 @@ module.exports = {
   plugins: [
     require('@tailwindcss/typography'),
     require('@headlessui/tailwindcss'),
+    plugin(function addBrandOutline({ addComponents, theme }) {
+      addComponents({
+        '.brand-outline': {
+          outlineStyle: 'solid',
+          outlineColor: theme('colors.brand.100'),
+          outlineWidth: 2,
+        },
+      })
+    }),
   ],
 }

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -92,6 +92,7 @@ module.exports = {
           outlineStyle: 'solid',
           outlineColor: theme('colors.brand.100'),
           outlineWidth: 2,
+          outlineOffset: 0,
         },
       })
     }),

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -93,6 +93,7 @@ module.exports = {
           outlineColor: theme('colors.brand.100'),
           outlineWidth: 2,
           outlineOffset: 0,
+          borderColor: 'transparent',
         },
       })
     }),


### PR DESCRIPTION
This PR normalises focus styles on all keyboard-accessible elements. On Firefox, the user agent's focus styles conflicted with ours.

I created a `brand-outline` class via `tailwind.config.js`.

This class is applied to all relevant elements as such `focus:brand-outline`, instead of `focus:outline focus:outline-2 focus:outline-brand-100`



Before
![CleanShot 2024-06-12 at 16 01 05](https://github.com/FilecoinFoundationWeb/filecoin-foundation/assets/20277959/3b0ae97d-fdaa-4c79-a9f0-9f5173a9b6b5)

After
![CleanShot 2024-06-12 at 16 01 42](https://github.com/FilecoinFoundationWeb/filecoin-foundation/assets/20277959/e56f0aa4-db56-437a-bb12-16de4009b194)
