### PR TITLE
Event Page: add location to event cards

### DIFF
--- a/src/app/_components/Card.tsx
+++ b/src/app/_components/Card.tsx
@@ -112,7 +112,7 @@ export function Card({
         )}
 
         {metaData && metaData.length > 0 && (
-          <span className="mb-2">
+          <span className="mb-3">
             <Meta metaData={metaData} />
           </span>
         )}

--- a/src/app/_components/Meta.tsx
+++ b/src/app/_components/Meta.tsx
@@ -14,7 +14,7 @@ export function Meta({ metaData }: MetaProps) {
   }
 
   return (
-    <div className="flex gap-3 text-brand-300">
+    <div className="flex flex-wrap gap-2 text-brand-300">
       {metaData.filter(Boolean).map((data, index) => {
         const isNotLastItem = index < metaData.length - 1
         const isNotFirstItem = index > 0

--- a/src/app/_components/Meta.tsx
+++ b/src/app/_components/Meta.tsx
@@ -14,7 +14,7 @@ export function Meta({ metaData }: MetaProps) {
   }
 
   return (
-    <div className="flex flex-wrap gap-2 text-brand-300">
+    <div className="flex flex-wrap gap-x-2 gap-y-1 text-brand-300">
       {metaData.filter(Boolean).map((data, index) => {
         const isNotLastItem = index < metaData.length - 1
         const isNotFirstItem = index > 0

--- a/src/app/_utils/getMetaData.ts
+++ b/src/app/_utils/getMetaData.ts
@@ -8,7 +8,7 @@ export function getBlogPostMetaData(publishedOn?: BlogPostData['publishedOn']) {
 }
 
 export function getEventMetaData(event: EventData) {
-  if (!event.startDate && !event.location) {
+  if (!event.startDate) {
     return []
   }
 

--- a/src/app/events/page.tsx
+++ b/src/app/events/page.tsx
@@ -21,13 +21,11 @@ import { Sort } from '@/components/Sort'
 import { StaticImage } from '@/components/StaticImage'
 import { StructuredDataScript } from '@/components/StructuredDataScript'
 
-import { EventData } from '@/types/eventTypes'
 import { NextServerSearchParams } from '@/types/searchParams'
 
 import { buildImageSizeProp } from '@/utils/buildImageSizeProp'
 import { getCategorySettings } from '@/utils/categoryUtils'
 import { createMetadata } from '@/utils/createMetadata'
-import { formatDate } from '@/utils/formatDate'
 import { getEventsData } from '@/utils/getEventData'
 import { getEventMetaData } from '@/utils/getMetaData'
 

--- a/src/app/events/page.tsx
+++ b/src/app/events/page.tsx
@@ -61,20 +61,6 @@ export const metadata = createMetadata({
   useAbsoluteTitle: true,
 })
 
-function prepareMetaData(
-  startDate: EventData['startDate'],
-  endDate: EventData['endDate'],
-) {
-  const formattedStartDate = startDate && formatDate(startDate)
-  const formattedEndDate = endDate && formatDate(endDate)
-
-  if (formattedStartDate && formattedEndDate) {
-    return [`${formattedStartDate} – ${formattedEndDate}`]
-  }
-
-  return [formattedStartDate]
-}
-
 export default function Events({ searchParams }: Props) {
   if (!featuredEvent) {
     throw new Error('Featured event not found')
@@ -169,13 +155,10 @@ export default function Events({ searchParams }: Props) {
                         title,
                         image,
                         involvement,
-                        startDate,
-                        endDate,
                         description,
                         externalLink,
                       } = event
 
-                      const metaData = prepareMetaData(startDate, endDate)
                       const isFirstTwoImages = i < 2
                       const shouldLinkToExternalEventsPage =
                         !description && externalLink
@@ -185,7 +168,7 @@ export default function Events({ searchParams }: Props) {
                           key={slug}
                           title={title}
                           tag={getInvolvementLabel(involvement)}
-                          metaData={metaData}
+                          metaData={getEventMetaData(event)}
                           borderColor="brand-400"
                           textIsClamped={true}
                           cta={{


### PR DESCRIPTION
## Note
- when the text wraps in a new line, the spacing between the `date` and `location` is `8px` (see left card below). It's because we use `flex` with `gap:2`. However, the design in Figma indicates `4px` gap between date and location (when wrapped). Didn't find an elegant solution - only hacky ones with negative margins, but honestly don't think it looks bad visually, I will double check with Filipa if it's ok with her if we leave `8px` gap everywhere. -> [Slack convo here](https://filecoinfoundation.slack.com/archives/C04HCHS4RRS/p1718267296396529)

## Visuals
<img width="769" alt="Screenshot 2024-06-12 at 15 53 22" src="https://github.com/FilecoinFoundationWeb/filecoin-foundation/assets/50910606/3ea41e9b-6794-419d-8810-636ccdc666b3">
