### PR TITLE
Hide result numbers on explorer page

### DIFF
--- a/src/app/_components/Category.tsx
+++ b/src/app/_components/Category.tsx
@@ -8,14 +8,14 @@ import { useUpdateSearchParams } from '@/hooks/useUpdateSearchParams'
 import { CategoryListbox } from '@/components/CategoryListbox'
 import { CategorySelect } from '@/components/CategorySelect'
 
-import { CategorySetting, type CategoryOption } from '@/types/categoryTypes'
+import type { CategorySetting, CategoryOption } from '@/types/categoryTypes'
 
 import { CATEGORY_KEY } from '@/constants/searchParams'
 
 type CategoryProps = {
   query: ReturnType<typeof useCategory>['categoryQuery']
   settings: CategorySetting[]
-  counts: ReturnType<typeof useCategory>['categoryCounts']
+  counts?: ReturnType<typeof useCategory>['categoryCounts']
 }
 
 export function Category({ query, settings, counts }: CategoryProps) {

--- a/src/app/_components/CategoryListbox.tsx
+++ b/src/app/_components/CategoryListbox.tsx
@@ -17,7 +17,7 @@ import {
 type CategoryListboxProps = {
   categoryOption: CategoryOption | undefined
   categorySettings: CategorySetting[]
-  categoryCounts: CategoryCounts
+  categoryCounts?: CategoryCounts
   onCategoryOptionChange: (selectedCategoryOption: CategoryOption) => void
 }
 

--- a/src/app/_components/CategorySelect.tsx
+++ b/src/app/_components/CategorySelect.tsx
@@ -37,7 +37,10 @@ export function CategorySelect({
     >
       {categorySettings.map((option) => {
         const isSelected = categoryOption === option.id
-        const count = categoryCounts[option.id] || 0
+
+        const countOrUndefined = categoryCounts
+          ? categoryCounts[option.id] || 0
+          : undefined
 
         return (
           <li key={option.id}>
@@ -53,7 +56,9 @@ export function CategorySelect({
               onClick={() => onCategoryOptionChange(option.id)}
             >
               <span>{option.name}</span>
-              <span className="text-sm font-light">({count})</span>
+              {countOrUndefined && (
+                <span className="text-sm font-light">({countOrUndefined})</span>
+              )}
             </button>
           </li>
         )

--- a/src/app/_components/CategorySelect.tsx
+++ b/src/app/_components/CategorySelect.tsx
@@ -41,12 +41,14 @@ export function CategorySelect({
         const countOrUndefined = categoryCounts
           ? categoryCounts[option.id] || 0
           : undefined
+        const hasCount = !!countOrUndefined
 
         return (
           <li key={option.id}>
             <button
               className={clsx(
-                'focus:brand-outline inline-flex cursor-pointer items-baseline gap-2 text-pretty rounded-lg py-2 text-left font-bold hover:bg-brand-700',
+                'text-pretty rounded-lg py-2 text-left font-bold focus:brand-outline hover:bg-brand-700',
+                hasCount && 'inline-flex items-baseline gap-2',
                 touchTarget.class,
                 {
                   'bg-brand-700 text-brand-400': isSelected,

--- a/src/app/_components/CategorySelect.tsx
+++ b/src/app/_components/CategorySelect.tsx
@@ -11,7 +11,7 @@ import {
 type CategoryListProps = {
   categoryOption: CategoryOption
   categorySettings: CategorySetting[]
-  categoryCounts: CategoryCounts
+  categoryCounts?: CategoryCounts
   onCategoryOptionChange: (selectedCategoryOption: CategoryOption) => void
 }
 

--- a/src/app/_components/ResultsAndReset.tsx
+++ b/src/app/_components/ResultsAndReset.tsx
@@ -10,17 +10,17 @@ export function ResultsAndReset({ results }: ResultsAndResetProps) {
   const { resetSearchParams } = useUpdateSearchParams()
 
   return (
-    <div className="flex items-baseline lg:gap-8">
-      <span className="inline-flex flex-1 items-center gap-2">
-        <span>Results</span>
-        {results && (
-          <span className="grid h-5 w-8 place-content-center rounded-[42px] bg-brand-300 p-1 text-xs font-bold text-brand-800">
+    <div className="flex items-baseline lg:mb-5 lg:gap-8">
+      {results && (
+        <span className="inline-flex flex-1 items-center gap-2">
+          <span>Results</span>
+          <span className="grid h-5 w-8 place-content-center rounded-full bg-brand-300 p-1 text-xs font-bold text-brand-800">
             {results}
           </span>
-        )}
-      </span>
+        </span>
+      )}
       <button
-        className="focus:brand-outline inline-flex whitespace-nowrap font-bold text-brand-300 underline"
+        className="inline-flex whitespace-nowrap font-bold text-brand-300 underline focus:brand-outline"
         onClick={resetSearchParams}
       >
         Reset Filters

--- a/src/app/_components/ResultsAndReset.tsx
+++ b/src/app/_components/ResultsAndReset.tsx
@@ -1,5 +1,7 @@
 'use client'
 
+import clsx from 'clsx'
+
 import { useUpdateSearchParams } from '@/hooks/useUpdateSearchParams'
 
 type ResultsAndResetProps = {
@@ -10,7 +12,7 @@ export function ResultsAndReset({ results }: ResultsAndResetProps) {
   const { resetSearchParams } = useUpdateSearchParams()
 
   return (
-    <div className="flex items-baseline lg:mb-5 lg:gap-8">
+    <div className={clsx('lg:mb-5 lg:gap-8', results && 'flex items-baseline')}>
       {results && (
         <span className="inline-flex flex-1 items-center gap-2">
           <span>Results</span>

--- a/src/app/_components/ResultsAndReset.tsx
+++ b/src/app/_components/ResultsAndReset.tsx
@@ -3,7 +3,7 @@
 import { useUpdateSearchParams } from '@/hooks/useUpdateSearchParams'
 
 type ResultsAndResetProps = {
-  results: number
+  results?: number
 }
 
 export function ResultsAndReset({ results }: ResultsAndResetProps) {
@@ -13,9 +13,11 @@ export function ResultsAndReset({ results }: ResultsAndResetProps) {
     <div className="flex items-baseline lg:gap-8">
       <span className="inline-flex flex-1 items-center gap-2">
         <span>Results</span>
-        <span className="grid h-5 w-8 place-content-center rounded-[42px] bg-brand-300 p-1 text-xs font-bold text-brand-800">
-          {results}
-        </span>
+        {results && (
+          <span className="grid h-5 w-8 place-content-center rounded-[42px] bg-brand-300 p-1 text-xs font-bold text-brand-800">
+            {results}
+          </span>
+        )}
       </span>
       <button
         className="focus:brand-outline inline-flex whitespace-nowrap font-bold text-brand-300 underline"

--- a/src/app/_types/categoryTypes.ts
+++ b/src/app/_types/categoryTypes.ts
@@ -1,6 +1,6 @@
 export type CategoryOption = string
 export type CategoryMap = Record<string, string>
-export type CategoryCounts = Record<CategoryOption, number> | undefined
+export type CategoryCounts = Record<CategoryOption, number>
 
 export type CategorySetting = {
   id: CategoryOption

--- a/src/app/_types/categoryTypes.ts
+++ b/src/app/_types/categoryTypes.ts
@@ -1,6 +1,6 @@
 export type CategoryOption = string
 export type CategoryMap = Record<string, string>
-export type CategoryCounts = Record<CategoryOption, number>
+export type CategoryCounts = Record<CategoryOption, number> | undefined
 
 export type CategorySetting = {
   id: CategoryOption

--- a/src/app/ecosystem-explorer/page.tsx
+++ b/src/app/ecosystem-explorer/page.tsx
@@ -79,7 +79,7 @@ export default function EcosystemExplorer({ searchParams }: Props) {
     sortByDefault: DEFAULT_SORT_OPTION,
   })
 
-  const { categoryQuery, categorizedResults, categoryCounts } = useCategory({
+  const { categoryQuery, categorizedResults } = useCategory({
     searchParams,
     entries: sortedResults,
     categorizeBy: 'category',
@@ -115,11 +115,7 @@ export default function EcosystemExplorer({ searchParams }: Props) {
           <FilterContainer.ResultsAndCategory
             results={<ResultsAndReset />}
             category={
-              <Category
-                query={categoryQuery}
-                settings={categorySettings}
-                counts={categoryCounts}
-              />
+              <Category query={categoryQuery} settings={categorySettings} />
             }
           />
           <FilterContainer.MainWrapper>
@@ -130,13 +126,9 @@ export default function EcosystemExplorer({ searchParams }: Props) {
             <FilterContainer.MobileFiltersAndResults
               search={<Search query={searchQuery} id="mobile-search" />}
               sort={<Sort query={sortQuery} />}
-              results={<ResultsAndReset results={categorizedResults.length} />}
+              results={<ResultsAndReset />}
               category={
-                <Category
-                  query={categoryQuery}
-                  settings={categorySettings}
-                  counts={categoryCounts}
-                />
+                <Category query={categoryQuery} settings={categorySettings} />
               }
             />
             <FilterContainer.ContentWrapper>

--- a/src/app/ecosystem-explorer/page.tsx
+++ b/src/app/ecosystem-explorer/page.tsx
@@ -113,7 +113,7 @@ export default function EcosystemExplorer({ searchParams }: Props) {
       >
         <FilterContainer>
           <FilterContainer.ResultsAndCategory
-            results={<ResultsAndReset results={categorizedResults.length} />}
+            results={<ResultsAndReset />}
             category={
               <Category
                 query={categoryQuery}


### PR DESCRIPTION
This PR hides the number of results on the ecosystem page, as Danielle requested on [Slack](https://filecoinfoundation.slack.com/archives/C06MTEQ3SP6/p1718212233895429).

To do so, it marks the respective props as optional in the `ResultsAndReset` and `Category` components, so they can be omitted on the explorer page. It doesn't affect the blog and events pages.

I added some space between the reset filters and the categories on desktop, as Filipa suggested on [Slack](https://filecoinfoundation.slack.com/archives/C06MTEQ3SP6/p1718648008521269).

_Desktop version_
![Screen Shot 2024-06-19 at 16 16 24](https://github.com/FilecoinFoundationWeb/filecoin-foundation/assets/20277959/047d8306-c9b0-4964-be35-906e06f1335e)

_Mobile version_
![Screen Shot 2024-06-19 at 16 17 10](https://github.com/FilecoinFoundationWeb/filecoin-foundation/assets/20277959/8e51ee6e-9e79-4fd1-a32a-67d61172d0f9)


---
Notion [ticket](https://www.notion.so/filecoin/FF-V4-Hide-number-of-results-on-ecosystem-explorer-c9d44f7988ed46ec8175af52369ffcb9?pvs=4)


