### PR TITLE
Fix youtube embed URLs

### DIFF
--- a/src/content/ecosystem-explorer/projects/archly.md
+++ b/src/content/ecosystem-explorer/projects/archly.md
@@ -23,7 +23,7 @@ website: https://archly.fi
 featured-content:
 repo: https://github.com/ArchlyFi
 twitter: https://twitter.com/archlyfinance/
-video-url: https://www.youtube.com/watch?v=8rt11F3qG1I&feature=youtu.be
+video-url: https://www.youtube.com/embed/8rt11F3qG1I
 year-joined: 2024-04-25T17:07:12.859000Z
 news-update:
 subcategories:

--- a/src/content/ecosystem-explorer/projects/banyan.md
+++ b/src/content/ecosystem-explorer/projects/banyan.md
@@ -23,7 +23,7 @@ website: "https://www.banyan.computer"
 featured-content: "https://www.youtube.com/watch?v=SaIGrSjOMP4&list=PLp3zrT1ewY0micCUXk2G1B1-ukbpuclJy&index=11"
 repo: "github.com/banyancomputer"
 twitter: "https://twitter.com/BanyanComputer"
-video-url: "https://www.youtube.com/watch?v=LFhw2qeMzkc&t"
+video-url: "https://www.youtube.com/embed/LFhw2qeMzkc"
 year-joined: "2024-02-01T20:41:25.602Z"
 news-update:
 subcategories:

--- a/src/content/ecosystem-explorer/projects/beryx.md
+++ b/src/content/ecosystem-explorer/projects/beryx.md
@@ -19,7 +19,7 @@ website: www.beryx.io
 featured-content:
 repo: "https://github.com/orgs/Zondax/repositories"
 twitter: "https://twitter.com/_beryx_"
-video-url: "https://www.youtube.com/watch?v=R2pso7nKxJE"
+video-url: "https://www.youtube.com/embed/R2pso7nKxJE"
 year-joined: 2023-02-01T17:44:05.293000Z
 news-update:
 subcategories:

--- a/src/content/ecosystem-explorer/projects/cavalry.md
+++ b/src/content/ecosystem-explorer/projects/cavalry.md
@@ -20,7 +20,7 @@ website: "https://cavalry.scenegroup.co"
 featured-content:
 repo:
 twitter: "https://twitter.com/cavalry__app"
-video-url: "https://www.youtube.com/watch?v=MSkeo4pPYa0"
+video-url: "https://www.youtube.com/embed/MSkeo4pPYa0"
 year-joined:
 news-update:
 subcategories:

--- a/src/content/ecosystem-explorer/projects/desci-labs.md
+++ b/src/content/ecosystem-explorer/projects/desci-labs.md
@@ -20,7 +20,7 @@ website: https://desci.com
 featured-content: https://fil.org/blog/case-study-desci-labs-and-filecoin-enabling-a-future-of-open-science/
 repo: https://github.com/desci-labs
 twitter: https://twitter.com/DeSciLabs
-video-url: https://www.youtube.com/watch?v=q_5hAe2AzhE&list=PLp3zrT1ewY0micCUXk2G1B1-ukbpuclJy&index=15
+video-url: https://www.youtube.com/embed/q_5hAe2AzhE
 year-joined:
 news-update:
 subcategories:

--- a/src/content/ecosystem-explorer/projects/drpc.md
+++ b/src/content/ecosystem-explorer/projects/drpc.md
@@ -17,7 +17,7 @@ featured-content:
 website: https://drpc.org/
 repo:
 twitter: https://twitter.com/drpcorg
-video-url: https://www.youtube.com/watch?v=AFB9eMukNTw&t=1s
+video-url: https://www.youtube.com/embed/AFB9eMukNTw
 year-joined: 2024-04-05T13:32:22.117000Z
 news-update:
 subcategories:

--- a/src/content/ecosystem-explorer/projects/filemarket.md
+++ b/src/content/ecosystem-explorer/projects/filemarket.md
@@ -24,7 +24,7 @@ website: "https://filemarket.xyz"
 featured-content:
 repo: "https://github.com/Filemarket-xyz/file-market"
 twitter: "https://twitter.com/filemarket_xyz/"
-video-url: "https://www.youtube.com/watch?v=MSOpSJnoFvQ"
+video-url: "https://www.youtube.com/embed/MSOpSJnoFvQ"
 year-joined: 2022-09-01T15:06:37.800000Z
 news-update:
 subcategories:

--- a/src/content/ecosystem-explorer/projects/filfi.md
+++ b/src/content/ecosystem-explorer/projects/filfi.md
@@ -19,7 +19,7 @@ featured-content:
 website: https://filfi.io
 repo: https://github.com/filfi
 twitter: https://twitter.com/filfi_io
-video-url: https://youtu.be/oaaLTpKSbYU?si=Tq2yisvmstECEaov
+video-url: https://www.youtube.com/embed/oaaLTpKSbYU
 year-joined: 2023-05-30T20:57:35.326000Z
 news-update:
 subcategories:

--- a/src/content/ecosystem-explorer/projects/filliquid.md
+++ b/src/content/ecosystem-explorer/projects/filliquid.md
@@ -20,7 +20,7 @@ website: "https://filliquid.io/"
 featured-content:
 repo:
 twitter: https://twitter.com/FILLiquid
-video-url: "https://www.youtube.com/watch?v=wYYGW7Rxc0E"
+video-url: "https://www.youtube.com/embed/wYYGW7Rxc0E"
 year-joined: 2024-01-24T13:45:47.646000Z
 news-update:
 subcategories:

--- a/src/content/ecosystem-explorer/projects/flare-api-portal.md
+++ b/src/content/ecosystem-explorer/projects/flare-api-portal.md
@@ -22,7 +22,7 @@ website: https://api-portal.flare.network
 featured-content:
 repo:
 twitter: https://twitter.com/APIPortal
-video-url: https://www.youtube.com/watch?v=mBTyTwh-Wzo
+video-url: https://www.youtube.com/embed/mBTyTwh-Wzo
 year-joined: 2024-04-05T13:18:56.264000Z
 news-update:
 subcategories:

--- a/src/content/ecosystem-explorer/projects/functionland-fula.md
+++ b/src/content/ecosystem-explorer/projects/functionland-fula.md
@@ -19,7 +19,7 @@ website: "https://fx.land/"
 repo: "https://github.com/functionland"
 featured-content:
 twitter: "https://twitter.com/functionland/"
-video-url: "https://www.youtube.com/watch?v=YJ-K7SKmIPk"
+video-url: "https://www.youtube.com/embed/YJ-K7SKmIPk"
 year-joined: 2021-03-03T16:17:36.608000Z
 news-update:
 subcategories:

--- a/src/content/ecosystem-explorer/projects/ghostdrive-global.md
+++ b/src/content/ecosystem-explorer/projects/ghostdrive-global.md
@@ -20,7 +20,7 @@ website: https://ghostdrive.com/
 featured-content:
 repo: https://github.com/Ghost-Drive
 twitter: https://twitter.com/GhostDrive_Web3
-video-url: https://www.youtube.com/watch?v=D0Mh3ZDA-3Y
+video-url: https://www.youtube.com/embed/D0Mh3ZDA-3Y
 year-joined: 2024-05-16T14:59:06.611000Z
 news-update:
 subcategories:

--- a/src/content/ecosystem-explorer/projects/nebula-block.md
+++ b/src/content/ecosystem-explorer/projects/nebula-block.md
@@ -24,7 +24,7 @@ featured-content:
 website: https://www.nebulablock.com/
 repo: https://github.com/Nebula-Block-Data
 twitter: https://twitter.com/nebulablockdata
-video-url: https://www.youtube.com/watch?v=Sl4vI4QgFts
+video-url: https://www.youtube.com/embed/Sl4vI4QgFts
 year-joined: 2020-06-15T13:58:36.727000Z
 news-update:
 subcategories:

--- a/src/content/ecosystem-explorer/projects/pyth-network.md
+++ b/src/content/ecosystem-explorer/projects/pyth-network.md
@@ -19,7 +19,7 @@ website: https://pyth.network/
 featured-content:
 repo: https://github.com/pyth-network
 twitter: https://x.com/PythNetwork
-video-url: https://www.youtube.com/watch?v=7k5gh-1JT3c
+video-url: https://www.youtube.com/embed/7k5gh-1JT3c
 year-joined: 2024-04-16T20:04:49.437000Z
 news-update:
 subcategories:

--- a/src/content/ecosystem-explorer/projects/sft-chain.md
+++ b/src/content/ecosystem-explorer/projects/sft-chain.md
@@ -21,7 +21,7 @@ website: "https://www.sftproject.io/"
 featured-content:
 repo: "https://github.com/SFT-project"
 twitter: "https://twitter.com/sftprotocol/"
-video-url: "https://www.youtube.com/watch?v=FOyv43DGH48"
+video-url: "https://www.youtube.com/embed/FOyv43DGH48"
 year-joined:
 news-update:
 subcategories:

--- a/src/content/ecosystem-explorer/projects/tres-finance.md
+++ b/src/content/ecosystem-explorer/projects/tres-finance.md
@@ -23,7 +23,7 @@ website: "https://tres.finance/"
 featured-content:
 repo:
 twitter: "https://twitter.com/TresDotFinance"
-video-url: "https://www.youtube.com/watch?v=4YHdkICYvJc"
+video-url: "https://www.youtube.com/embed/4YHdkICYvJc"
 year-joined: "2024-01-12T20:09:29.935Z"
 news-update:
 subcategories:

--- a/src/content/ecosystem-explorer/projects/waterlily-ai.md
+++ b/src/content/ecosystem-explorer/projects/waterlily-ai.md
@@ -22,7 +22,7 @@ website: "https://www.waterlily.ai/"
 featured-content: "https://fil.org/blog/decentralizing-art-a-deep-dive-into-waterlily-ais-use-of-fvm-and-ai/"
 repo: "https://github.com/bacalhau-project/Waterlily"
 twitter: "https://twitter.com/Waterlily"
-video-url: "https://www.youtube.com/watch?v=AhCScfpeN3k"
+video-url: "https://www.youtube.com/embed/AhCScfpeN3k"
 year-joined: "2023-04-25T22:00:00.000Z"
 news-update:
 subcategories:

--- a/src/content/ecosystem-explorer/projects/weatherxm.md
+++ b/src/content/ecosystem-explorer/projects/weatherxm.md
@@ -18,7 +18,7 @@ website: "https://weatherxm.com/"
 featured-content:
 repo: "https://github.com/WeatherXM/docs"
 twitter: "https://twitter.com/weatherxm"
-video-url: "https://www.youtube.com/watch?v=w7_wLlA6n8I&t=1s"
+video-url: "https://www.youtube.com/embed/w7_wLlA6n8I"
 year-joined:
 news-update:
 subcategories:

--- a/src/content/ecosystem-explorer/projects/xbanking.md
+++ b/src/content/ecosystem-explorer/projects/xbanking.md
@@ -20,7 +20,7 @@ website: "https://xbanking.org"
 featured-content:
 repo: "https://github.com/xbankingorg"
 twitter: "https://twitter.com/TresDotFinance"
-video-url: "https://www.youtube.com/watch?v=4YHdkICYvJc"
+video-url: "https://www.youtube.com/embed/4YHdkICYvJc"
 year-joined: 2024-01-12T20:27:39.394000Z
 news-update:
 subcategories:


### PR DESCRIPTION
This PR fixes the YouTube embed urls on all the following ecosystem projects, as reported by Danielle on [Slack](https://filecoinfoundation.slack.com/archives/C06MTEQ3SP6/p1718206210180559).

1. archly
2. banyan
3. beryx
4. cavalry
5. desci-labs
6. drpc
7. filemarket
8. filfi
9. filliquid
10. flare-api-portal
11. functionland-fula
12. ghostdrive-global
13. nebula-block
14. pyth-network
15. sft-chain
16. tres-finance
17. waterlily-ai
18. weatherxm
19. xbanking