### PR TITLE
Add redirect for blog post

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -43,6 +43,13 @@ const nextConfig = {
         permanent: true,
       },
       {
+        source:
+          '/blog/democracy%E2%80%99s-library-announces-more-than-a-petabyte-of-government-data-uploaded-to-the-filecoin-network',
+        destination:
+          '/blog/democracys-library-announces-more-than-a-petabyte-of-government-data-uploaded-to-the-filecoin-network',
+        permanent: true,
+      },
+      {
         source: '/davos',
         destination: '/events/the-filecoin-sanctuary-davos-2024',
         permanent: true,


### PR DESCRIPTION
This PR adds a redirect for a blog post entry, as per this [Slack convo](https://filecoinfoundation.slack.com/archives/C06MTEQ3SP6/p1718371582594239).

This: `/blog/democracy%E2%80%99s-library-announces-more-than-a-petabyte-of-government-data-uploaded-to-the-filecoin-network`

should redirect to: `blog/democracys-library-announces-more-than-a-petabyte-of-government-data-uploaded-to-the-filecoin-network`

It should work in development as well.

https://nextjs.org/docs/app/api-reference/next-config-js/redirects