### PR TITLE
Lock PageHeader Images in 16:9

### DIFF
--- a/src/app/_components/PageHeader.tsx
+++ b/src/app/_components/PageHeader.tsx
@@ -1,3 +1,5 @@
+import clsx from 'clsx'
+
 import { Button } from '@/components/Button'
 import {
   DescriptionText,
@@ -34,9 +36,9 @@ function Title({ children }: TitleProps) {
   )
 }
 
-const sharedContainerStyle = 'relative aspect-video lg:aspect-auto lg:w-1/2'
-const sharedImageStyle = 'h-full w-full rounded-lg border border-brand-100'
-const imageSizes = buildImageSizeProp({ startSize: '100vw', md: '660px' })
+const aspectRatioStyle = 'aspect-video'
+const imageStyle = 'rounded-lg border border-brand-100'
+const imageSizes = buildImageSizeProp({ startSize: '100vw', lg: '490px' })
 
 function PageHeaderImage({ image }: Pick<PageHeaderProps, 'image'>) {
   const isDynamicImage = 'src' in image
@@ -44,28 +46,25 @@ function PageHeaderImage({ image }: Pick<PageHeaderProps, 'image'>) {
 
   if (isStaticImage) {
     return (
-      <div className={sharedContainerStyle}>
-        <StaticImage
-          {...image}
-          fill
-          priority
-          quality={100}
-          className={sharedImageStyle}
-          sizes={imageSizes}
-        />
-      </div>
+      <StaticImage
+        {...image}
+        priority
+        quality={100}
+        className={clsx(aspectRatioStyle, imageStyle)}
+        sizes={imageSizes}
+      />
     )
   }
 
   if (isDynamicImage) {
     return (
-      <div className={sharedContainerStyle}>
+      <div className={clsx('relative', aspectRatioStyle)}>
         <DynamicImage
           {...image}
           fill
           priority
           quality={100}
-          className={sharedImageStyle}
+          className={clsx('h-full w-full', imageStyle)}
           sizes={imageSizes}
           fallback={image.fallback}
         />
@@ -119,7 +118,9 @@ export function PageHeader({
           </div>
         </div>
 
-        <PageHeaderImage image={image} />
+        <div className="lg:w-1/2">
+          <PageHeaderImage image={image} />
+        </div>
       </div>
     </header>
   )

--- a/src/app/_components/PageHeader.tsx
+++ b/src/app/_components/PageHeader.tsx
@@ -37,7 +37,7 @@ function Title({ children }: TitleProps) {
 }
 
 const aspectRatioStyle = 'aspect-video'
-const imageStyle = 'rounded-lg border border-brand-100'
+const borderStyle = 'rounded-lg border border-brand-100'
 const imageSizes = buildImageSizeProp({ startSize: '100vw', lg: '490px' })
 
 function PageHeaderImage({ image }: Pick<PageHeaderProps, 'image'>) {
@@ -50,7 +50,7 @@ function PageHeaderImage({ image }: Pick<PageHeaderProps, 'image'>) {
         {...image}
         priority
         quality={100}
-        className={clsx(aspectRatioStyle, imageStyle)}
+        className={clsx(aspectRatioStyle, borderStyle)}
         sizes={imageSizes}
       />
     )
@@ -64,7 +64,7 @@ function PageHeaderImage({ image }: Pick<PageHeaderProps, 'image'>) {
           fill
           priority
           quality={100}
-          className={clsx('h-full w-full', imageStyle)}
+          className={clsx('h-full w-full', borderStyle)}
           sizes={imageSizes}
           fallback={image.fallback}
         />


### PR DESCRIPTION
This PR updates `PageHeader` so that all images are in a `16:9` ratio instead of mirroring the height of the parent container.

_Now_
![CleanShot 2024-06-20 at 17 46 07](https://github.com/FilecoinFoundationWeb/filecoin-foundation/assets/20277959/0b9b4083-f4cb-47cf-8ea6-e53ef6567467)

_Before_
![CleanShot 2024-06-20 at 17 46 21](https://github.com/FilecoinFoundationWeb/filecoin-foundation/assets/20277959/19d5a28b-9a9d-4b2f-9d83-cda1489fde3f)

---

[Notion Ticket](https://www.notion.so/filecoin/FF-V4-Adapt-PageHeader-images-a3c99aed7db44f06aab477f108e6ee61?pvs=4)
