### PR TITLE
Include Past Events Category for Events

### DIFF
--- a/src/app/_constants/categoryConstants.ts
+++ b/src/app/_constants/categoryConstants.ts
@@ -1,0 +1,4 @@
+export const pastEventsSetting = {
+  id: 'past-events',
+  name: 'Past Events',
+} as const

--- a/src/app/_hooks/useCategory.ts
+++ b/src/app/_hooks/useCategory.ts
@@ -12,7 +12,7 @@ import { normalizeQueryParam } from '@/utils/queryUtils'
 
 import { CATEGORY_KEY } from '@/constants/searchParams'
 
-type UseCategoryProps<Entry extends Object> = {
+export type UseCategoryProps<Entry extends Object> = {
   searchParams: NextServerSearchParams
   entries: Entry[]
   categorizeBy: keyof CategorizableBy & keyof Entry

--- a/src/app/_hooks/useEventsCategory.ts
+++ b/src/app/_hooks/useEventsCategory.ts
@@ -1,0 +1,63 @@
+import { useMemo } from 'react'
+
+import { UseCategoryProps, useCategory } from '@/hooks/useCategory'
+
+import type { EventData } from '@/types/eventTypes'
+
+import { isDateValid } from '@/utils/formatDate'
+
+import { pastEventsSetting } from '@/constants/categoryConstants'
+
+export function useEventsCategory(props: UseCategoryProps<EventData>) {
+  const { entries } = props
+
+  const results = useCategory(props)
+  const { categoryQuery, categoryCounts, categorizedResults } = results
+
+  const countsWithPastEvents = useMemo(() => {
+    const pastEventsCount = entries.filter(filterByPastEvents).length
+
+    return { ...categoryCounts, [pastEventsSetting.id]: pastEventsCount }
+  }, [categoryCounts, entries])
+
+  const resultsWithPastEvents = useMemo(() => {
+    if (categoryQuery === pastEventsSetting.id) {
+      return entries.filter(filterByPastEvents)
+    }
+
+    return categorizedResults
+  }, [categoryQuery, categorizedResults, entries])
+
+  return {
+    categoryQuery,
+    categorizedResults: resultsWithPastEvents,
+    categoryCounts: countsWithPastEvents,
+  }
+}
+
+const today = getTodayDateUTCZero()
+
+function filterByPastEvents(entry: EventData) {
+  const { startDate, endDate, slug } = entry
+
+  if (endDate) {
+    if (!isDateValid(endDate)) {
+      throw new Error(`Invalid date provided for event: ${slug}`)
+    }
+    return new Date(endDate) < today
+  }
+
+  if (!isDateValid(startDate)) {
+    throw new Error(`Invalid date provided for event: ${slug}`)
+  }
+  return new Date(startDate) < today
+}
+
+function getTodayDateUTCZero() {
+  const today = new Date()
+  const utcYear = today.getUTCFullYear()
+  const utcMonth = today.getUTCMonth()
+  const utcDate = today.getUTCDate()
+
+  return new Date(Date.UTC(utcYear, utcMonth, utcDate, 0, 0, 0, 0))
+}

--- a/src/app/_hooks/useEventsCategory.ts
+++ b/src/app/_hooks/useEventsCategory.ts
@@ -42,13 +42,13 @@ function filterByPastEvents(entry: EventData) {
 
   if (endDate) {
     if (!isDateValid(endDate)) {
-      throw new Error(`Invalid date provided for event: ${slug}`)
+      throw new Error(`Invalid endDate provided for event: ${slug}`)
     }
     return new Date(endDate) < today
   }
 
   if (!isDateValid(startDate)) {
-    throw new Error(`Invalid date provided for event: ${slug}`)
+    throw new Error(`Invalid startDate provided for event: ${slug}`)
   }
   return new Date(startDate) < today
 }

--- a/src/app/_utils/categoryUtils.ts
+++ b/src/app/_utils/categoryUtils.ts
@@ -9,6 +9,7 @@ import { type CMSFieldOption } from '@/types/cmsConfig'
 import { getCollectionConfig, getCMSFieldOptions } from '@/utils/cmsConfigUtils'
 import { readAndValidateYamlFiles } from '@/utils/yamlUtils'
 
+import { pastEventsSetting } from '@/constants/categoryConstants'
 import { CMS_CATEGORY_FIELD_MAPPING } from '@/constants/cmsConstants'
 
 function transformCategoryDataToSettings(
@@ -50,6 +51,16 @@ export function getCategorySettings(
   const categoryIds = categorySettings.map((setting) => setting.id)
 
   return { categorySettings, validCategoryOptions: categoryIds }
+}
+
+export function getEventsCategorySettings() {
+  const eventSettings = getCategorySettings('events')
+  const { categorySettings, validCategoryOptions } = eventSettings
+
+  return {
+    categorySettings: [...categorySettings, pastEventsSetting],
+    validCategoryOptions: [...validCategoryOptions, pastEventsSetting.id],
+  }
 }
 
 export function getCategorySettingsFromMap(categoryMap: CategoryMap) {

--- a/src/app/_utils/formatDate.ts
+++ b/src/app/_utils/formatDate.ts
@@ -6,7 +6,7 @@ export function formatDate(
 ): string {
   const date = new Date(dateString)
 
-  if (Number.isNaN(date.getTime())) {
+  if (!isDateValid(date)) {
     console.error('Invalid date provided:', dateString)
     return 'Invalid Date'
   }
@@ -25,4 +25,11 @@ export function formatDate(
   }
 
   return date.toLocaleDateString('en-US', options)
+}
+
+export function isDateValid(dateString: string | Date) {
+  const date = new Date(dateString)
+  const isValid = !Number.isNaN(date.getTime())
+
+  return isValid
 }

--- a/src/app/_utils/formatDate.ts
+++ b/src/app/_utils/formatDate.ts
@@ -1,35 +1,18 @@
-type FormatDateOption = 'default' | 'blog' | 'event'
+export function isDateValid(date: string | Date): boolean {
+  return !Number.isNaN(new Date(date).getTime())
+}
 
-export function formatDate(
-  dateString: string,
-  format: FormatDateOption = 'default',
-): string {
+export function formatDate(dateString: string): string {
   const date = new Date(dateString)
-
-  if (!isDateValid(date)) {
-    console.error('Invalid date provided:', dateString)
-    return 'Invalid Date'
+  const options: Intl.DateTimeFormatOptions = {
+    year: 'numeric',
+    month: 'short',
+    day: 'numeric',
   }
 
-  let options: Intl.DateTimeFormatOptions
-
-  switch (format) {
-    case 'blog':
-      options = { year: 'numeric', month: 'long', day: 'numeric' }
-      break
-    case 'event':
-      options = { year: 'numeric', month: '2-digit', day: '2-digit' }
-      break
-    default:
-      options = { year: 'numeric', month: 'short', day: 'numeric' }
+  if (!isDateValid(date)) {
+    throw new Error(`Invalid date provided: ${dateString}`)
   }
 
   return date.toLocaleDateString('en-US', options)
-}
-
-export function isDateValid(dateString: string | Date) {
-  const date = new Date(dateString)
-  const isValid = !Number.isNaN(date.getTime())
-
-  return isValid
 }

--- a/src/app/events/page.tsx
+++ b/src/app/events/page.tsx
@@ -2,7 +2,7 @@ import dynamic from 'next/dynamic'
 
 import { MagnifyingGlass } from '@phosphor-icons/react/dist/ssr'
 
-import { useCategory } from '@/hooks/useCategory'
+import { useEventsCategory } from '@/hooks/useEventsCategory'
 import { usePagination } from '@/hooks/usePagination'
 import { useSearch } from '@/hooks/useSearch'
 import { useSort } from '@/hooks/useSort'
@@ -24,7 +24,7 @@ import { StructuredDataScript } from '@/components/StructuredDataScript'
 import { NextServerSearchParams } from '@/types/searchParams'
 
 import { buildImageSizeProp } from '@/utils/buildImageSizeProp'
-import { getCategorySettings } from '@/utils/categoryUtils'
+import { getEventsCategorySettings } from '@/utils/categoryUtils'
 import { createMetadata } from '@/utils/createMetadata'
 import { getEventData, getEventsData } from '@/utils/getEventData'
 import { getEventMetaData } from '@/utils/getMetaData'
@@ -49,7 +49,7 @@ type Props = {
 }
 
 const events = getEventsData()
-const { categorySettings, validCategoryOptions } = getCategorySettings('events')
+const { categorySettings, validCategoryOptions } = getEventsCategorySettings()
 const { featured_entry: featuredEventSlug, seo } = attributes
 const featuredEvent = getEventData(featuredEventSlug || '')
 
@@ -67,7 +67,6 @@ export default function Events({ searchParams }: Props) {
   const { searchQuery, searchResults } = useSearch({
     searchParams,
     entries: events,
-
     searchBy: ['title', 'location'],
   })
 
@@ -78,12 +77,13 @@ export default function Events({ searchParams }: Props) {
     sortByDefault: DEFAULT_SORT_OPTION,
   })
 
-  const { categoryQuery, categorizedResults, categoryCounts } = useCategory({
-    searchParams,
-    entries: sortedResults,
-    categorizeBy: 'involvement',
-    validCategoryOptions: validCategoryOptions,
-  })
+  const { categoryQuery, categorizedResults, categoryCounts } =
+    useEventsCategory({
+      searchParams,
+      entries: sortedResults,
+      categorizeBy: 'involvement',
+      validCategoryOptions,
+    })
 
   const { currentPage, pageCount, paginatedResults } = usePagination({
     searchParams,


### PR DESCRIPTION
This PR adds a `Past Events` category to the events page.

Unlike other categories, `Past Events` does not come from the CMS. It is programmatically calculated based on the end date of a given event or the start date If no end date is available.

Also, unlike other categories, this category is not exclusive to other categories, meaning an event can be both `Hosted` and `Past Events`, but it cannot be both `Hosted` and `Supported.`

To implement this mechanism, I created:
- `useEventsCategory`, built on top of `useCetagory`
- `getEventsCategorySettings`, built on top of `getCategorySettings`

I added these 2 functions to avoid "polluting" the original ones with code that is specific to the events page.

---

_No filters_
![CleanShot 2024-06-21 at 14 44 25](https://github.com/FilecoinFoundationWeb/filecoin-foundation/assets/20277959/10409d5a-3508-4596-9820-d0bc88f14894)

_Past Events category filter_
![CleanShot 2024-06-21 at 14 45 14](https://github.com/FilecoinFoundationWeb/filecoin-foundation/assets/20277959/de111afa-c12b-4a4a-8bd0-5476fff8b796)

---

[Notion](https://www.notion.so/filecoin/FF-V4-Include-Past-Events-Category-for-Events-ed3745b367fe46faae1a5b1867dea68c?pvs=4)