### PR TITLE
Replace image url field by src

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -56,11 +56,6 @@ const nextConfig = {
         permanent: true,
       },
       {
-        source: '/blog/Filecoin-nv19-Lightning-Upgrade',
-        destination: '/blog/filecoin-nv19-lightning-upgrade',
-        permanent: true,
-      },
-      {
         source:
           '/blog/pilecoin-foundation-successfully-deploys-interflanetary-pile-system-IFPS-in-space',
         destination:

--- a/public/admin/config.yml
+++ b/public/admin/config.yml
@@ -23,7 +23,7 @@ image_config: &image_config
   label: "Image"
   widget: "object"
   fields:
-    - name: "url"
+    - name: "src"
       label: "URL"
       widget: "image"
       allow_multiple: false

--- a/src/app/_components/BlogPostHeader.tsx
+++ b/src/app/_components/BlogPostHeader.tsx
@@ -39,7 +39,7 @@ export function BlogPostHeader({
           fill
           priority
           quality={100}
-          src={image.url}
+          src={image.src}
           alt={image.alt}
           className="rounded-lg"
           sizes={buildImageSizeProp({ startSize: '100vw', md: '680px' })}

--- a/src/app/_components/FeaturedBlogPosts.tsx
+++ b/src/app/_components/FeaturedBlogPosts.tsx
@@ -41,8 +41,7 @@ export function FeaturedBlogPosts() {
               text: 'Learn More',
             }}
             image={{
-              src: image.url,
-              alt: image.alt,
+              ...image,
               fallback: graphicsData.imageFallback,
               sizes: buildImageSizeProp({
                 startSize: '100vw',

--- a/src/app/_components/FeaturedEcosystemProjects.tsx
+++ b/src/app/_components/FeaturedEcosystemProjects.tsx
@@ -36,8 +36,7 @@ export function FeaturedEcosystemProjects({
             icon: MagnifyingGlass,
           }}
           image={{
-            src: image.url,
-            alt: image.alt,
+            ...image,
             fallback: graphicsData.imageFallback,
             padding: true,
             objectFit: 'contain',

--- a/src/app/_components/FeaturedGrantGraduates.tsx
+++ b/src/app/_components/FeaturedGrantGraduates.tsx
@@ -35,8 +35,7 @@ export function FeaturedGrantsGraduates({
             icon: BookOpen,
           }}
           image={{
-            src: image.url,
-            alt: image.alt,
+            ...image,
             fallback: graphicsData.imageFallback,
             objectFit: 'contain',
             padding: true,

--- a/src/app/_data/cmsConfigSchema.json
+++ b/src/app/_data/cmsConfigSchema.json
@@ -1274,7 +1274,7 @@
           "widget": "object",
           "fields": [
             {
-              "name": "url",
+              "name": "src",
               "label": "URL",
               "widget": "image",
               "allow_multiple": false,
@@ -1494,7 +1494,7 @@
           "widget": "object",
           "fields": [
             {
-              "name": "url",
+              "name": "src",
               "label": "URL",
               "widget": "image",
               "allow_multiple": false,
@@ -1924,7 +1924,7 @@
           "widget": "object",
           "fields": [
             {
-              "name": "url",
+              "name": "src",
               "label": "URL",
               "widget": "image",
               "allow_multiple": false,

--- a/src/app/_data/cmsConfigSchema.json
+++ b/src/app/_data/cmsConfigSchema.json
@@ -30,7 +30,7 @@
     "widget": "object",
     "fields": [
       {
-        "name": "url",
+        "name": "src",
         "label": "URL",
         "widget": "image",
         "allow_multiple": false,

--- a/src/app/_types/sharedProps/imageType.ts
+++ b/src/app/_types/sharedProps/imageType.ts
@@ -1,5 +1,5 @@
 export type ImageProps = {
-  url: string
+  src: string
   alt: string
 }
 

--- a/src/app/_utils/mapMarkdownToBlogPostData.ts
+++ b/src/app/_utils/mapMarkdownToBlogPostData.ts
@@ -16,7 +16,7 @@ export function mapMarkdownToBlogPostData({
     category: data.category,
     description: data.description,
     image: {
-      url: data.image?.url || '',
+      src: data.image?.src || '',
       alt: data.image?.alt || '',
     },
     content,

--- a/src/app/_utils/mapMarkdownToEcosystemProjectData.ts
+++ b/src/app/_utils/mapMarkdownToEcosystemProjectData.ts
@@ -19,8 +19,8 @@ export function mapMarkdownToEcosystemProjectData({
     tags: data.tags,
     tech: data.tech,
     image: {
-      url: data.image.url,
-      alt: data.image.alt,
+      src: data.image?.src || '',
+      alt: data.image?.alt || '',
     },
     website: data.website,
     content: content,

--- a/src/app/_utils/mapMarkdownToEventData.ts
+++ b/src/app/_utils/mapMarkdownToEventData.ts
@@ -18,7 +18,7 @@ export function mapMarkdownToEventData({
     startDate: data['start-date'],
     endDate: data['end-date'],
     image: {
-      url: data.image?.url || '',
+      src: data.image?.src || '',
       alt: data.image?.alt || '',
     },
     involvement: data.involvement,

--- a/src/app/blog/[slug]/utils/generateStructuredData.ts
+++ b/src/app/blog/[slug]/utils/generateStructuredData.ts
@@ -19,7 +19,7 @@ export function generateStructuredData(
     '@type': 'BlogPosting',
     headline: title,
     description: description,
-    image: image.url,
+    image: image.src,
     author: {
       '@type': 'Organization',
       name: ORGANIZATION_NAME,

--- a/src/app/blog/page.tsx
+++ b/src/app/blog/page.tsx
@@ -99,7 +99,6 @@ export default function Blog({ searchParams }: Props) {
         metaData={getBlogPostMetaData(featuredPost.publishedOn)}
         image={{
           ...featuredPost.image,
-          src: featuredPost.image.url,
           fallback: graphicsData.imageFallback,
         }}
         cta={{
@@ -174,8 +173,7 @@ export default function Blog({ searchParams }: Props) {
                             icon: BookOpen,
                           }}
                           image={{
-                            src: image.url,
-                            alt: image.alt,
+                            ...image,
                             fallback: graphicsData.imageFallback,
                             priority: isFirstTwoImages,
                             sizes: buildImageSizeProp({

--- a/src/app/blog/utils/generateStructuredData.ts
+++ b/src/app/blog/utils/generateStructuredData.ts
@@ -31,7 +31,7 @@ export function generateStructuredData(
           '@type': 'BlogPosting',
           headline: post.title,
           description: post.description,
-          image: post.image.url,
+          image: post.image.src,
           url: `${BASE_URL}${PATHS.BLOG.path}/${post.slug}`,
           author: {
             '@type': 'Organization',

--- a/src/app/ecosystem-explorer/[slug]/page.tsx
+++ b/src/app/ecosystem-explorer/[slug]/page.tsx
@@ -72,7 +72,7 @@ export default function EcosystemProject({ params }: EcosystemProjectProps) {
           <DynamicImage
             fill
             priority
-            src={image.url}
+            src={image.src}
             alt={image.alt}
             objectFit="contain"
             className="object-left-bottom"

--- a/src/app/ecosystem-explorer/page.tsx
+++ b/src/app/ecosystem-explorer/page.tsx
@@ -155,8 +155,7 @@ export default function EcosystemExplorer({ searchParams }: Props) {
                             icon: BookOpen,
                           }}
                           image={{
-                            src: image.url,
-                            alt: image.alt,
+                            ...image,
                             padding: true,
                             priority: isFirstTwoImages,
                             objectFit: 'contain',

--- a/src/app/events/[slug]/page.tsx
+++ b/src/app/events/[slug]/page.tsx
@@ -48,8 +48,6 @@ export default function EventEntry({ params }: EventProps) {
         }
         image={{
           ...image,
-          src: image.url,
-          alt: image.alt,
           fallback: graphicsData.imageFallback,
         }}
       />

--- a/src/app/events/[slug]/utils/generateStructuredData.ts
+++ b/src/app/events/[slug]/utils/generateStructuredData.ts
@@ -62,7 +62,7 @@ export function generateStructuredData(data: EventData): WithContext<Event> {
     startDate,
     endDate,
     ...(eventLocation && { location: eventLocation }),
-    image: image.url,
+    image: image.src,
     url: `${BASE_URL}${PATHS.EVENTS.path}/${slug}`,
   }
 }

--- a/src/app/events/page.tsx
+++ b/src/app/events/page.tsx
@@ -100,7 +100,6 @@ export default function Events({ searchParams }: Props) {
         metaData={getEventMetaData(featuredEvent)}
         image={{
           ...featuredEvent.image,
-          src: featuredEvent.image.url,
           fallback: graphicsData.events1,
         }}
         cta={{
@@ -176,8 +175,7 @@ export default function Events({ searchParams }: Props) {
                             icon: MagnifyingGlass,
                           }}
                           image={{
-                            src: image.url,
-                            alt: image.alt,
+                            ...image,
                             priority: isFirstTwoImages,
                             fallback: graphicsData.imageFallback,
                             sizes: buildImageSizeProp({

--- a/src/content/blog/10-tools-for-filecoin-storage-providers.md
+++ b/src/content/blog/10-tools-for-filecoin-storage-providers.md
@@ -8,7 +8,7 @@ description: >-
   array of "as-a-service" tools, services, and platforms designed to streamline operations
   and enhance service offerings.
 image:
-  url: /assets/images/92523-sptooling.png
+  src: /assets/images/92523-sptooling.png
   alt: Filecoin Storage Providers
 recommended-posts: []
 category: ecosystem

--- a/src/content/blog/2021-developer-grants-wrap.md
+++ b/src/content/blog/2021-developer-grants-wrap.md
@@ -8,7 +8,7 @@ description: >-
   development projects to foster a more robust and efficient decentralized web through
   the Filecoin ecosystem.
 image:
-  url: /assets/images/image-c-16.png
+  src: /assets/images/image-c-16.png
   alt:
 recommended-posts: []
 category: reports

--- a/src/content/blog/ai-data-verifiability-and-decentralized-storage-a-recap-from-fil-vegas.md
+++ b/src/content/blog/ai-data-verifiability-and-decentralized-storage-a-recap-from-fil-vegas.md
@@ -9,7 +9,7 @@ description: >-
   gathering under one roof to discuss decentralized storage in the age of artificial
   intelligence (AI).
 image:
-  url: /assets/images/filvegas_recap_header.png
+  src: /assets/images/filvegas_recap_header.png
   alt:
 recommended-posts: []
 seo:

--- a/src/content/blog/announcing-explorer-awards-by-filecoin-foundation-and-unfinished.md
+++ b/src/content/blog/announcing-explorer-awards-by-filecoin-foundation-and-unfinished.md
@@ -8,7 +8,7 @@ description: >-
   Explorer Awards, a joint program to support the growth of the decentralized web
   movement and help others catalyze their Web3 learning.
 image:
-  url: /assets/images/0609-ffxunfinished.png
+  src: /assets/images/0609-ffxunfinished.png
   alt:
 recommended-posts: []
 category: news

--- a/src/content/blog/announcing-network-upgrade-skyr.md
+++ b/src/content/blog/announcing-network-upgrade-skyr.md
@@ -8,7 +8,7 @@ description: >-
   Wednesday, July 6. By introducing Milestone 1 of the Filecoin Virtual Machine
   (FVM), Skyr is one of the largest upgrades in Filecoin network history.
 image:
-  url: /assets/images/64423a88f053c985627f3ae7_1-ko-wwh4crpe6t8ioqymtfq.png
+  src: /assets/images/64423a88f053c985627f3ae7_1-ko-wwh4crpe6t8ioqymtfq.png
   alt:
 recommended-posts: []
 category: news

--- a/src/content/blog/announcing-the-filecoin-community-roadmap.md
+++ b/src/content/blog/announcing-the-filecoin-community-roadmap.md
@@ -8,7 +8,7 @@ description: >-
   overview of significant, upcoming enhancements to the Filecoin protocol and network
   implementations.
 image:
-  url: /assets/images/64423a8ab068b0286f5c29dc_1-puuomuuoq9o-ezxjtdpppw.png
+  src: /assets/images/64423a8ab068b0286f5c29dc_1-puuomuuoq9o-ezxjtdpppw.png
   alt:
 recommended-posts: []
 category: news

--- a/src/content/blog/announcing-the-filecoin-nv22-dragon-upgrade-a-leap-forward-in-network-efficiency-and-flexibility.md
+++ b/src/content/blog/announcing-the-filecoin-nv22-dragon-upgrade-a-leap-forward-in-network-efficiency-and-flexibility.md
@@ -8,7 +8,7 @@ published-on: 2024-04-24T13:19:08.184000Z
 category: news
 description: Filecoin nv22 Dragon upgrade has launched on mainnet.
 image:
-  url: /assets/images/blog-header-_-nv22-upgrade.png
+  src: /assets/images/blog-header-_-nv22-upgrade.png
   alt: Filecoin nv22 Dragon Upgrade
 recommended-posts: []
 seo:

--- a/src/content/blog/announcing-the-public-data-commons-and-awards-program.md
+++ b/src/content/blog/announcing-the-public-data-commons-and-awards-program.md
@@ -8,8 +8,7 @@ description: >-
   Commons initiative to support open data projects in partnership with
   government and official organizations across the globe.
 image:
-  url: >-
-    /assets/images/64423a8c4e4c682bdff3f2e5_1-1hvgrfumdxuavwm1qy5flw.webp
+  src: /assets/images/64423a8c4e4c682bdff3f2e5_1-1hvgrfumdxuavwm1qy5flw.webp
   alt:
 recommended-posts: []
 category: news

--- a/src/content/blog/announcing-the-quality-phase-for-filecoin-plus-aligning-on-the-filecoin-plus-vision-mission-statement-and-roadmap.md
+++ b/src/content/blog/announcing-the-quality-phase-for-filecoin-plus-aligning-on-the-filecoin-plus-vision-mission-statement-and-roadmap.md
@@ -10,7 +10,7 @@ description:
   information by incentivizing data onboarding across use-cases with community governed
   trust mechanisms.
 image:
-  url: /assets/images/03292023-filplusmission.png
+  src: /assets/images/03292023-filplusmission.png
   alt:
 recommended-posts: []
 category: ecosystem

--- a/src/content/blog/announcing-the-starling-lab.md
+++ b/src/content/blog/announcing-the-starling-lab.md
@@ -9,7 +9,7 @@ description: >-
   research center tackling the technical and ethical challenges of establishing
   trust in the most sensitive digital records of our human history.
 image:
-  url:
+  src:
   alt:
 recommended-posts: []
 category: news

--- a/src/content/blog/announcing-the-venushub-platform.md
+++ b/src/content/blog/announcing-the-venushub-platform.md
@@ -7,8 +7,7 @@ description: >-
   One of the main goals in building out the Filecoin network is to ensure the
   Mainnet is secure and resilient.
 image:
-  url: >-
-    /assets/images/64423a911fe00b2cb076101a_1-_gcjaae5jjlt5kkzewfd6g.png
+  src: /assets/images/64423a911fe00b2cb076101a_1-_gcjaae5jjlt5kkzewfd6g.png
   alt:
 recommended-posts: []
 category: news

--- a/src/content/blog/announcing-watermelon-nv21-upgrade-extended-sector-commitments-synthetic-porep-fvm-enhancements-and-more.md
+++ b/src/content/blog/announcing-watermelon-nv21-upgrade-extended-sector-commitments-synthetic-porep-fvm-enhancements-and-more.md
@@ -11,7 +11,7 @@ description:
   codenamed ‘Watermelon’ brings a wave of enhancements and new features aimed at bolstering
   the network’s efficiency and robustness.
 image:
-  url: /assets/images/twitter-_-nv21_upgrade.png
+  src: /assets/images/twitter-_-nv21_upgrade.png
   alt: The arrival of the nv21 Network Upgrade on Filecoin mainnet is here.
 recommended-posts: []
 seo:

--- a/src/content/blog/applications-are-open-for-filecoin-plus-notary-elections.md
+++ b/src/content/blog/applications-are-open-for-filecoin-plus-notary-elections.md
@@ -7,7 +7,7 @@ description:
   This month, the Filecoin Plus program will kick off its third round of
   elections.
 image:
-  url: /assets/images/0218-filpluselection.png
+  src: /assets/images/0218-filpluselection.png
   alt:
 recommended-posts: []
 category: news

--- a/src/content/blog/applications-are-open-for-the-filecoin-launchpad-accelerator-ii.md
+++ b/src/content/blog/applications-are-open-for-the-filecoin-launchpad-accelerator-ii.md
@@ -7,7 +7,7 @@ description:
   "Filecoin Launchpad Accelerator, powered by Tachyon, is seeking applications
   for its next cohort of innovators. "
 image:
-  url: /assets/images/image-c-26.png
+  src: /assets/images/image-c-26.png
   alt:
 recommended-posts: []
 category: news

--- a/src/content/blog/bbc-s-the-real-story-explores-the-promise-of-cryptocurrency.md
+++ b/src/content/blog/bbc-s-the-real-story-explores-the-promise-of-cryptocurrency.md
@@ -7,7 +7,7 @@ description:
   Filecoin Foundation Board Chair Marta Belcher joined the BBC’s Ritula
   Shah on The Real Story to discuss the promise of Filecoin and the future of cryptocurrency.
 image:
-  url: /assets/images/64423a958d1be740f4ce6485_1-idr5jnytk_i2rab2ggn9uq.png
+  src: /assets/images/64423a958d1be740f4ce6485_1-idr5jnytk_i2rab2ggn9uq.png
   alt:
 recommended-posts: []
 category: news

--- a/src/content/blog/bela-supernova-awarded-chainlink-filecoin-joint-grant-to-support-public-health-data-oracle.md
+++ b/src/content/blog/bela-supernova-awarded-chainlink-filecoin-joint-grant-to-support-public-health-data-oracle.md
@@ -10,8 +10,7 @@ description: >-
   accelerate the development of hybrid smart contracts that combine Chainlink
   decentralized oracles and Filecoin decentralized storage.
 image:
-  url: >-
-    /assets/images/64423a97d1b025cf67f903ec_1-k1bbzfo-mulctcjeu5e_da.png
+  src: /assets/images/64423a97d1b025cf67f903ec_1-k1bbzfo-mulctcjeu5e_da.png
   alt:
 recommended-posts: []
 category: news

--- a/src/content/blog/blockchain-copyright-law.md
+++ b/src/content/blog/blockchain-copyright-law.md
@@ -7,7 +7,7 @@ description:
   FF Board Chair Marta Belcher and Advisor Kristin Smith discuss use cases
   for blockchain in art and music
 image:
-  url: /assets/images/image-c-30.png
+  src: /assets/images/image-c-30.png
   alt:
 recommended-posts: []
 category: reports

--- a/src/content/blog/building-a-flow-nft-pet-store-part-1.md
+++ b/src/content/blog/building-a-flow-nft-pet-store-part-1.md
@@ -8,8 +8,7 @@ description: >-
   create a simple NFT marketplace app on the Flow blockchain from scratch, using
   the Flow blockchain and IPFS/Filecoin storage via nft.storage.
 image:
-  url: >-
-    /assets/images/64423a9bd1b0256d85f907e2_0-al1sv2xu4ah_bwdo.png
+  src: /assets/images/64423a9bd1b0256d85f907e2_0-al1sv2xu4ah_bwdo.png
   alt:
 recommended-posts: []
 category: use-cases

--- a/src/content/blog/building-an-nft-store-on-flow-part-2.md
+++ b/src/content/blog/building-an-nft-store-on-flow-part-2.md
@@ -8,8 +8,7 @@ description: >-
   create a simple NFT marketplace app on the Flow blockchain from scratch, using
   the Flow blockchain and IPFS/Filecoin storage via nft.storage.
 image:
-  url: >-
-    /assets/images/6452458c4af3f5baef0c433c_0-4zwhgcutykrxqrsw.jpg
+  src: /assets/images/6452458c4af3f5baef0c433c_0-4zwhgcutykrxqrsw.jpg
   alt:
 recommended-posts: []
 category: use-cases

--- a/src/content/blog/call-for-community-feedback-weigh-in-on-the-new-filecoin-governance-process-proposal-fip0001v2.md
+++ b/src/content/blog/call-for-community-feedback-weigh-in-on-the-new-filecoin-governance-process-proposal-fip0001v2.md
@@ -11,7 +11,7 @@ description:
   engagements, Filecoin Foundation is proud to announce the release of the FIP0001v2
   draft.
 image:
-  url: /assets/images/231017-fip0001v2.png
+  src: /assets/images/231017-fip0001v2.png
   alt: "Filecoin Foundation FIP 0001v2 Governance"
 recommended-posts: []
 seo:

--- a/src/content/blog/case-study-desci-labs-and-filecoin-enabling-a-future-of-open-science.md
+++ b/src/content/blog/case-study-desci-labs-and-filecoin-enabling-a-future-of-open-science.md
@@ -11,7 +11,7 @@ description:
   systems for years without significant progress. The vision is a world without vendor
   lock-in, paywalls, proprietary analytics, link rot and fake science.
 image:
-  url: /assets/images/0719-cs-desci.png
+  src: /assets/images/0719-cs-desci.png
   alt:
 recommended-posts: []
 category: use-cases

--- a/src/content/blog/case-study-genrait-leverages-filecoin-network-for-greater-visibility-access-and-storage-of-genomic-data.md
+++ b/src/content/blog/case-study-genrait-leverages-filecoin-network-for-greater-visibility-access-and-storage-of-genomic-data.md
@@ -11,7 +11,7 @@ description:
   ecosystem. In the GenRAIT ecosystem, scientists retain full autonomy and flexibility
   with regards to their data and analytics processes.
 image:
-  url: /assets/images/image-c-02.png
+  src: /assets/images/image-c-02.png
   alt:
 recommended-posts: []
 category: use-cases

--- a/src/content/blog/case-study-opsci-how-an-open-science-commons-project-built-on-web3-infrastructure-empowers-community-discovery.md
+++ b/src/content/blog/case-study-opsci-how-an-open-science-commons-project-built-on-web3-infrastructure-empowers-community-discovery.md
@@ -9,7 +9,7 @@ description:
   How an Open Science Commons Project Built on Web3 Infrastructure Empowers
   Community Discovery
 image:
-  url: /assets/images/0224-cs-opsci.png
+  src: /assets/images/0224-cs-opsci.png
   alt:
 recommended-posts: []
 category: use-cases

--- a/src/content/blog/case-study-redefining-web-presence-no-code-tools-meet-decentralized-hosting.md
+++ b/src/content/blog/case-study-redefining-web-presence-no-code-tools-meet-decentralized-hosting.md
@@ -7,7 +7,7 @@ description:
   In this case study, we at Filecoin Foundation explore an innovative approach
   to website design workflow.
 image:
-  url: /assets/images/0905-cs-ff.png
+  src: /assets/images/0905-cs-ff.png
   alt:
 recommended-posts: []
 category: use-cases

--- a/src/content/blog/case-study-seal-storage-making-web3-accessible-for-all-through-ecosystem-leadership-and-the-filecoin-network-1.md
+++ b/src/content/blog/case-study-seal-storage-making-web3-accessible-for-all-through-ecosystem-leadership-and-the-filecoin-network-1.md
@@ -11,8 +11,7 @@ description: >-
   North America, with over 20PB of capacity across the U.S. and Canada, and is
   looking to add over 100PiBs more.
 image:
-  url: >-
-    /assets/images/64423aa28d1be743ddce7ab2_1-inwzqgetwegv3q8q0c4fea.webp
+  src: /assets/images/64423aa28d1be743ddce7ab2_1-inwzqgetwegv3q8q0c4fea.webp
   alt:
 recommended-posts: []
 category: use-cases

--- a/src/content/blog/congratulations-to-the-hedera-x-filecoin-grant-program-winners.md
+++ b/src/content/blog/congratulations-to-the-hedera-x-filecoin-grant-program-winners.md
@@ -7,7 +7,7 @@ description:
   "The Filecoin Foundation is pleased to announce the winners of the Hedera
   x Filecoin grant program. "
 image:
-  url: /assets/images/64423aa44e4c6826a3f40982_0-3uh8nohy2qqafnfv.png
+  src: /assets/images/64423aa44e4c6826a3f40982_0-3uh8nohy2qqafnfv.png
   alt:
 recommended-posts: []
 category: news

--- a/src/content/blog/decentralizing-art-a-deep-dive-into-waterlily-ais-use-of-fvm-and-ai.md
+++ b/src/content/blog/decentralizing-art-a-deep-dive-into-waterlily-ais-use-of-fvm-and-ai.md
@@ -8,7 +8,7 @@ description:
   Filecoin for ethical compensation and transparency. Dive into an insightful conversation
   with Allie Haire on the future of AI and blockchain in art.
 image:
-  url: /assets/images/06262023-waterlilly.png
+  src: /assets/images/06262023-waterlilly.png
   alt:
 recommended-posts: []
 category: use-cases

--- a/src/content/blog/deep-dive-on-messaris-q1-filecoin-ecosystem-report.md
+++ b/src/content/blog/deep-dive-on-messaris-q1-filecoin-ecosystem-report.md
@@ -8,7 +8,7 @@ description:
   Insights from Messari's recently released Q1 2024 Filecoin Ecosystem
   Report.
 image:
-  url: /assets/images/050824-messariq1.png
+  src: /assets/images/050824-messariq1.png
   alt: Messari Filecoin Report
 recommended-posts: []
 seo:

--- a/src/content/blog/democracys-library-announces-more-than-a-petabyte-of-government-data-uploaded-to-the-filecoin-network.md
+++ b/src/content/blog/democracys-library-announces-more-than-a-petabyte-of-government-data-uploaded-to-the-filecoin-network.md
@@ -5,7 +5,7 @@ updated-on: 2023-09-21T17:34:18.789Z
 published-on: 2023-09-21T17:34:18.798Z
 description: Democracy’s Library announces over a petabyte of government data uploaded to the Filecoin network. Learn about the project and its impact.
 image:
-  url: /assets/images/1018-sps-democracyslibrary.png
+  src: /assets/images/1018-sps-democracyslibrary.png
   alt: null
 recommended-posts: []
 category: news

--- a/src/content/blog/dev-grant-spotlight-4everland.md
+++ b/src/content/blog/dev-grant-spotlight-4everland.md
@@ -9,8 +9,7 @@ description: >-
   features such as global acceleration, privacy protection, and distributed
   storage.
 image:
-  url: >-
-    /assets/images/64423aa58d1be7828cce7d89_1-45khiwwqpsgwtnrtjpkoqa.png
+  src: /assets/images/64423aa58d1be7828cce7d89_1-45khiwwqpsgwtnrtjpkoqa.png
   alt:
 recommended-posts: []
 category: reports

--- a/src/content/blog/dev-grant-spotlight-arlequin-the-artist-s-metaverse.md
+++ b/src/content/blog/dev-grant-spotlight-arlequin-the-artist-s-metaverse.md
@@ -8,7 +8,7 @@ description:
   system where users can collect NFT 3D animals, known as ‘Arlee’, in a creative ecosystem
   powered by the Flow blockchain and using Interplanetary File System (IPFS) via nft.storage.
 image:
-  url: /assets/images/64423aa70425d34fa6f2743e_1-s1umhgp4fz8mfyk3fixjia.png
+  src: /assets/images/64423aa70425d34fa6f2743e_1-s1umhgp4fz8mfyk3fixjia.png
   alt:
 recommended-posts: []
 category: reports

--- a/src/content/blog/dev-grant-spotlight-datastation.md
+++ b/src/content/blog/dev-grant-spotlight-datastation.md
@@ -8,7 +8,7 @@ description:
   on the Filecoin network by providing storage providers and clients with standardized
   storage performance data in a format that's both easy to store and to understand. "
 image:
-  url: /assets/images/image-c-22.png
+  src: /assets/images/image-c-22.png
   alt:
 recommended-posts: []
 category: reports

--- a/src/content/blog/dev-grant-spotlight-encloud.md
+++ b/src/content/blog/dev-grant-spotlight-encloud.md
@@ -10,7 +10,7 @@ description:
   capture more value. Encloud, formerly known as 180Protocol that lets you easily
   onboard and ecrypt data to the decentralized web."
 image:
-  url: /assets/images/0405-dgs-180protocol.png
+  src: /assets/images/0405-dgs-180protocol.png
   alt:
 recommended-posts: []
 category: reports

--- a/src/content/blog/dev-grant-spotlight-fileverse.md
+++ b/src/content/blog/dev-grant-spotlight-fileverse.md
@@ -8,7 +8,7 @@ description:
   creating new tools and services on the Filecoin network. Learn more about Filecoin
   Foundation’s Dev Grants program.
 image:
-  url: /assets/images/rectangle-31-.png
+  src: /assets/images/rectangle-31-.png
   alt:
 recommended-posts: []
 category: reports

--- a/src/content/blog/dev-grant-spotlight-freenet-2.md
+++ b/src/content/blog/dev-grant-spotlight-freenet-2.md
@@ -4,8 +4,7 @@ description: >-
   Freenet is free software that lets users anonymously chat, share files, use
   email, browse, and publish Freenet-accessible websites known as “freesites.”
 image:
-  url: >-
-    /assets/images/64423aae5b72a20c3b84a368_0-y9cgmvjvrgwywsvt.png
+  src: /assets/images/64423aae5b72a20c3b84a368_0-y9cgmvjvrgwywsvt.png
   alt:
 updated-on: "2023-04-21T07:26:38.609Z"
 created-on: "2023-04-21T07:26:38.609Z"

--- a/src/content/blog/dev-grant-spotlight-geo-web.md
+++ b/src/content/blog/dev-grant-spotlight-geo-web.md
@@ -5,8 +5,7 @@ description: >-
   a set of open protocols that creates novel property rights for augmented
   reality (AR) content.
 image:
-  url: >-
-    /assets/images/64423aafa6ec4151d52a3dc9_0-eczvdfkkiozsdvgv.jpeg
+  src: /assets/images/64423aafa6ec4151d52a3dc9_0-eczvdfkkiozsdvgv.jpeg
   alt:
 updated-on: "2023-04-21T07:26:40.008Z"
 created-on: "2023-04-21T07:26:40.008Z"

--- a/src/content/blog/dev-grant-spotlight-jackal-storage.md
+++ b/src/content/blog/dev-grant-spotlight-jackal-storage.md
@@ -4,8 +4,7 @@ description: >-
   JACKAL Storage is a platform that provides a secure, private, and
   user-friendly solution for decentralized storage on the Filecoin network.
 image:
-  url: >-
-    /assets/images/64423ab18d1be70ae7ce9031_1-qwnolzesajrp3gjwrthflg.png
+  src: /assets/images/64423ab18d1be70ae7ce9031_1-qwnolzesajrp3gjwrthflg.png
   alt:
 updated-on: "2023-04-21T07:26:41.530Z"
 created-on: "2023-04-21T07:26:41.530Z"

--- a/src/content/blog/dev-grant-spotlight-numbers-protocol-puts-digital-creators-in-control-of-their-assets.md
+++ b/src/content/blog/dev-grant-spotlight-numbers-protocol-puts-digital-creators-in-control-of-their-assets.md
@@ -10,7 +10,7 @@ description:
   artists to control, monetize, and protect their digital assets in the Web2 and Web3
   landscape."
 image:
-  url: /assets/images/0315-dgs-numbers.png
+  src: /assets/images/0315-dgs-numbers.png
   alt:
 recommended-posts: []
 category: reports

--- a/src/content/blog/dev-grant-spotlight-portrait.md
+++ b/src/content/blog/dev-grant-spotlight-portrait.md
@@ -4,8 +4,7 @@ description: >-
   Portrait is the first open-source web page builder, allowing people to turn
   their blockchain address into a website.
 image:
-  url: >-
-    /assets/images/64423ab50425d36d72f2895f_1-brm0bxgpfk7-tr5tfyq-la.png
+  src: /assets/images/64423ab50425d36d72f2895f_1-brm0bxgpfk7-tr5tfyq-la.png
   alt:
 updated-on: "2023-04-21T07:26:45.129Z"
 created-on: "2023-04-21T07:26:45.129Z"

--- a/src/content/blog/dev-grant-spotlight-renovi.md
+++ b/src/content/blog/dev-grant-spotlight-renovi.md
@@ -8,7 +8,7 @@ description:
   marketplace and design studio that works with global brands and businesses to create,
   develop, and implement their Web3 strategies.
 image:
-  url: /assets/images/image-c-11.png
+  src: /assets/images/image-c-11.png
   alt:
 recommended-posts: []
 category: reports

--- a/src/content/blog/dev-grant-spotlight-ukraine-art-collective.md
+++ b/src/content/blog/dev-grant-spotlight-ukraine-art-collective.md
@@ -8,7 +8,7 @@ description:
   the world to contribute their creative talents to support the Ukrainian people in
   their fight for freedom.
 image:
-  url: /assets/images/64423ab8fa70d13d126ff4f7_1-4bia5dzrvjftkirryi_bxq.png
+  src: /assets/images/64423ab8fa70d13d126ff4f7_1-4bia5dzrvjftkirryi_bxq.png
   alt:
 recommended-posts: []
 category: reports

--- a/src/content/blog/dev-grant-spotlight-webrecorder.md
+++ b/src/content/blog/dev-grant-spotlight-webrecorder.md
@@ -10,7 +10,7 @@ description:
   for all’, building browser-based tools to enable institutions all over the world
   to create web archives, from a single to running larger crawls in the cloud.
 image:
-  url: /assets/images/image-c-14.png
+  src: /assets/images/image-c-14.png
   alt:
 recommended-posts: []
 category: reports

--- a/src/content/blog/driving-widespread-filecoin-adoption-key-initiatives-and-community-involvement-in-2024.md
+++ b/src/content/blog/driving-widespread-filecoin-adoption-key-initiatives-and-community-involvement-in-2024.md
@@ -12,7 +12,7 @@ description:
   growth metrics and outline what some Ecosystem leaders suggest are the keys to further
   expansion in 2024."
 image:
-  url: /assets/images/050924-adoption.png
+  src: /assets/images/050924-adoption.png
   alt:
 recommended-posts: []
 seo:

--- a/src/content/blog/dweb-on-the-rise-the-many-uses-for-decentralized-storage.md
+++ b/src/content/blog/dweb-on-the-rise-the-many-uses-for-decentralized-storage.md
@@ -11,7 +11,7 @@ description:
   be run by any one of thousands of hosting providers around the world, instead of
   just being run by Amazon by default."
 image:
-  url: /assets/images/0905-dweb-on-the-rise.png
+  src: /assets/images/0905-dweb-on-the-rise.png
   alt:
 recommended-posts: []
 category: ecosystem

--- a/src/content/blog/dzk-foundation-awarded-chainlink-filecoin-joint-grant-to-support-zk-rollup-research.md
+++ b/src/content/blog/dzk-foundation-awarded-chainlink-filecoin-joint-grant-to-support-zk-rollup-research.md
@@ -7,8 +7,7 @@ description: >-
   accelerate the development of hybrid smart contracts that combine Chainlink
   decentralized oracles and Filecoin decentralized storage.
 image:
-  url: >-
-    /assets/images/64423abce3c08f49114f50eb_1-9utuc70k3mbyvlsllf7dqa.png
+  src: /assets/images/64423abce3c08f49114f50eb_1-9utuc70k3mbyvlsllf7dqa.png
   alt:
 updated-on: "2023-04-21T07:26:52.479Z"
 created-on: "2023-04-21T07:26:52.479Z"

--- a/src/content/blog/ecosystem-spotlight-ghostdrives-secure-decentralized-storage-now-on-mobile.md
+++ b/src/content/blog/ecosystem-spotlight-ghostdrives-secure-decentralized-storage-now-on-mobile.md
@@ -8,7 +8,7 @@ description: "As part of Filecoin Foundation’s work to showcase innovative
   platform that leverages Filecoin's decentralized storage to improve redundancy
   and security."
 image:
-  url: /assets/images/0604-ghostdrive.png
+  src: /assets/images/0604-ghostdrive.png
   alt: "Filecoin Foundation and GhostDrive Logos"
 category: ecosystem
 recommended-posts: []

--- a/src/content/blog/ecosystem-spotlight-transfer-q-a-on-preserving-artistic-value-with-decentralized-technology-data-sovereignty-and-harnessing-value-of-data.md
+++ b/src/content/blog/ecosystem-spotlight-transfer-q-a-on-preserving-artistic-value-with-decentralized-technology-data-sovereignty-and-harnessing-value-of-data.md
@@ -11,7 +11,7 @@ description: >
   technology, automated governance systems, harnessing the value of data in unique
   ways.
 image:
-  url: /assets/images/020124-transfer.png
+  src: /assets/images/020124-transfer.png
   alt: Filecoin Foundation TRANSFER Blog Post
 recommended-posts: []
 seo:

--- a/src/content/blog/empowering-governance-the-launch-of-metropolis-to-the-filecoin-community.md
+++ b/src/content/blog/empowering-governance-the-launch-of-metropolis-to-the-filecoin-community.md
@@ -8,7 +8,7 @@ description:
   Introducing Metropolis, a temperature check tool for early-stage Filecoin
   Improvement Proposals.
 image:
-  url: /assets/images/blog-header-_-metropolis.png
+  src: /assets/images/blog-header-_-metropolis.png
   alt: Metropolis Filecoin
 recommended-posts: []
 seo:

--- a/src/content/blog/european-orbit-community-meetups-eager-developers-decentralized-storage-curiosity-and-vibrant-communities.md
+++ b/src/content/blog/european-orbit-community-meetups-eager-developers-decentralized-storage-curiosity-and-vibrant-communities.md
@@ -9,7 +9,7 @@ description: "The Filecoin Orbit community teamed up with Filecoin Foundation
   recently on a Europe roadshow tour to engage builders, strengthen the
   community, and drive interest in the region. "
 image:
-  url: /assets/images/110624-europe.png
+  src: /assets/images/110624-europe.png
 recommended-posts: []
 seo:
   twitter:

--- a/src/content/blog/everything-you-need-to-know-about-fip0036-deliberation-discussion-and-next-steps.md
+++ b/src/content/blog/everything-you-need-to-know-about-fip0036-deliberation-discussion-and-next-steps.md
@@ -7,8 +7,7 @@ description: >-
   Introducing a Sector Duration Multiple for Longer Term Storage Commitment.
   Here's everything you need to know.
 image:
-  url: >-
-    /assets/images/64423abda6ec4131c52a3df0_1-et2gg4agkn7chfbur-8a6g.webp
+  src: /assets/images/64423abda6ec4131c52a3df0_1-et2gg4agkn7chfbur-8a6g.webp
   alt:
 updated-on: "2023-04-21T07:26:54.116Z"
 created-on: "2023-04-21T07:26:54.116Z"

--- a/src/content/blog/ff-x-lockheed-martin-mission-announcement.md
+++ b/src/content/blog/ff-x-lockheed-martin-mission-announcement.md
@@ -11,7 +11,7 @@ description:
   place in 2023 aboard Lockheed Martin’s [NYSE: LMT] LM 400 Technology Demonstrator
   spacecraft."
 image:
-  url: /assets/images/01-lockheed-p-1080.png
+  src: /assets/images/01-lockheed-p-1080.png
   alt:
 recommended-posts: []
 category: news

--- a/src/content/blog/fil-austin-2022-recap-fil-ling-you-in.md
+++ b/src/content/blog/fil-austin-2022-recap-fil-ling-you-in.md
@@ -8,7 +8,7 @@ description:
   at FIL Austin, a week of Filecoin community events set against the backdrop of Consensus,
   CoinDesk’s annual crypto conference in June.
 image:
-  url: /assets/images/image-c-15.png
+  src: /assets/images/image-c-15.png
   alt:
 recommended-posts: []
 category: events

--- a/src/content/blog/fil-toronto-2022-recap.md
+++ b/src/content/blog/fil-toronto-2022-recap.md
@@ -8,7 +8,7 @@ description:
   FIL Toronto. From July 4–6, attendees gathered to discuss new features, partner
   tools, and other developments in the Filecoin ecosystem.
 image:
-  url: /assets/images/image-c-07.png
+  src: /assets/images/image-c-07.png
   alt:
 recommended-posts: []
 category: events

--- a/src/content/blog/filecoin-as-a-depin-prototype.md
+++ b/src/content/blog/filecoin-as-a-depin-prototype.md
@@ -8,7 +8,7 @@ description:
   The Decentralized Physical Infrastructure Network (DePIN) movement is
   re-architecting the Internet's physical and digital backbone.
 image:
-  url: /assets/images/022624-depin.png
+  src: /assets/images/022624-depin.png
   alt: Filecoin DePIN
 recommended-posts: []
 seo:

--- a/src/content/blog/filecoin-community-approves-change-to-storage-provider-terminology.md
+++ b/src/content/blog/filecoin-community-approves-change-to-storage-provider-terminology.md
@@ -8,7 +8,7 @@ description:
   18 (FIP-0018), which reframes how we message around the storage market and those
   who participate in it as storage providers.
 image:
-  url: /assets/images/fip18.png
+  src: /assets/images/fip18.png
   alt:
 recommended-posts: []
 category: news

--- a/src/content/blog/filecoin-ecosystem-shines-at-fil-hong-kong-ai-depin-fvm-and-more.md
+++ b/src/content/blog/filecoin-ecosystem-shines-at-fil-hong-kong-ai-depin-fvm-and-more.md
@@ -8,7 +8,7 @@ description:
   The Filecoin ecosystem was on full display at FIL Hong Kong, hosted by
   ND Labs and supported by Filecoin Foundation.
 image:
-  url: /assets/images/blogheader-filhk24recap-1-.png
+  src: /assets/images/blogheader-filhk24recap-1-.png
   alt: Filecoin Ecosystem at FIL Hong Kong
 recommended-posts: []
 seo:

--- a/src/content/blog/filecoin-foundation-2022-annual-report.md
+++ b/src/content/blog/filecoin-foundation-2022-annual-report.md
@@ -7,8 +7,7 @@ description: >-
   Despite challenges for the blockchain space in 2022, the Filecoin network has
   continued to thrive.
 image:
-  url: >-
-    /assets/images/64423ac6b068b0a9945c5010_0206-ff-22-annual-report.png
+  src: /assets/images/64423ac6b068b0a9945c5010_0206-ff-22-annual-report.png
   alt:
 recommended-posts: []
 category: reports

--- a/src/content/blog/filecoin-foundation-2023-annual-report.md
+++ b/src/content/blog/filecoin-foundation-2023-annual-report.md
@@ -11,7 +11,7 @@ description:
   network, the promises of the decentralized web, and the mission of the Foundation.
   This report also provides additional details on FF’s annual budget.
 image:
-  url: /assets/images/022624-ff-anualreport.png
+  src: /assets/images/022624-ff-anualreport.png
   alt: "Filecoin Foundation 2023 Annual Report"
 recommended-posts: []
 seo:

--- a/src/content/blog/filecoin-foundation-and-blockchain-law-for-social-good-center-accelerate-web3-education-1.md
+++ b/src/content/blog/filecoin-foundation-and-blockchain-law-for-social-good-center-accelerate-web3-education-1.md
@@ -6,8 +6,7 @@ description: >-
   New Blockchain Academy Lab will provide education and training to support
   understanding of decentralized technology
 image:
-  url: >-
-    /assets/images/64423ac8ef619d74dcb60e37_1-dvxhahnhu5a5qk3xidlxga.webp
+  src: /assets/images/64423ac8ef619d74dcb60e37_1-dvxhahnhu5a5qk3xidlxga.webp
   alt:
 updated-on: "2023-04-21T07:27:04.336Z"
 created-on: "2023-04-21T07:27:04.336Z"

--- a/src/content/blog/filecoin-foundation-and-blockchain-law-for-social-good-center-accelerate-web3-education.md
+++ b/src/content/blog/filecoin-foundation-and-blockchain-law-for-social-good-center-accelerate-web3-education.md
@@ -7,8 +7,7 @@ description: >-
   for Social Good Center at Golden Gate University School of Law to create the
   Filecoin Foundation Blockchain Academy Lab (the Lab).
 image:
-  url: >-
-    /assets/images/64423ac9e3c08f1a784f5119_1-dvxhahnhu5a5qk3xidlxga.png
+  src: /assets/images/64423ac9e3c08f1a784f5119_1-dvxhahnhu5a5qk3xidlxga.png
   alt:
 updated-on: "2023-04-21T07:27:05.729Z"
 created-on: "2023-04-21T07:27:05.729Z"

--- a/src/content/blog/filecoin-foundation-and-ffdw-team-up-with-the-internet-archive-to-preserve-government-datasets-in-new-democracy-s-library-initiative.md
+++ b/src/content/blog/filecoin-foundation-and-ffdw-team-up-with-the-internet-archive-to-preserve-government-datasets-in-new-democracy-s-library-initiative.md
@@ -7,8 +7,7 @@ description: >-
   will ensure that government research and publications from around the world
   remain permanently accessible to the public.
 image:
-  url: >-
-    /assets/images/64423acba6ec41b8da2a46d0_1-jrf-dri7quysyfpqa5rpaw.webp
+  src: /assets/images/64423acba6ec41b8da2a46d0_1-jrf-dri7quysyfpqa5rpaw.webp
   alt:
 updated-on: "2023-04-21T07:27:07.444Z"
 created-on: "2023-04-21T07:27:07.444Z"

--- a/src/content/blog/filecoin-foundation-and-filecoin-foundation-for-the-decentralized-web-expand-boards.md
+++ b/src/content/blog/filecoin-foundation-and-filecoin-foundation-for-the-decentralized-web-expand-boards.md
@@ -11,8 +11,7 @@ description: >-
   Blockchain Association, has joined the board of the Filecoin Foundation for
   the Decentralized Web (FFDW).
 image:
-  url: >-
-    /assets/images/64423acca6ec4184be2a4866_1-kequqilr3jvs6nq_e7naqq.png
+  src: /assets/images/64423acca6ec4184be2a4866_1-kequqilr3jvs6nq_e7naqq.png
   alt:
 recommended-posts: []
 category: news

--- a/src/content/blog/filecoin-foundation-and-filecoin-foundation-for-the-decentralized-web-gain-momentum.md
+++ b/src/content/blog/filecoin-foundation-and-filecoin-foundation-for-the-decentralized-web-gain-momentum.md
@@ -9,7 +9,7 @@ description:
   In 2017, the creators of Filecoin envisioned that an independent Filecoin
   Foundation would serve as the long-term governance body for the Filecoin Ecosystem.
 image:
-  url: /assets/images/64423aceef619d5dc5b60e52_1-e009tiaipq2vndk-evb9ng.png
+  src: /assets/images/64423aceef619d5dc5b60e52_1-e009tiaipq2vndk-evb9ng.png
   alt:
 recommended-posts: []
 category: news

--- a/src/content/blog/filecoin-foundation-and-lockheed-martin-bring-decentralized-storage-to-space.md
+++ b/src/content/blog/filecoin-foundation-and-lockheed-martin-bring-decentralized-storage-to-space.md
@@ -12,7 +12,7 @@ description: >-
   Filecoin Foundation (FF) and Lockheed Martin are working together to develop a program
   for deploying the Interplanetary File System (IPFS) in space.
 image:
-  url: /assets/images/01-lockheed-p-1080.png
+  src: /assets/images/01-lockheed-p-1080.png
   alt:
 recommended-posts: []
 category: news

--- a/src/content/blog/filecoin-foundation-and-protocol-labs-embark-on-experimental-project-to-put-new-york-city-open-data-on-the-filecoin-network.md
+++ b/src/content/blog/filecoin-foundation-and-protocol-labs-embark-on-experimental-project-to-put-new-york-city-open-data-on-the-filecoin-network.md
@@ -12,8 +12,7 @@ description: >-
   together to store and maintain New York City Open Data on the decentralized
   web for the next five years.
 image:
-  url: >-
-    /assets/images/64423ad14e4c686170f43f8e_1-_l1pjw5m2ayuddshdifbcg.png
+  src: /assets/images/64423ad14e4c686170f43f8e_1-_l1pjw5m2ayuddshdifbcg.png
   alt:
 recommended-posts:
   - src/content/blog/applications-are-open-for-filecoin-plus-notary-elections.md

--- a/src/content/blog/filecoin-foundation-announces-board-of-directors.md
+++ b/src/content/blog/filecoin-foundation-announces-board-of-directors.md
@@ -7,7 +7,7 @@ description:
   The Filecoin Foundation and Filecoin Foundation for the Decentralized
   Web shared their board of directors.
 image:
-  url: /assets/images/image-c-06.png
+  src: /assets/images/image-c-06.png
   alt:
 recommended-posts: []
 category: news

--- a/src/content/blog/filecoin-foundation-chair-marta-belcher-testifies-before-us-senate-banking-committee.md
+++ b/src/content/blog/filecoin-foundation-chair-marta-belcher-testifies-before-us-senate-banking-committee.md
@@ -12,7 +12,7 @@ description:
   the benefits of cryptocurrency and explained Filecoin as one example of a use case
   that could serve as the foundation for the next generation of the Internet."
 image:
-  url: /assets/images/64423ad4d7488e39d6b03c3a_0-oh5oa7medvgzjscu.png
+  src: /assets/images/64423ad4d7488e39d6b03c3a_0-oh5oa7medvgzjscu.png
   alt:
 recommended-posts: []
 category: news

--- a/src/content/blog/filecoin-foundation-first-half-year-in-review.md
+++ b/src/content/blog/filecoin-foundation-first-half-year-in-review.md
@@ -5,8 +5,7 @@ description: >-
   to the first six months of what’s been a packed year and all that’s taken
   place within the rapidly growing Filecoin community.
 image:
-  url: >-
-    /assets/images/64423ad6d7488e70c7b03c3d_1-6lpmwpmsydkqniohiklqla.png
+  src: /assets/images/64423ad6d7488e70c7b03c3d_1-6lpmwpmsydkqniohiklqla.png
   alt:
 updated-on: "2023-04-21T07:27:18.330Z"
 created-on: "2023-04-21T07:27:18.330Z"

--- a/src/content/blog/filecoin-foundation-introduces-fil-lisbon-2022-to-bring-the-web3-community-together-announces-speakers.md
+++ b/src/content/blog/filecoin-foundation-introduces-fil-lisbon-2022-to-bring-the-web3-community-together-announces-speakers.md
@@ -6,8 +6,7 @@ description: >-
   Week-long event welcomes 50+speakers to explore FVM, sustainability, NFTs, the
   metaverse, Web3 and more through the perspective of the Filecoin community.
 image:
-  url: >-
-    /assets/images/64423ad74e4c688bfff4446d_1-ru5fimtnssl-v4znrrl-ew.webp
+  src: /assets/images/64423ad74e4c688bfff4446d_1-ru5fimtnssl-v4znrrl-ew.webp
   alt:
 updated-on: "2023-04-21T07:27:19.915Z"
 created-on: "2023-04-21T07:27:19.915Z"

--- a/src/content/blog/filecoin-foundation-joins-blockchain-for-europe.md
+++ b/src/content/blog/filecoin-foundation-joins-blockchain-for-europe.md
@@ -5,8 +5,7 @@ description: >-
   member of Blockchain for Europe (BC4EU), a leading voice on EU blockchain
   policy.
 image:
-  url: >-
-    /assets/images/64423ad9ef619d9dd2b60e6d_0-yilkincrhittd7ub.png
+  src: /assets/images/64423ad9ef619d9dd2b60e6d_0-yilkincrhittd7ub.png
   alt:
 updated-on: "2023-04-21T07:27:21.334Z"
 created-on: "2023-04-21T07:27:21.334Z"

--- a/src/content/blog/filecoin-foundation-successfully-deploys-interplanetary-file-system-ipfs-in-space.md
+++ b/src/content/blog/filecoin-foundation-successfully-deploys-interplanetary-file-system-ipfs-in-space.md
@@ -12,7 +12,7 @@ description:
   involved sending files from Earth to orbit and back using an implementation of the
   IPFS protocol designed for space communications.
 image:
-  url: /assets/images/01-lockheed.png
+  src: /assets/images/01-lockheed.png
   alt: IPFS in Space
 recommended-posts: []
 seo:

--- a/src/content/blog/filecoin-foundation-wave-9-dev-grant-proposals-due-friday-july-30.md
+++ b/src/content/blog/filecoin-foundation-wave-9-dev-grant-proposals-due-friday-july-30.md
@@ -8,7 +8,7 @@ description:
   to critical development projects to foster a more robust and efficient decentralized
   web through the Filecoin ecosystem.
 image:
-  url: /assets/images/image-c-17.png
+  src: /assets/images/image-c-17.png
   alt:
 recommended-posts: []
 category: news

--- a/src/content/blog/filecoin-mainnet-marks-three-years.md
+++ b/src/content/blog/filecoin-mainnet-marks-three-years.md
@@ -7,7 +7,7 @@ description:
   This week, Filecoin Foundation celebrates the three-year anniversary
   of the Filecoin network’s  mainnet launch.
 image:
-  url: /assets/images/image-3-.png
+  src: /assets/images/image-3-.png
   alt: Filecoin network growth over 3 years
 recommended-posts: []
 category: news

--- a/src/content/blog/filecoin-network-base-at-consensus-2023-wrapped.md
+++ b/src/content/blog/filecoin-network-base-at-consensus-2023-wrapped.md
@@ -9,7 +9,7 @@ description:
   to highlight the builders, storage providers and storage clients bringing the project
   to life.
 image:
-  url: /assets/images/051823-austin-recap.png
+  src: /assets/images/051823-austin-recap.png
   alt:
 recommended-posts: []
 category: events

--- a/src/content/blog/filecoin-nv19-lightning-upgrade.md
+++ b/src/content/blog/filecoin-nv19-lightning-upgrade.md
@@ -9,7 +9,7 @@ description:
   storage. This technical milestone brings a host of enhancements and improvements
   to the Filecoin ecosystem, enabling greater efficiency, security, and usability.
 image:
-  url: /assets/images/06012023-lightningupgrade.png
+  src: /assets/images/06012023-lightningupgrade.png
   alt:
 recommended-posts: []
 category: news

--- a/src/content/blog/filecoin-storage-provider-spotlight-dcent.md
+++ b/src/content/blog/filecoin-storage-provider-spotlight-dcent.md
@@ -8,7 +8,7 @@ description:
   active in growing and encouraging the local community, organizing meetups and other
   events, as well as providing advice to others in the network.
 image:
-  url: /assets/images/0524-sps-dcent.png
+  src: /assets/images/0524-sps-dcent.png
   alt:
 recommended-posts: []
 category: ecosystem

--- a/src/content/blog/filecoin-storage-provider-spotlight-filswan.md
+++ b/src/content/blog/filecoin-storage-provider-spotlight-filswan.md
@@ -6,8 +6,7 @@ description: >-
   provider that specializes in edge data and goes to great lengths to bring data
   closer to the data source.
 image:
-  url: >-
-    /assets/images/64423adea6ec4171202a5cf2_1-hdrc5daoaw6mxtrklvxhcg.png
+  src: /assets/images/64423adea6ec4171202a5cf2_1-hdrc5daoaw6mxtrklvxhcg.png
   alt:
 updated-on: "2023-04-21T07:27:26.180Z"
 created-on: "2023-04-21T07:27:26.180Z"

--- a/src/content/blog/filecoin-storage-provider-spotlight-linix.md
+++ b/src/content/blog/filecoin-storage-provider-spotlight-linix.md
@@ -7,8 +7,7 @@ description: >-
   Angelo Schalley as a side project to provide web hosting and cloud storage to
   friends and family.
 image:
-  url: >-
-    /assets/images/64423adfef619de193b60e70_1-3vi1mqlj6blg3lay_py58g.png
+  src: /assets/images/64423adfef619de193b60e70_1-3vi1mqlj6blg3lay_py58g.png
   alt:
 updated-on: "2023-04-21T07:27:27.712Z"
 created-on: "2023-04-21T07:27:27.712Z"

--- a/src/content/blog/filecoin-storage-provider-spotlight-meta-blockchain.md
+++ b/src/content/blog/filecoin-storage-provider-spotlight-meta-blockchain.md
@@ -6,8 +6,7 @@ description: >-
   business has two data centers in Seoul and provides enterprise cloud storage
   services via a subsidiary called Meta Cloud and Creation (Meta C&C).
 image:
-  url: >-
-    /assets/images/64423ae18d1be72cd2ceb12e_1-avr_3ujwveph-055eq1s_q.png
+  src: /assets/images/64423ae18d1be72cd2ceb12e_1-avr_3ujwveph-055eq1s_q.png
   alt:
 updated-on: "2023-04-21T07:27:29.284Z"
 created-on: "2023-04-21T07:27:29.284Z"

--- a/src/content/blog/filecoin-storage-provider-spotlight-nonentropy.md
+++ b/src/content/blog/filecoin-storage-provider-spotlight-nonentropy.md
@@ -5,7 +5,7 @@ updated-on: 2023-04-21T07:27:30.951000Z
 published-on: 2023-04-21T07:33:56.200000Z
 description: NonEntropy is on a mission to protect the digital future.
 image:
-  url: /assets/images/64423ae2ef619d69dab60e9f_0-qyjcuk2pe_bhv2jh.png
+  src: /assets/images/64423ae2ef619d69dab60e9f_0-qyjcuk2pe_bhv2jh.png
   alt:
 recommended-posts: []
 category: ecosystem

--- a/src/content/blog/filecoin-storage-provider-spotlight-origin-storage.md
+++ b/src/content/blog/filecoin-storage-provider-spotlight-origin-storage.md
@@ -8,7 +8,7 @@ description:
   technology solutions for the Web3 ecosystem with safe, flexible, and reliable products
   and services. "
 image:
-  url: /assets/images/image-c-01.png
+  src: /assets/images/image-c-01.png
   alt:
 recommended-posts: []
 category: ecosystem

--- a/src/content/blog/filecoin-storage-provider-spotlight-piknik.md
+++ b/src/content/blog/filecoin-storage-provider-spotlight-piknik.md
@@ -5,8 +5,7 @@ description: >-
   Storage Provider Working Group and Protocol Labs MinerX Fellows, PiKNiK joined
   the Filecoin community as a bootstrapped Web3 storage provider.
 image:
-  url: >-
-    /assets/images/64423ae5a6ec4107462a6350_0-dab1y7whx7fuaol0.png
+  src: /assets/images/64423ae5a6ec4107462a6350_0-dab1y7whx7fuaol0.png
   alt:
 updated-on: "2023-04-21T07:27:34.032Z"
 created-on: "2023-04-21T07:27:34.032Z"

--- a/src/content/blog/filecoin-storage-provider-spotlight-seal-storage-technology.md
+++ b/src/content/blog/filecoin-storage-provider-spotlight-seal-storage-technology.md
@@ -5,8 +5,7 @@ description: >-
   decentralized cloud storage. Seal’s advanced infrastructure and services
   enable large organizations to seamlessly store files on the Filecoin network.
 image:
-  url: >-
-    /assets/images/64423ae74e4c68130ff45382_1-tjiihglruqcaybnpwmudmg.png
+  src: /assets/images/64423ae74e4c68130ff45382_1-tjiihglruqcaybnpwmudmg.png
   alt:
 updated-on: "2023-04-21T07:27:36.061Z"
 created-on: "2023-04-21T07:27:36.061Z"

--- a/src/content/blog/filswan-awarded-chainlink-filecoin-joint-grant-to-create-multi-chain-decentralized-data-storage-payment-solution.md
+++ b/src/content/blog/filswan-awarded-chainlink-filecoin-joint-grant-to-create-multi-chain-decentralized-data-storage-payment-solution.md
@@ -8,8 +8,7 @@ description: >-
   decentralized oracles and Filecoin decentralized storage within a single
   application.
 image:
-  url: >-
-    /assets/images/64423ae9ef619d8d6eb60ed0_1-pvi22ssfyyn-thpuj3ltgg.png
+  src: /assets/images/64423ae9ef619d8d6eb60ed0_1-pvi22ssfyyn-thpuj3ltgg.png
   alt:
 updated-on: "2023-04-21T07:27:37.543Z"
 created-on: "2023-04-21T07:27:37.543Z"

--- a/src/content/blog/fip0056-in-last-call-until-03-24-introducing-a-sector-duration-multiplier-and-increasing-sector-duration-times.md
+++ b/src/content/blog/fip0056-in-last-call-until-03-24-introducing-a-sector-duration-multiplier-and-increasing-sector-duration-times.md
@@ -9,7 +9,7 @@ description:
   FIP0056, a proposal aiming to address some of the broader challenges
   facing the Filecoin network, is in its last call until Friday, March 24.
 image:
-  url: /assets/images/0621-2022-01.png
+  src: /assets/images/0621-2022-01.png
   alt:
 recommended-posts: []
 category: ecosystem

--- a/src/content/blog/fip0056-update-proposal-rejected-following-community-feedback-and-deliberation.md
+++ b/src/content/blog/fip0056-update-proposal-rejected-following-community-feedback-and-deliberation.md
@@ -10,7 +10,7 @@ description:
   who elect to commit storage resources to the network for a longer period of time.\
   \  "
 image:
-  url: /assets/images/0621-2022-01.png
+  src: /assets/images/0621-2022-01.png
   alt:
 recommended-posts: []
 category: news

--- a/src/content/blog/fresh-from-ff-early-april.md
+++ b/src/content/blog/fresh-from-ff-early-april.md
@@ -8,7 +8,7 @@ description:
   Check out the latest updates about what the Filecoin Foundation team
   has been up to.
 image:
-  url: /assets/images/0215-ff-3-.png
+  src: /assets/images/0215-ff-3-.png
   alt: Fresh From FF Early April, 2024
 recommended-posts: []
 seo:

--- a/src/content/blog/fresh-from-ff-early-july-2024.md
+++ b/src/content/blog/fresh-from-ff-early-july-2024.md
@@ -7,7 +7,7 @@ category: news
 description: Check out the latest updates about what the Filecoin Foundation
   team has been up to.
 image:
-  url: /assets/images/0215-ff-9-.jpg
+  src: /assets/images/0215-ff-9-.jpg
   alt:
 recommended-posts: []
 seo:

--- a/src/content/blog/fresh-from-ff-early-june-2024.md
+++ b/src/content/blog/fresh-from-ff-early-june-2024.md
@@ -5,7 +5,7 @@ updated-on: 2024-05-31T17:08:54.178Z
 published-on: 2024-05-31T17:08:54.189Z
 description: "Check out the latest updates about what the Filecoin Foundation has been up to."
 image:
-  url: /assets/images/0215-ff-7-.png
+  src: /assets/images/0215-ff-7-.png
   alt: "Filecoin Foundation"
 category: news
 recommended-posts: []

--- a/src/content/blog/fresh-from-ff-early-march-2024.md
+++ b/src/content/blog/fresh-from-ff-early-march-2024.md
@@ -8,7 +8,7 @@ description:
   Check out the latest updates about what the Filecoin Foundation team
   has been up to.
 image:
-  url: /assets/images/0215-ff-1-.png
+  src: /assets/images/0215-ff-1-.png
   alt: Fresh From FF Early March, 2024
 recommended-posts: []
 seo:

--- a/src/content/blog/fresh-from-ff-early-may-2024.md
+++ b/src/content/blog/fresh-from-ff-early-may-2024.md
@@ -8,7 +8,7 @@ description:
   "Check out the latest updates about what the Filecoin Foundation team
   has been up to."
 image:
-  url: /assets/images/fresh-from-ff-early-may.png
+  src: /assets/images/fresh-from-ff-early-may.png
   alt: "Fresh from FF Early May, 2024"
 recommended-posts: []
 seo:

--- a/src/content/blog/fresh-from-ff-mid-april-2024.md
+++ b/src/content/blog/fresh-from-ff-mid-april-2024.md
@@ -8,7 +8,7 @@ description:
   "Check out the latest updates about what the Filecoin Foundation team
   has been up to."
 image:
-  url: /assets/images/0215-ff-4-.png
+  src: /assets/images/0215-ff-4-.png
   alt: "Fresh From FF: Mid-April, 2024"
 recommended-posts: []
 seo:

--- a/src/content/blog/fresh-from-ff-mid-february-2024.md
+++ b/src/content/blog/fresh-from-ff-mid-february-2024.md
@@ -11,7 +11,7 @@ description:
   partners, advocates, and more as we work toward our mission of building a stronger,
   more decentralized internet.
 image:
-  url: /assets/images/0215-ff.png
+  src: /assets/images/0215-ff.png
   alt: "Fresh from FF, Mid-February, 2024 on a radial blue background."
 recommended-posts: []
 seo:

--- a/src/content/blog/fresh-from-ff-mid-june-2024.md
+++ b/src/content/blog/fresh-from-ff-mid-june-2024.md
@@ -7,7 +7,7 @@ category: news
 description: Check out the latest updates about what the Filecoin Foundation
   team has been up to.
 image:
-  url: /assets/images/0215-ff-8-.png
+  src: /assets/images/0215-ff-8-.png
   alt: "Fresh From FF: Mid-June, 2024"
 recommended-posts: []
 seo:

--- a/src/content/blog/fresh-from-ff-mid-march-2024.md
+++ b/src/content/blog/fresh-from-ff-mid-march-2024.md
@@ -8,7 +8,7 @@ description:
   Check out the latest updates about what the Filecoin Foundation team
   has been up to.
 image:
-  url: /assets/images/0215-ff-2-.png
+  src: /assets/images/0215-ff-2-.png
   alt: "Fresh From FF: Mid-March, 2024"
 recommended-posts: []
 seo:

--- a/src/content/blog/fresh-from-ff-mid-may-2024.md
+++ b/src/content/blog/fresh-from-ff-mid-may-2024.md
@@ -8,7 +8,7 @@ description:
   "Check out the latest updates about what the Filecoin Foundation has
   been up to."
 image:
-  url: /assets/images/0215-ff-6-.png
+  src: /assets/images/0215-ff-6-.png
   alt: "Fresh From FF: Mid-May, 2024"
 recommended-posts: []
 seo:

--- a/src/content/blog/from-roadmap-to-reality-three-takeaways-on-the-future-of-filecoin-with-jonathan-victor.md
+++ b/src/content/blog/from-roadmap-to-reality-three-takeaways-on-the-future-of-filecoin-with-jonathan-victor.md
@@ -12,7 +12,7 @@ description:
   in the Filecoin ecosystem.​​​​​​​​​​ In the latest episode, we chatted with Jonathan
   Victor, Ecosystem Lead at Protocol Labs.
 image:
-  url: /assets/images/jonathan-victor.png
+  src: /assets/images/jonathan-victor.png
   alt: From Roadmap to Reality. DWeb Decoded podcast with Jonathan Victor
 recommended-posts: []
 seo:

--- a/src/content/blog/gathering-community-input-on-fip-0018-for-miner-to-storage-provider-terminology-change.md
+++ b/src/content/blog/gathering-community-input-on-fip-0018-for-miner-to-storage-provider-terminology-change.md
@@ -9,7 +9,7 @@ description:
   The Filecoin community is currently considering Filecoin Improvement
   Proposal (FIP) 0018, which proposes to rebrand network “miners” as “storage providers”.
 image:
-  url: /assets/images/fip-header.png
+  src: /assets/images/fip-header.png
   alt:
 recommended-posts: []
 category: ecosystem

--- a/src/content/blog/guest-post-if-the-library-of-alexandria-were-built-better.md
+++ b/src/content/blog/guest-post-if-the-library-of-alexandria-were-built-better.md
@@ -8,7 +8,7 @@ description:
   Guest Post from Museum of Crypto Art on preserving the crypto art movement
   on the Filecoin network.
 image:
-  url: /assets/images/021224-guest-moca-1-.png
+  src: /assets/images/021224-guest-moca-1-.png
   alt: "Guest Post: If the Library of Alexandria Were Built Better"
 recommended-posts: []
 seo:

--- a/src/content/blog/hack-away-in-summer-2021.md
+++ b/src/content/blog/hack-away-in-summer-2021.md
@@ -7,7 +7,7 @@ description:
   This summer, the Filecoin Foundation is supporting numerous hackathons
   for community members.
 image:
-  url: /assets/images/image-c-31.png
+  src: /assets/images/image-c-31.png
   alt:
 recommended-posts: []
 category: events

--- a/src/content/blog/help-us-improve-filecoin-docs-plus-how-to-receive-grant-funding-up-to-50-000.md
+++ b/src/content/blog/help-us-improve-filecoin-docs-plus-how-to-receive-grant-funding-up-to-50-000.md
@@ -5,7 +5,7 @@ updated-on: 2024-05-30T14:16:20.354Z
 published-on: 2024-05-30T14:16:20.362Z
 description: "Filecoin Foundation awards grant funding for critical development projects to foster a more decentralized, efficient, and robust foundation for humanity’s information. Currently, we’re looking to support projects that enhance existing Filecoin documentation or create new educational resources."
 image:
-  url: /assets/images/052924-docgrants.png
+  src: /assets/images/052924-docgrants.png
   alt: "Filecoin Foundation Documentation Grants"
 category: reports
 recommended-posts: []

--- a/src/content/blog/help-us-increase-utility-for-filecoin-and-zcash-chains.md
+++ b/src/content/blog/help-us-increase-utility-for-filecoin-and-zcash-chains.md
@@ -6,8 +6,7 @@ description: >-
   Together, we’re working to empower the Filecoin, Zcash, and greater Web3
   ecosystems through a new grants pool that funds Filecoin and Zcash projects.
 image:
-  url: >-
-    /assets/images/64423af1e3c08fa6464f5199_0-kt1qsyhnwcfriwtg.png
+  src: /assets/images/64423af1e3c08fa6464f5199_0-kt1qsyhnwcfriwtg.png
   alt:
 updated-on: "2023-04-21T07:27:45.806Z"
 created-on: "2023-04-21T07:27:45.806Z"

--- a/src/content/blog/how-artifact-labs-is-preserving-and-connecting-history-and-culture-using-the-blockchain.md
+++ b/src/content/blog/how-artifact-labs-is-preserving-and-connecting-history-and-culture-using-the-blockchain.md
@@ -13,7 +13,7 @@ description: >-
   facilitate rights management of digital assets, and unlock fundraising and
   commercialization opportunities.
 image:
-  url: /assets/images/070723-qa-artifactlabs.png
+  src: /assets/images/070723-qa-artifactlabs.png
   alt:
 recommended-posts: []
 category: use-cases

--- a/src/content/blog/how-basic-beasts-uses-the-filecoin-network-to-design-the-next-generation-of-decentralized-gaming.md
+++ b/src/content/blog/how-basic-beasts-uses-the-filecoin-network-to-design-the-next-generation-of-decentralized-gaming.md
@@ -14,7 +14,7 @@ description:
   4,500 Discord members, 3,000 Twitter followers, and 700 NFT holders, plus collaborations
   with Flowverse, Emerald City, and Flow, Basic Beasts is made by gamers for gamers.
 image:
-  url: /assets/images/0517-dgs-_.png
+  src: /assets/images/0517-dgs-_.png
   alt:
 recommended-posts: []
 category: use-cases

--- a/src/content/blog/how-swash-is-leveraging-filecoin-s-decentralized-storage-network-to-preserve-and-protect-consumer-data.md
+++ b/src/content/blog/how-swash-is-leveraging-filecoin-s-decentralized-storage-network-to-preserve-and-protect-consumer-data.md
@@ -10,7 +10,7 @@ description:
   all prior “internet years” up to 2016 combined. As internet traffic multiplies,
   two trends are developing in parallel.
 image:
-  url: /assets/images/64423af3e3c08f488e4f519c_1-pyb3swiscnbniykvqyrrdq.png
+  src: /assets/images/64423af3e3c08f488e4f519c_1-pyb3swiscnbniykvqyrrdq.png
   alt:
 recommended-posts: []
 category: use-cases

--- a/src/content/blog/insights-from-dweb-decoded-jenks-guo-on-decentralization-and-developer-relations.md
+++ b/src/content/blog/insights-from-dweb-decoded-jenks-guo-on-decentralization-and-developer-relations.md
@@ -10,7 +10,7 @@ description:
   Jenks Guo, a developer advocate at Filecoin Foundation, shared his insights
   on decentralization and its role in shaping the future of the internet.
 image:
-  url: /assets/images/jenks-guo.png
+  src: /assets/images/jenks-guo.png
   alt: Jenks Guo Developer Advocacy Filecoin Foundation
 recommended-posts: []
 seo:

--- a/src/content/blog/insights-into-responsible-ai-with-the-founder-of-ai-guardian-1.md
+++ b/src/content/blog/insights-into-responsible-ai-with-the-founder-of-ai-guardian-1.md
@@ -14,7 +14,7 @@ description: >-
   Decentralized data storage is a reliable solution for preserving AI datasets––
   offering unparalleled resilience, scale, and cost savings.
 image:
-  url: /assets/images/chris-hackney.png
+  src: /assets/images/chris-hackney.png
   alt:
 recommended-posts: []
 seo:

--- a/src/content/blog/introducing-co-rise-course-building-web3-applications-and-filecoin-ipfs.md
+++ b/src/content/blog/introducing-co-rise-course-building-web3-applications-and-filecoin-ipfs.md
@@ -8,7 +8,7 @@ description:
   course focused on building applications on a blockchain with decentralized storage
   on Filecoin/IPFS.
 image:
-  url: /assets/images/64423af4e3c08f6f124f519f_1-gvlzuxsp3dbmsdxwobsexq.png
+  src: /assets/images/64423af4e3c08f6f124f519f_1-gvlzuxsp3dbmsdxwobsexq.png
   alt:
 recommended-posts: []
 category: news

--- a/src/content/blog/introducing-the-filecoin-storage-provider-incubation-center.md
+++ b/src/content/blog/introducing-the-filecoin-storage-provider-incubation-center.md
@@ -7,7 +7,7 @@ description:
   "The Filecoin Foundation is committed to growing and supporting the Filecoin
   ecosystem — miners, developers, and storage clients alike. "
 image:
-  url: /assets/images/image-c-21.png
+  src: /assets/images/image-c-21.png
   alt:
 recommended-posts: []
 category: news

--- a/src/content/blog/introducing-the-future-rules-a-new-podcast-series-from-the-filecoin-foundation-and-forkast-news.md
+++ b/src/content/blog/introducing-the-future-rules-a-new-podcast-series-from-the-filecoin-foundation-and-forkast-news.md
@@ -10,7 +10,7 @@ description: >
   podcast series dedicated to exploring the intersection of Web3 and the many
   factors that impact the growth and viability of a decentralized web.
 image:
-  url: /assets/images/image-c-33.png
+  src: /assets/images/image-c-33.png
   alt:
 recommended-posts: []
 category: news

--- a/src/content/blog/introducing-the-orbit-community-program.md
+++ b/src/content/blog/introducing-the-orbit-community-program.md
@@ -7,7 +7,7 @@ description:
   "We’re excited to announce the launch of the Orbit Community Program,
   powered by Filecoin Foundation and Protocol Labs. "
 image:
-  url: /assets/images/0114-orbitcommunity-twitter.png
+  src: /assets/images/0114-orbitcommunity-twitter.png
   alt:
 recommended-posts: []
 category: news

--- a/src/content/blog/introducing-the-storage-provider-bounty-board.md
+++ b/src/content/blog/introducing-the-storage-provider-bounty-board.md
@@ -8,7 +8,7 @@ description:
   open tool for coordinating work priorities and tapping the collective knowledge
   of the Filecoin ecosystem in crowdsourcing solutions for the storage provider community.
 image:
-  url: /assets/images/image-c-08.png
+  src: /assets/images/image-c-08.png
   alt:
 recommended-posts: []
 category: news

--- a/src/content/blog/introducing-the-wave-7-developer-grant-recipients.md
+++ b/src/content/blog/introducing-the-wave-7-developer-grant-recipients.md
@@ -8,7 +8,7 @@ description:
   to critical development projects to foster a more robust and efficient decentralized
   web through the Filecoin ecosystem. "
 image:
-  url: /assets/images/image-c-32.png
+  src: /assets/images/image-c-32.png
   alt:
 recommended-posts: []
 category: news

--- a/src/content/blog/join-20-fascinating-startups-on-september-28-for-filecoin-launchpad-accelerator-demo-day.md
+++ b/src/content/blog/join-20-fascinating-startups-on-september-28-for-filecoin-launchpad-accelerator-demo-day.md
@@ -9,7 +9,7 @@ description:
   It’s time to register for the upcoming Filecoin II Launchpad Accelerator
   Demo Day, taking place September 28 @ 11:00 AM EDT!
 image:
-  url: /assets/images/64423afe4e4c68b60af47060_0-8alsa5xsesgbjyrr.png
+  src: /assets/images/64423afe4e4c68b60af47060_0-8alsa5xsesgbjyrr.png
   alt:
 recommended-posts: []
 category: events

--- a/src/content/blog/join-the-filecoin-foundation-team-for-a-hiring-webinar.md
+++ b/src/content/blog/join-the-filecoin-foundation-team-for-a-hiring-webinar.md
@@ -7,7 +7,7 @@ description:
   The Filecoin Foundation is part of the community building the next generation
   of the web.
 image:
-  url: /assets/images/64423b004e4c68dc35f473ac_0-zlsuhdrlo5hqa1zy.png
+  src: /assets/images/64423b004e4c68dc35f473ac_0-zlsuhdrlo5hqa1zy.png
   alt:
 recommended-posts: []
 category: news

--- a/src/content/blog/join-us-as-we-build-a-better-web.md
+++ b/src/content/blog/join-us-as-we-build-a-better-web.md
@@ -8,7 +8,7 @@ description:
   we create more than 2.5 quintillion bytes of data daily — from photos and videos,
   tweets and texts, Reddit posts and research reports, and so much more.
 image:
-  url: /assets/images/64423b02e3c08f20a74f51df_1-l9a-l_g2zxiuk3zdsi5lwq-1-.png
+  src: /assets/images/64423b02e3c08f20a74f51df_1-l9a-l_g2zxiuk3zdsi5lwq-1-.png
   alt:
 recommended-posts: []
 category: ecosystem

--- a/src/content/blog/join-us-in-celebrating-filecoin-mainnet-s-one-year-milestone.md
+++ b/src/content/blog/join-us-in-celebrating-filecoin-mainnet-s-one-year-milestone.md
@@ -4,8 +4,7 @@ description: >-
   It’s been one year since the Filecoin Mainnet launch, and there’s a lot
   planned to celebrate this first year in orbit!
 image:
-  url: >-
-    /assets/images/64423b04fa70d18281705693_0-0y1ex6vkr4htxclc.png
+  src: /assets/images/64423b04fa70d18281705693_0-0y1ex6vkr4htxclc.png
   alt:
 updated-on: "2023-04-21T07:28:04.262Z"
 created-on: "2023-04-21T07:28:04.262Z"

--- a/src/content/blog/leading-ai-projects-choose-filecoin-to-advance-ai-marking-the-networks-leading-role-as-depin-backbone-for-ai.md
+++ b/src/content/blog/leading-ai-projects-choose-filecoin-to-advance-ai-marking-the-networks-leading-role-as-depin-backbone-for-ai.md
@@ -6,61 +6,62 @@ updated-on: 2024-07-10T11:33:00.000Z
 published-on: 2024-07-10T11:33:00.000Z
 category: news
 description: "Network announcements include collaborations with SingularityNET,
-  Theoriq, Bagel, and Nuklai. "
+  Theoriq, Bagel, and Nuklai."
 image:
-  url: /assets/images/120624-brussels.jpg
+  src: /assets/images/120624-brussels.jpg
   alt: FIL Brussels logo on black background.
 seo:
   twitter:
     title: summary
     card: summary
-  title: " Leading AI Projects Collaborate with Filecoin Foundation to Drive AI
+  title: "Leading AI Projects Collaborate with Filecoin Foundation to Drive AI
     Innovation"
   description: Filecoin Foundation collaborates with SingularityNET, Theoriq,
     Bagel, Nuklai, and more to enhance AI with decentralized storage and secure
     data solutions.
 ---
-Filecoin Foundation today announced collaborations with prominent AI organizations including SingularityNET, Theoriq, Bagel, and Nuklai. These collaborations, highlighted on stage at FIL Brussels alongside EthCC, underscore the Filecoin network’s pivotal role as the DePIN (Decentralized Physical Infrastructure Network) backbone for advancements in AI. 
 
-The AI industry is facing a critical juncture as more organizations shift toward closed and opaque training models, raising concerns about power concentration, creating information silos and centralized control that expose data to vulnerabilities. The lack of transparency in these systems obscures crucial aspects of AI development, including details on data sources and training methodologies. 
+Filecoin Foundation today announced collaborations with prominent AI organizations including SingularityNET, Theoriq, Bagel, and Nuklai. These collaborations, highlighted on stage at FIL Brussels alongside EthCC, underscore the Filecoin network’s pivotal role as the DePIN (Decentralized Physical Infrastructure Network) backbone for advancements in AI.
 
-The Filecoin network offers an alternative to centralized models by enabling decentralization and transparency, addressing the pressing need for open AI systems and promoting the resilience of digital infrastructure.  
+The AI industry is facing a critical juncture as more organizations shift toward closed and opaque training models, raising concerns about power concentration, creating information silos and centralized control that expose data to vulnerabilities. The lack of transparency in these systems obscures crucial aspects of AI development, including details on data sources and training methodologies.
+
+The Filecoin network offers an alternative to centralized models by enabling decentralization and transparency, addressing the pressing need for open AI systems and promoting the resilience of digital infrastructure.
 
 The latest announcements from the ecosystem highlight the diverse applications of Filecoin for AI. From decentralized storage integrations to open humanities datasets to make Filecoin data more accessible and usable, and comprehensive solutions for storing and processing machine learning (ML) workloads, Filecoin has emerged as the DePIN primitive for the AI wave.
 
-## Secure Data Provenance and Verifiable Model Training 
+## Secure Data Provenance and Verifiable Model Training
 
 [SingularityNET](https://singularitynet.io/), a leading AI platform developer, and Filecoin Foundation are collaborating to store SingularityNET metadata on the Filecoin network via Lighthouse, a data onboarding solution. This collaboration will also integrate the Filecoin tech stack to support archival data needs, enhancing the robustness and security of decentralized data storage. Additionally, the two groups are exploring the formation of an AI Ethics Working Group to encourage responsible sourcing and handling of data in a decentralized AI context. Read the [SingularityNET announcement](https://medium.com/singularitynet/singularitynet-and-filecoin-foundation-collaborate-to-enhance-ai-capabilities-through-depin-6b6db3ea224a).
 
 ## Unlocking the Potential of Open Data Stored on Filecoin with AI Agents
 
-[Theoriq](https://www.theoriq.ai/), an AI base layer platform, and Filecoin Foundation are developing a series of AI agents trained on data from the Filecoin network, making open data more accessible and usable. Currently, a [Filecoin AI agent](https://infinity.theoriq.ai/) trained on the Filecoin docs and GitHub repositories is available for testing. This agent allows users to get answers through natural language queries on how to build on Filecoin, troubleshoot common issues, getting started as a storage provider, and more. 
+[Theoriq](https://www.theoriq.ai/), an AI base layer platform, and Filecoin Foundation are developing a series of AI agents trained on data from the Filecoin network, making open data more accessible and usable. Currently, a [Filecoin AI agent](https://infinity.theoriq.ai/) trained on the Filecoin docs and GitHub repositories is available for testing. This agent allows users to get answers through natural language queries on how to build on Filecoin, troubleshoot common issues, getting started as a storage provider, and more.
 
 Additionally, FF and Theoriq are exploring an AI agent leveraging [25 years of declassified CIA datasets](https://www.muckrock.com/news/archives/2017/jan/17/cias-declassified-database-now-online/) from MuckRock that are stored on Filecoin, enabling efficient and verifiable research of one million documents. Read the [Theoriq announcement](https://mirror.xyz/0xbCAa90C8bA95b3ba6C8Aa6900a92FE70b97E5eF7/y8zj9hbr6ZEES9V9bMtqyzEBm0osh5ivoSBEYVN3mkI).
 
 ## Cost-Effective and Efficient Decentralized AI Infrastructure
 
-[Bagel](https://www.bagel.net/), an AI and cryptography research lab, and Filecoin Foundation are collaborating to enable AI developers to train and store their models using the compute and storage power of the Filecoin network. With Bagel’s decentralized compute network aggregator, Filecoin storage providers will be able to utilize both storage and computational resources, increasing revenue, optimizing compute resource utilization, and accelerating adoption by offering a comprehensive solution for ML workloads. Read the [Bagel announcement](https://www.businesswire.com/news/home/20240708730698/en/Bagel-and-Filecoin-Foundation-Collaborate-to-Support-Decentralized-AI-Development). 
+[Bagel](https://www.bagel.net/), an AI and cryptography research lab, and Filecoin Foundation are collaborating to enable AI developers to train and store their models using the compute and storage power of the Filecoin network. With Bagel’s decentralized compute network aggregator, Filecoin storage providers will be able to utilize both storage and computational resources, increasing revenue, optimizing compute resource utilization, and accelerating adoption by offering a comprehensive solution for ML workloads. Read the [Bagel announcement](https://www.businesswire.com/news/home/20240708730698/en/Bagel-and-Filecoin-Foundation-Collaborate-to-Support-Decentralized-AI-Development).
 
-## Accelerating and Securing Access to AI Data 
+## Accelerating and Securing Access to AI Data
 
-[Nuklai](https://www.nukl.ai/), a collaborative data marketplace and infrastructure provider for data ecosystems, has integrated Filecoin through Lighthouse to make Nuklai’s metadata publicly accessible. Nuklai plans to support secure data uploads to the InterPlanetary File System (IPFS) in the future and is exploring integrating Filecoin as a data storage cluster within its Layer 1 network for enterprise and other use cases, providing a perpetual and decentralized data storage model. Read the [Nuklai announcement](https://www.nukl.ai/blog/nuklai-and-filecoin-foundation-collaborate-to-archive-the-worlds-data). 
+[Nuklai](https://www.nukl.ai/), a collaborative data marketplace and infrastructure provider for data ecosystems, has integrated Filecoin through Lighthouse to make Nuklai’s metadata publicly accessible. Nuklai plans to support secure data uploads to the InterPlanetary File System (IPFS) in the future and is exploring integrating Filecoin as a data storage cluster within its Layer 1 network for enterprise and other use cases, providing a perpetual and decentralized data storage model. Read the [Nuklai announcement](https://www.nukl.ai/blog/nuklai-and-filecoin-foundation-collaborate-to-archive-the-worlds-data).
 
 “For a more decentralized, open, and transparent AI-driven industry, we need data storage and compute solutions that work for businesses, while providing greater transparency and trust around the tech products transforming our lives,” said Danny O’Brien, Senior Fellow, Filecoin Foundation. “We’re thrilled to work with leading projects in this space to make decentralized storage on Filecoin the backbone of the AI wave.”
 
-Also on stage at FIL Brussels and during EthCC, Filecoin ecosystem teams made announcements enriching the tooling and data onboarding solutions available on the network. 
+Also on stage at FIL Brussels and during EthCC, Filecoin ecosystem teams made announcements enriching the tooling and data onboarding solutions available on the network.
 
 ## Qamcom DDS and DeStor Partner to Enhance Data Privacy and Security
 
-[Qamcom](https://www.qamcom.com/) DDS and [DeStor](https://destor.com/) announced a partnership to provide enhanced security, robustness, and petabyte-scale storage services on the Filecoin network. The partnership has secured two clients, including Swedish startups [YayPal](https://www.yaypal.io/), a Web3 gaming studio with over 500,000 users for its flagship game Yay Ride, and [Fieldstream](https://www.fieldstream.ai/), an AI marketing analytics platform. DeStor's platform offers verifiable storage solutions that ensure data integrity and availability through daily data verification. And the partnership with Qamcom DDS allows clients to store extensive data securely and efficiently, ensuring confidentiality and protection. Read [DeStor’s announcement](https://destor.com/resources/news/qamcom-dds-destor-partnership?utm_campaign=DeStor%20x%20Qamcom&utm_content=299525148&utm_medium=social&utm_source=twitter&hss_channel=tw-1643978783375106050). 
+[Qamcom](https://www.qamcom.com/) DDS and [DeStor](https://destor.com/) announced a partnership to provide enhanced security, robustness, and petabyte-scale storage services on the Filecoin network. The partnership has secured two clients, including Swedish startups [YayPal](https://www.yaypal.io/), a Web3 gaming studio with over 500,000 users for its flagship game Yay Ride, and [Fieldstream](https://www.fieldstream.ai/), an AI marketing analytics platform. DeStor's platform offers verifiable storage solutions that ensure data integrity and availability through daily data verification. And the partnership with Qamcom DDS allows clients to store extensive data securely and efficiently, ensuring confidentiality and protection. Read [DeStor’s announcement](https://destor.com/resources/news/qamcom-dds-destor-partnership?utm_campaign=DeStor%20x%20Qamcom&utm_content=299525148&utm_medium=social&utm_source=twitter&hss_channel=tw-1643978783375106050).
 
 ## Fileverse launches dDocs, a private, peer-to-peer, onchain alternative for real-time collaboration
 
-[Fileverse](https://fileverse.io/) launched a decentralized docs app, providing a privacy-enhancing alternative to one of the most used apps on the Internet: Google Docs. With end-to-end encryption by design, [ddocs.new](http://ddocs.new) is a decentralized docs app that ensures that user data remains accessible only by the document owner and those with whom they choose to share it. This encryption approach is also maintained during real-time collaboration. Unlike other platforms, ddocs.new does not store any data on centralized servers. Instead, documents and drafts are stored via peer-to-peer networks like IPFS. Read [Fileverse’s announcement](https://portal.fileverse.io/#/0x73266E4875f3A0828310920A0A54AC1D6d5bec75/file/2?chainId=100). 
+[Fileverse](https://fileverse.io/) launched a decentralized docs app, providing a privacy-enhancing alternative to one of the most used apps on the Internet: Google Docs. With end-to-end encryption by design, [ddocs.new](http://ddocs.new) is a decentralized docs app that ensures that user data remains accessible only by the document owner and those with whom they choose to share it. This encryption approach is also maintained during real-time collaboration. Unlike other platforms, ddocs.new does not store any data on centralized servers. Instead, documents and drafts are stored via peer-to-peer networks like IPFS. Read [Fileverse’s announcement](https://portal.fileverse.io/#/0x73266E4875f3A0828310920A0A54AC1D6d5bec75/file/2?chainId=100).
 
 ### About Filecoin
 
-Filecoin is a peer-to-peer network to store files, with built-in economic incentives to ensure files are stored reliably over time. It’s designed to create a decentralized, efficient, and robust foundation for humanity’s information. 
+Filecoin is a peer-to-peer network to store files, with built-in economic incentives to ensure files are stored reliably over time. It’s designed to create a decentralized, efficient, and robust foundation for humanity’s information.
 
 ### About Filecoin Foundation
 

--- a/src/content/blog/linkstorage-awarded-chainlink-filecoin-joint-grant-to-create-blockchain-data-storage-protocol.md
+++ b/src/content/blog/linkstorage-awarded-chainlink-filecoin-joint-grant-to-create-blockchain-data-storage-protocol.md
@@ -11,7 +11,7 @@ description: >-
   decentralized oracles and Filecoin decentralized storage within a single
   application.
 image:
-  url: /assets/images/64423b050425d3f577f2eb36_1-qzfjf0m6l6_fzcxuic-8zg.png
+  src: /assets/images/64423b050425d3f577f2eb36_1-qzfjf0m6l6_fzcxuic-8zg.png
   alt:
 recommended-posts: []
 category: news

--- a/src/content/blog/look-back-and-look-forward-filecoin-foundation-in-2021-and-2022.md
+++ b/src/content/blog/look-back-and-look-forward-filecoin-foundation-in-2021-and-2022.md
@@ -4,8 +4,7 @@ description: >-
   Filecoin Foundation experienced tremendous growth in 2021, both in size and
   scope.
 image:
-  url: >-
-    /assets/images/64423b078d1be7013acecd8c_0-wrv5zur8bytkshra.png
+  src: /assets/images/64423b078d1be7013acecd8c_0-wrv5zur8bytkshra.png
   alt:
 updated-on: "2023-04-21T07:28:07.363Z"
 created-on: "2023-04-21T07:28:07.363Z"

--- a/src/content/blog/marta-belcher-talks-crypto-privacy-or-lack-thereof-at-consensus-2021.md
+++ b/src/content/blog/marta-belcher-talks-crypto-privacy-or-lack-thereof-at-consensus-2021.md
@@ -7,7 +7,7 @@ description:
   Filecoin Foundation Board Chair Marta Belcher participated in a panel
   discussion on privacy coins at CoinDesk’s Consensus 2021.
 image:
-  url: /assets/images/64423b080425d3dc88f2efd0_0-ujllypeozzx_ebfb.png
+  src: /assets/images/64423b080425d3dc88f2efd0_0-ujllypeozzx_ebfb.png
   alt:
 recommended-posts: []
 category: events

--- a/src/content/blog/meet-filecoin-foundation-developer-advocate-sonia-john.md
+++ b/src/content/blog/meet-filecoin-foundation-developer-advocate-sonia-john.md
@@ -7,7 +7,7 @@ description:
   "The Filecoin Foundation is thrilled to welcome Sonia John to the Filecoin
   Foundation team! "
 image:
-  url: /assets/images/64423b0ae3c08f37be4f5200_1-ollwmtygvgvih2kjh6jffq.png
+  src: /assets/images/64423b0ae3c08f37be4f5200_1-ollwmtygvgvih2kjh6jffq.png
   alt:
 recommended-posts: []
 category: interviews

--- a/src/content/blog/meet-filecoin-foundation-senior-fellow-danny-o-brien.md
+++ b/src/content/blog/meet-filecoin-foundation-senior-fellow-danny-o-brien.md
@@ -4,8 +4,7 @@ description: >-
   The Filecoin Foundation (FF) and the Filecoin Foundation for the Decentralized
   Web (FFDW) are delighted to welcome Danny O’Brien to the team.
 image:
-  url: >-
-    /assets/images/64423b0c0425d33126f2f20d_0-62iqqktk7czvo78e.jpeg
+  src: /assets/images/64423b0c0425d33126f2f20d_0-62iqqktk7czvo78e.jpeg
   alt:
 updated-on: "2023-04-21T07:28:12.620Z"
 created-on: "2023-04-21T07:28:12.620Z"

--- a/src/content/blog/meet-orbit-community-program-ambassadors.md
+++ b/src/content/blog/meet-orbit-community-program-ambassadors.md
@@ -9,7 +9,7 @@ description:
   by Filecoin Foundation and Protocol Labs to amplify the voice of the Filecoin, IPFS,
   and libp2p communities.
 image:
-  url: /assets/images/0713-orbitcommunity.png
+  src: /assets/images/0713-orbitcommunity.png
   alt:
 recommended-posts: []
 category: ecosystem

--- a/src/content/blog/meet-the-filecoin-foundation-and-the-filecoin-foundation-for-the-decentralized-web.md
+++ b/src/content/blog/meet-the-filecoin-foundation-and-the-filecoin-foundation-for-the-decentralized-web.md
@@ -10,7 +10,7 @@ description:
   Foundation for the Decentralized Web (FFDW) took the stage at Filecoin Liftoff Week
   to talk about the future of the organizations and the promise of Web3.
 image:
-  url: /assets/images/64423b0f4e4c686c88f481d6_1-mg36oqbqdetgd3sn8-bgsq.png
+  src: /assets/images/64423b0f4e4c686c88f481d6_1-mg36oqbqdetgd3sn8-bgsq.png
   alt:
 recommended-posts: []
 category: ecosystem

--- a/src/content/blog/meet-the-new-programs-making-it-easier-to-contribute-to-the-filecoin-network.md
+++ b/src/content/blog/meet-the-new-programs-making-it-easier-to-contribute-to-the-filecoin-network.md
@@ -7,7 +7,7 @@ description:
   "This winter, two new programs launched that make it easier than ever
   to contribute to the Filecoin network: Filecoin Saturn and Filecoin Station."
 image:
-  url: /assets/images/12202022-saturnandstation.png
+  src: /assets/images/12202022-saturnandstation.png
   alt:
 recommended-posts: []
 category: ecosystem

--- a/src/content/blog/meet-the-newest-members-of-the-filecoin-foundation-team.md
+++ b/src/content/blog/meet-the-newest-members-of-the-filecoin-foundation-team.md
@@ -8,7 +8,7 @@ description:
   workforce of professionals dedicated to research, development, and community engagement
   around open source, decentralized storage, and nurturing the Filecoin ecosystem.
 image:
-  url: /assets/images/image-c-29.png
+  src: /assets/images/image-c-29.png
   alt:
 recommended-posts: []
 category: news

--- a/src/content/blog/new-agreement-between-filecoin-foundation-and-electric-coin-co-simplifies-halo-licensing-and-creates-grant-pool-for-filecoin-zcash-projects.md
+++ b/src/content/blog/new-agreement-between-filecoin-foundation-and-electric-coin-co-simplifies-halo-licensing-and-creates-grant-pool-for-filecoin-zcash-projects.md
@@ -4,8 +4,7 @@ title: >-
   Halo licensing and creates grant pool for Filecoin-Zcash projects
 description: null
 image:
-  url: >-
-    /assets/images/64423bd7ba1528be454f2e64_0211-zcash-twitter.png
+  src: /assets/images/64423bd7ba1528be454f2e64_0211-zcash-twitter.png
   alt: null
 updated-on: "2023-04-21T07:31:35.155Z"
 created-on: "2023-04-21T07:31:35.155Z"

--- a/src/content/blog/new-survey-american-consumers-are-ready-to-change-up-to-web3.md
+++ b/src/content/blog/new-survey-american-consumers-are-ready-to-change-up-to-web3.md
@@ -8,8 +8,7 @@ description: >-
   reveal that — while Americans trust the internet’s overall resilience, they
   don’t like how their data is managed by the current gatekeepers.
 image:
-  url: >-
-    /assets/images/643e66ba7403cdfbea565a6e_1-57prfcg89azmw_kf5bqvjw.webp
+  src: /assets/images/643e66ba7403cdfbea565a6e_1-57prfcg89azmw_kf5bqvjw.webp
   alt:
 recommended-posts: []
 category: reports

--- a/src/content/blog/new-wave-9-developer-grant-recipients.md
+++ b/src/content/blog/new-wave-9-developer-grant-recipients.md
@@ -8,7 +8,7 @@ description:
   basis to critical development projects to foster a more robust and efficient decentralized
   web through the Filecoin ecosystem. "
 image:
-  url: /assets/images/image-c-17.png
+  src: /assets/images/image-c-17.png
   alt:
 recommended-posts: []
 category: news

--- a/src/content/blog/one-year-of-programmability-smart-contracts-and-dapp-growth-on-filecoin.md
+++ b/src/content/blog/one-year-of-programmability-smart-contracts-and-dapp-growth-on-filecoin.md
@@ -8,7 +8,7 @@ description:
   One year ago on March 14, 2023, the launch of the Filecoin Virtual Machine
   (FVM) brought onchain programmability and smart contracts live on Filecoin mainnet.
 image:
-  url: /assets/images/031224-fvm-anniversary.png
+  src: /assets/images/031224-fvm-anniversary.png
   alt: "One Year of Programmability, Smart Contracts, and Dapp Growth on Filecoin"
 recommended-posts: []
 seo:

--- a/src/content/blog/orbit-fvm-open-hack-days.md
+++ b/src/content/blog/orbit-fvm-open-hack-days.md
@@ -10,7 +10,7 @@ description:
   experience building on FVM. Entrants will develop on FVM in order to compete for
   $6,000 in prizes!
 image:
-  url: /assets/images/0208-orbitfvm.png
+  src: /assets/images/0208-orbitfvm.png
   alt:
 recommended-posts: []
 category: events

--- a/src/content/blog/orbit-year-in-review-growing-a-global-community-of-builders.md
+++ b/src/content/blog/orbit-year-in-review-growing-a-global-community-of-builders.md
@@ -8,7 +8,7 @@ description:
   In 2023, the Filecoin Orbit program helped seed a new crop of thousands
   of builders in the Filecoin ecosystem.
 image:
-  url: /assets/images/231205-orbit-year.png
+  src: /assets/images/231205-orbit-year.png
   alt: "Filecoin Orbit Program Year in Review"
 recommended-posts: []
 seo:

--- a/src/content/blog/orbiting-ethdenver-perspectives-from-a-filecoin-orbit-ambassador.md
+++ b/src/content/blog/orbiting-ethdenver-perspectives-from-a-filecoin-orbit-ambassador.md
@@ -9,7 +9,7 @@ description:
   America came together to host a Filecoin Ecosystem Showcase event. Read about what
   this event meant for the community and the future of the Orbit program.
 image:
-  url: /assets/images/032224-orbit-austin.png
+  src: /assets/images/032224-orbit-austin.png
   alt: "Orbiting ETHDenver: Perspectives From a Filecoin Orbit Ambassador"
 recommended-posts: []
 seo:

--- a/src/content/blog/participate-in-the-filecoin-network-s-poll-on-extending-the-maximum-lifetime-of-v1-sectors.md
+++ b/src/content/blog/participate-in-the-filecoin-network-s-poll-on-extending-the-maximum-lifetime-of-v1-sectors.md
@@ -10,8 +10,7 @@ description: >-
   community members can submit, discuss, and approve changes to the Filecoin
   protocol.
 image:
-  url: >-
-    /assets/images/64423bdeb13e032a58960cfb_1-xicc70v_m64rcu1wlbq6qq.png
+  src: /assets/images/64423bdeb13e032a58960cfb_1-xicc70v_m64rcu1wlbq6qq.png
   alt:
 recommended-posts: []
 category: ecosystem

--- a/src/content/blog/participating-in-the-filecoin-ecosystem-bounties-microgrants-and-fips.md
+++ b/src/content/blog/participating-in-the-filecoin-ecosystem-bounties-microgrants-and-fips.md
@@ -7,7 +7,7 @@ description:
   "As an open-source, decentralized protocol, the success of the Filecoin
   network is inextricably linked with the development of its community. "
 image:
-  url: /assets/images/image-c-20.png
+  src: /assets/images/image-c-20.png
   alt:
 recommended-posts: []
 category: ecosystem

--- a/src/content/blog/recapping-ethdenver-ipc-announcement-exploring-depin-and-connecting-with-the-community.md
+++ b/src/content/blog/recapping-ethdenver-ipc-announcement-exploring-depin-and-connecting-with-the-community.md
@@ -11,7 +11,7 @@ description:
   the Filecoin ecosystem for a week of collaboration and innovation –– to usher the
   network into a new era of adoption and growth."
 image:
-  url: /assets/images/ethdenver.png
+  src: /assets/images/ethdenver.png
   alt:
     "Recapping ETHDenver: IPC Announcement, Exploring DePIN, and Connecting with
     the Community"

--- a/src/content/blog/recapping-filecoin-foundation-at-davos-ipfs-deployed-in-space-exploring-the-future-of-ai-and-web3-future-proofing-regulation-and-more.md
+++ b/src/content/blog/recapping-filecoin-foundation-at-davos-ipfs-deployed-in-space-exploring-the-future-of-ai-and-web3-future-proofing-regulation-and-more.md
@@ -10,7 +10,7 @@ description: The Filecoin Sanctuary in Davos brought together the world’s
   future of the decentralized web.
 recommended-posts: []
 image:
-  url: /assets/images/020724-davos.png
+  src: /assets/images/020724-davos.png
   alt: Recapping Filecoin Foundation at Davos
 seo:
   noindex: false

--- a/src/content/blog/recapping-filecoin-foundation-s-2021-governance-summit.md
+++ b/src/content/blog/recapping-filecoin-foundation-s-2021-governance-summit.md
@@ -8,7 +8,7 @@ description:
   Governance Summit, a three-day series of meetings, brainstorming sessions, and design
   sprints.
 image:
-  url: /assets/images/image-c-18.png
+  src: /assets/images/image-c-18.png
   alt:
 recommended-posts: []
 category: events

--- a/src/content/blog/recognizing-the-recipients-of-the-explorer-awards.md
+++ b/src/content/blog/recognizing-the-recipients-of-the-explorer-awards.md
@@ -8,8 +8,7 @@ description: >-
   series of grants to provide organizations and individuals using decentralized
   technology with the support to learn more about Web3.
 image:
-  url: >-
-    /assets/images/645244ea3a4dd637ee3c0347_0609-ffxunfinished.jpg
+  src: /assets/images/645244ea3a4dd637ee3c0347_0609-ffxunfinished.jpg
   alt:
 recommended-posts: []
 category: news

--- a/src/content/blog/remixing-the-art-world-with-blockchain-technology-a-q-a-with-ntent.md
+++ b/src/content/blog/remixing-the-art-world-with-blockchain-technology-a-q-a-with-ntent.md
@@ -8,7 +8,7 @@ description:
   rules. Now, Web3 is creating a more inclusive and user-centric experience, lowering
   the barrier to entry through decentralized technology.
 image:
-  url: /assets/images/06012023-ntent.png
+  src: /assets/images/06012023-ntent.png
   alt:
 recommended-posts: []
 category: interviews

--- a/src/content/blog/second-round-of-filecoin-plus-notaries-elected-5-pib-more-datacap-awarded.md
+++ b/src/content/blog/second-round-of-filecoin-plus-notaries-elected-5-pib-more-datacap-awarded.md
@@ -7,7 +7,7 @@ description:
   The Filecoin Plus community recently held elections for notaries for
   the second time since its launch.
 image:
-  url: /assets/images/image-c-34.png
+  src: /assets/images/image-c-34.png
   alt:
 recommended-posts: []
 category: news

--- a/src/content/blog/signal-spotlights-software-storage-solutions-built-on-filecoin-to-watch.md
+++ b/src/content/blog/signal-spotlights-software-storage-solutions-built-on-filecoin-to-watch.md
@@ -9,7 +9,7 @@ description: "There are dozens of ways to store data on Filecoin. From
   Filecoin ecosystem includes a range of tools designed to cater to different
   storage needs."
 image:
-  url: /assets/images/120624-spotlight.png
+  src: /assets/images/120624-spotlight.png
   alt: >-
     Logos for Lighthouse, Titan Storage, CIDgravity, GhostDrive, SteelDome, and
     Decentrally

--- a/src/content/blog/social-media-on-the-decentralized-web.md
+++ b/src/content/blog/social-media-on-the-decentralized-web.md
@@ -8,8 +8,7 @@ description: >-
   decentralized social media network Mastodon, in the face of controversial
   layoffs, and leadership and product changes.
 image:
-  url: >-
-    /assets/images/64423be63db3a0a2416bac69_1-vcqlzywn6ec6brxs8lmzng.webp
+  src: /assets/images/64423be63db3a0a2416bac69_1-vcqlzywn6ec6brxs8lmzng.webp
   alt:
 recommended-posts: []
 category: use-cases

--- a/src/content/blog/spotlight-new-filecoin-virtual-machine-projects-unlocking-smart-contract-programmability-1.md
+++ b/src/content/blog/spotlight-new-filecoin-virtual-machine-projects-unlocking-smart-contract-programmability-1.md
@@ -10,7 +10,7 @@ description:
   efficient, and robust platform for humanity’s data by introducing programmability
   to the network.
 image:
-  url: /assets/images/rectangle-32-.png
+  src: /assets/images/rectangle-32-.png
   alt:
 recommended-posts: []
 category: news

--- a/src/content/blog/storage-company-ewesion-leverages-filecoin-network-for-data-preservation-1.md
+++ b/src/content/blog/storage-company-ewesion-leverages-filecoin-network-for-data-preservation-1.md
@@ -8,8 +8,7 @@ description: >-
   serves everyone from large and medium-sized enterprises to media and
   individual users.
 image:
-  url: >-
-    /assets/images/643e66c80a81033d920c68ba_1-b1odemnhfczn_24q2linww.webp
+  src: /assets/images/643e66c80a81033d920c68ba_1-b1odemnhfczn_24q2linww.webp
   alt:
 recommended-posts: []
 category: use-cases

--- a/src/content/blog/storage-company-ewesion-leverages-filecoin-network-for-data-preservation.md
+++ b/src/content/blog/storage-company-ewesion-leverages-filecoin-network-for-data-preservation.md
@@ -8,8 +8,7 @@ description: >-
   serves everyone from large and medium-sized enterprises to media and
   individual users.
 image:
-  url: >-
-    /assets/images/643e66c80a810364460c68bb_1-b1odemnhfczn_24q2linww.png
+  src: /assets/images/643e66c80a810364460c68bb_1-b1odemnhfczn_24q2linww.png
   alt:
 recommended-posts: []
 category: use-cases

--- a/src/content/blog/storage-spotlight-how-twin-quasar-and-celeste-are-bringing-green-data-hosting-to-european-data-storage-clients.md
+++ b/src/content/blog/storage-spotlight-how-twin-quasar-and-celeste-are-bringing-green-data-hosting-to-european-data-storage-clients.md
@@ -9,7 +9,7 @@ description:
   Twin Quasar and CELESTE have teamed up to build an environmentally friendly
   and cost-effective alternative for data storage on the Filecoin network.
 image:
-  url: /assets/images/twin-quasar-celeste-filecoin-blog-image.png
+  src: /assets/images/twin-quasar-celeste-filecoin-blog-image.png
   alt: Twin Quasar and CELESTE logos for Filecoin Foundation blog
 recommended-posts: []
 category: use-cases

--- a/src/content/blog/storing-ai-datasets-on-the-decentralized-web.md
+++ b/src/content/blog/storing-ai-datasets-on-the-decentralized-web.md
@@ -10,8 +10,7 @@ description: >-
   private partners together to develop model AI initiatives, drive policy, and
   facilitate investment, with a special focus on underserved communities.
 image:
-  url: >-
-    /assets/images/643e66c9def161164793d8aa_0-ykastlsfwq52kr4r.png
+  src: /assets/images/643e66c9def161164793d8aa_0-ykastlsfwq52kr4r.png
   alt:
 recommended-posts: []
 category: use-cases

--- a/src/content/blog/supporting-the-community-the-filecoin-storage-provider-group.md
+++ b/src/content/blog/supporting-the-community-the-filecoin-storage-provider-group.md
@@ -8,7 +8,7 @@ description:
   resources, community support, and guidance to everyone involved in building the
   Filecoin and Web3 ecosystems. "
 image:
-  url: /assets/images/image-c-04.png
+  src: /assets/images/image-c-04.png
   alt:
 recommended-posts: []
 category: ecosystem

--- a/src/content/blog/surveying-the-filecoin-community-priorities-and-opportunities-for-2022.md
+++ b/src/content/blog/surveying-the-filecoin-community-priorities-and-opportunities-for-2022.md
@@ -7,7 +7,7 @@ description:
   "As a core building block of the Web3 world, the Filecoin network is
   both open-source and decentralized. "
 image:
-  url: /assets/images/643e66cbb75bbf237f8e1292_1-1dqtfatumnkf7vdkmw1rhq.png
+  src: /assets/images/643e66cbb75bbf237f8e1292_1-1dqtfatumnkf7vdkmw1rhq.png
   alt:
 recommended-posts: []
 category: reports

--- a/src/content/blog/takeaways-from-the-filecoin-community-at-consensus-2024.md
+++ b/src/content/blog/takeaways-from-the-filecoin-community-at-consensus-2024.md
@@ -5,7 +5,7 @@ updated-on: 2024-06-07T01:34:20.372Z
 published-on: 2024-06-07T01:34:20.379Z
 description: "Last week, the Filecoin community convened in Austin against the backdrop of Consensus to hear from some of the ecosystem's leading voices and check out the latest projects building on the network. Filecoin Foundation team members took the stage at events across the conference to highlight what the ecosystem is working on and to underscore the innovation happening throughout the network."
 image:
-  url: /assets/images/060624-consensus.png
+  src: /assets/images/060624-consensus.png
   alt: "Filecoin Foundation at Consensus 2024"
 category: events
 recommended-posts: []

--- a/src/content/blog/thanks-for-participating-in-fip-0014.md
+++ b/src/content/blog/thanks-for-participating-in-fip-0014.md
@@ -7,8 +7,7 @@ description: >-
   The Filecoin community has completed its first-ever FILPoll, a new tool for
   surveying stakeholders on improvement proposals and other initiatives.
 image:
-  url: >-
-    /assets/images/64423bf6ba1528b0814f3496_0-w3wa_u-ynigzoedy.png
+  src: /assets/images/64423bf6ba1528b0814f3496_0-w3wa_u-ynigzoedy.png
   alt:
 recommended-posts: []
 category: news

--- a/src/content/blog/the-filecoin-foundation-announces-50-000-fil-grant-to-the-internet-archive.md
+++ b/src/content/blog/the-filecoin-foundation-announces-50-000-fil-grant-to-the-internet-archive.md
@@ -8,7 +8,7 @@ description:
   data by creating a new internet infrastructure that’s more secure, user-focused,
   and competitive.
 image:
-  url: /assets/images/64423bf8da735f52ab392c9a_0-gxap0iqlhpvsxnst.png
+  src: /assets/images/64423bf8da735f52ab392c9a_0-gxap0iqlhpvsxnst.png
   alt:
 recommended-posts: []
 category: news

--- a/src/content/blog/the-filecoin-virtual-machine-has-arrived.md
+++ b/src/content/blog/the-filecoin-virtual-machine-has-arrived.md
@@ -9,8 +9,7 @@ description: >-
   Filecoin network history, and a major FVM milestone as the network becomes
   programmable for the first time.
 image:
-  url: >-
-    /assets/images/64423bf9da735f547c392f21_unnamed-14.png
+  src: /assets/images/64423bf9da735f547c392f21_unnamed-14.png
   alt:
 recommended-posts: []
 category: news

--- a/src/content/blog/the-foundations-roles-in-the-filecoin-ecosystem.md
+++ b/src/content/blog/the-foundations-roles-in-the-filecoin-ecosystem.md
@@ -7,8 +7,7 @@ description: >-
   In 2017, the creators of Filecoin envisioned an independent foundation that
   would serve as the long-term governance body for the Filecoin ecosystem.
 image:
-  url: >-
-    /assets/images/64423bfbca39dd7d4d1f170f_1-mbcuqyncw-uoyzwsbrapqw.png
+  src: /assets/images/64423bfbca39dd7d4d1f170f_1-mbcuqyncw-uoyzwsbrapqw.png
   alt:
 recommended-posts: []
 category: ecosystem

--- a/src/content/blog/the-growth-of-filecoin-plus-and-upcoming-notary-elections.md
+++ b/src/content/blog/the-growth-of-filecoin-plus-and-upcoming-notary-elections.md
@@ -9,8 +9,7 @@ updated-on: "2023-05-03T11:27:34.731Z"
 created-on: "2023-04-21T07:32:13.414Z"
 published-on: "2023-05-03T12:47:09.568Z"
 image:
-  url: >-
-    /assets/images/64524524a1a3e64e1d97de7f_0202-filpluselection.jpg
+  src: /assets/images/64524524a1a3e64e1d97de7f_0202-filpluselection.jpg
   alt:
 recommended-posts: []
 category: news

--- a/src/content/blog/unleashing-the-power-of-decentralized-compute-with-filecoin.md
+++ b/src/content/blog/unleashing-the-power-of-decentralized-compute-with-filecoin.md
@@ -11,7 +11,7 @@ description:
   access to computing power, enabling individuals and organizations to tap into a
   shared pool of resources without being dependent on a single provider.
 image:
-  url: /assets/images/decentralized-compute-v2.png
+  src: /assets/images/decentralized-compute-v2.png
   alt: "Unleashing the Power of Decentralized Compute with Filecoin"
 recommended-posts: []
 seo:

--- a/src/content/blog/unveiling-the-filecoin-ecosystem-explorer.md
+++ b/src/content/blog/unveiling-the-filecoin-ecosystem-explorer.md
@@ -8,7 +8,7 @@ description:
   The Filecoin Ecosystem Explorer is a crowd-sourced database that showcases
   the breadth and depth of Filecoin ecosystem projects.
 image:
-  url: /assets/images/240109-ecosystemexplorerlaunch_blogheader.png
+  src: /assets/images/240109-ecosystemexplorerlaunch_blogheader.png
   alt: "Filecoin Ecosystem Explorer"
 recommended-posts: []
 seo:

--- a/src/content/blog/venus-v1-0-0-passes-least-authority-security-audit.md
+++ b/src/content/blog/venus-v1-0-0-passes-least-authority-security-audit.md
@@ -8,7 +8,7 @@ description:
   released venus v1.0.0, which will enable global storage providers and clients to
   store valuable data securely on Filecoin.
 image:
-  url: /assets/images/image-c-28.png
+  src: /assets/images/image-c-28.png
   alt:
 recommended-posts: []
 category: news

--- a/src/content/blog/wave-11-dev-grant-recipients.md
+++ b/src/content/blog/wave-11-dev-grant-recipients.md
@@ -8,7 +8,7 @@ description:
   development projects to foster a more robust and efficient decentralized web through
   the Filecoin ecosystem.
 image:
-  url: /assets/images/image-c-17.png
+  src: /assets/images/image-c-17.png
   alt:
 recommended-posts: []
 category: news

--- a/src/content/blog/welcome-to-the-forest-with-chainsafe-s-filecoin.md
+++ b/src/content/blog/welcome-to-the-forest-with-chainsafe-s-filecoin.md
@@ -7,7 +7,7 @@ description:
   Filecoin Mainnet launched one year ago this week, opening up the decentralized
   storage protocol to developers, storage providers, and Web3 enthusiasts worldwide.
 image:
-  url: /assets/images/image-c-19.png
+  src: /assets/images/image-c-19.png
   alt:
 recommended-posts: []
 category: ecosystem

--- a/src/content/blog/what-to-know-about-the-future-of-digital-public-infrastructure-in-five-minutes.md
+++ b/src/content/blog/what-to-know-about-the-future-of-digital-public-infrastructure-in-five-minutes.md
@@ -8,7 +8,7 @@ description:
   a professor at the University of Massachusetts at Amherst, about the future of digital
   public infrastructure and how communities can govern their own digital spaces.
 image:
-  url: /assets/images/0928-filecoinfortnight.png
+  src: /assets/images/0928-filecoinfortnight.png
   alt:
 recommended-posts: []
 category: ecosystem

--- a/src/content/blog/what-to-know-about-the-uses-of-decentralization-in-online-community-governance-in-five-minutes.md
+++ b/src/content/blog/what-to-know-about-the-uses-of-decentralization-in-online-community-governance-in-five-minutes.md
@@ -13,7 +13,7 @@ description: >-
   journalist, who has been recognized for his work on democratic ownership and
   governance models for online platforms and protocols.
 image:
-  url: /assets/images/n-schneider-blogpost-banner.png
+  src: /assets/images/n-schneider-blogpost-banner.png
   alt:
 recommended-posts: []
 category: ecosystem

--- a/src/content/blog/whats-new-with-the-filecoin-plus-notary-election-and-filecoin-day-highlights-from-labweek23.md
+++ b/src/content/blog/whats-new-with-the-filecoin-plus-notary-election-and-filecoin-day-highlights-from-labweek23.md
@@ -12,7 +12,7 @@ description: >-
   intersection of artificial intelligence and decentralized storage, and more.
 category: news
 image:
-  url: /assets/images/231120-fd-fpd.png
+  src: /assets/images/231120-fd-fpd.png
   alt: Filecoin Day and Filecoin Plus Day Recap
 recommended-posts: []
 seo:

--- a/src/content/blog/xinshu-technology-how-the-chinese-shutterfly-uses-the-filecoin-network-to-keep-a-competitive-edge-in-the-photo-sharing-industry.md
+++ b/src/content/blog/xinshu-technology-how-the-chinese-shutterfly-uses-the-filecoin-network-to-keep-a-competitive-edge-in-the-photo-sharing-industry.md
@@ -10,8 +10,7 @@ description: >-
   last a lifetime — and then some — for thousands of Chinese families and
   businesses.
 image:
-  url: >-
-    /assets/images/643e66da3820f63a69cf3f15_1-mspvlfvj4hi7yykisqwcfg.png
+  src: /assets/images/643e66da3820f63a69cf3f15_1-mspvlfvj4hi7yykisqwcfg.png
   alt:
 recommended-posts: []
 category: use-cases

--- a/src/content/blog/you-re-invited-filecoin-fall.md
+++ b/src/content/blog/you-re-invited-filecoin-fall.md
@@ -9,7 +9,7 @@ description:
   involved in the Filecoin community, there’s something for everyone in the ecosystem
   over the next few months."
 image:
-  url: /assets/images/64423c054821268e6e8e743b_1-rdpz1p6lnwm1fnnk37urdw.png
+  src: /assets/images/64423c054821268e6e8e743b_1-rdpz1p6lnwm1fnnk37urdw.png
   alt:
 recommended-posts: []
 category: events

--- a/src/content/ecosystem-explorer/projects/3pad.md
+++ b/src/content/ecosystem-explorer/projects/3pad.md
@@ -13,7 +13,7 @@ tags:
 tech:
   - ipfs
 image:
-  url: /assets/images/pad_logo_white.png
+  src: /assets/images/pad_logo_white.png
   alt: 3Pad Logo
 website: https://hello.3pad.xyz/
 featured-content:

--- a/src/content/ecosystem-explorer/projects/acaisia.md
+++ b/src/content/ecosystem-explorer/projects/acaisia.md
@@ -5,7 +5,7 @@ title: Acaisia
 updated-on: 2024-01-12T19:56:32.835000Z
 published-on: 2024-01-12T19:56:32.887000Z
 image:
-  url: /assets/images/acaisia-logo_white.png
+  src: /assets/images/acaisia-logo_white.png
   alt: Acaisia Logo
 category: storage
 subcategories:

--- a/src/content/ecosystem-explorer/projects/ahdx-aihealthdataxchain.md
+++ b/src/content/ecosystem-explorer/projects/ahdx-aihealthdataxchain.md
@@ -13,7 +13,7 @@ tech:
   - filecoin
   - ipfs
 image:
-  url: /assets/images/ahdx-update-3-2-.png
+  src: /assets/images/ahdx-update-3-2-.png
   alt: AHDX Logo
 website: https://www.ahdx.org/
 featured-content:

--- a/src/content/ecosystem-explorer/projects/algovera.md
+++ b/src/content/ecosystem-explorer/projects/algovera.md
@@ -12,7 +12,7 @@ tags:
 tech:
   - ipfs
 image:
-  url: /assets/images/659872d2b2c229176c8ae210_algovera-whitebackground.png
+  src: /assets/images/659872d2b2c229176c8ae210_algovera-whitebackground.png
   alt: Algovera Logo
 website: "https://www.algovera.ai"
 featured-content:

--- a/src/content/ecosystem-explorer/projects/ankr.md
+++ b/src/content/ecosystem-explorer/projects/ankr.md
@@ -10,7 +10,7 @@ tags:
 tech:
   - filecoin
 image:
-  url: /assets/images/6607329044923c80b38a9b1a_ankr.png
+  src: /assets/images/6607329044923c80b38a9b1a_ankr.png
   alt: Ankr Logo
 website: https://www.ankr.com/
 featured-content:

--- a/src/content/ecosystem-explorer/projects/anytype.md
+++ b/src/content/ecosystem-explorer/projects/anytype.md
@@ -4,7 +4,7 @@ created-on: 2024-04-05T17:13:01.978Z
 updated-on: 2024-04-05T17:13:01.996Z
 published-on: 2024-04-05T17:13:02.007Z
 image:
-  url: /assets/images/anytype.png
+  src: /assets/images/anytype.png
   alt: Anytype Logo
 category: tooling-productivity
 subcategories:

--- a/src/content/ecosystem-explorer/projects/archly.md
+++ b/src/content/ecosystem-explorer/projects/archly.md
@@ -16,7 +16,7 @@ tags:
 tech:
   - filecoin
 image:
-  url: /assets/images/archly-logo-circle-1000.png
+  src: /assets/images/archly-logo-circle-1000.png
   alt: Archly Logo
 website: https://archly.fi
 featured-content:

--- a/src/content/ecosystem-explorer/projects/artifact-labs.md
+++ b/src/content/ecosystem-explorer/projects/artifact-labs.md
@@ -11,7 +11,7 @@ tech:
   - filecoin
   - ipfs
 image:
-  url: /assets/images/659746e70b1ecbf25f67cd3c_artifact-labs-logo.png
+  src: /assets/images/659746e70b1ecbf25f67cd3c_artifact-labs-logo.png
   alt: Artifact Labs Logo
 website: "https://www.artifactlabs.com"
 featured-content: "https://fil.org/blog/how-artifact-labs-is-preserving-and-connecting-history-and-culture-using-the-blockchain/"

--- a/src/content/ecosystem-explorer/projects/astral.md
+++ b/src/content/ecosystem-explorer/projects/astral.md
@@ -12,7 +12,7 @@ tags:
 tech:
   - filecoin
 image:
-  url: /assets/images/66073290d5091847d125282a_astral.png
+  src: /assets/images/66073290d5091847d125282a_astral.png
   alt: Astral Logo
 website: https://astral.global/
 featured-content:

--- a/src/content/ecosystem-explorer/projects/atlas-experiment-at-cern.md
+++ b/src/content/ecosystem-explorer/projects/atlas-experiment-at-cern.md
@@ -14,7 +14,7 @@ tech:
   - filecoin
   - ipfs
 image:
-  url: /assets/images/6597243ac2419e5f35982ce6_rbbxg-heb6koeqarfszeocq4yjtsw2cqpkwb9atop1y.png
+  src: /assets/images/6597243ac2419e5f35982ce6_rbbxg-heb6koeqarfszeocq4yjtsw2cqpkwb9atop1y.png
   alt: Atlas Experiment Logo
 website: "https://atlas.cern"
 featured-content: "https://www.sealstorage.io/blog/atlascern"

--- a/src/content/ecosystem-explorer/projects/audius.md
+++ b/src/content/ecosystem-explorer/projects/audius.md
@@ -12,7 +12,7 @@ tags:
 tech:
   - ipfs
 image:
-  url: /assets/images/659746fdd59f6b944d45ca8f_audius_logo.png
+  src: /assets/images/659746fdd59f6b944d45ca8f_audius_logo.png
   alt: Audius Logo
 website: "https://audius.co"
 featured-content: "https://docs.ipfs.tech/case-studies/audius/"

--- a/src/content/ecosystem-explorer/projects/bacalhau.md
+++ b/src/content/ecosystem-explorer/projects/bacalhau.md
@@ -13,7 +13,7 @@ tech:
   - filecoin
   - ipfs
 image:
-  url: /assets/images/659872da19567f4307ba3b38_bacalhua_logo_white.png
+  src: /assets/images/659872da19567f4307ba3b38_bacalhua_logo_white.png
   alt: Bacalhau Logo
 website: "https://www.bacalhau.org"
 featured-content:

--- a/src/content/ecosystem-explorer/projects/backedby.md
+++ b/src/content/ecosystem-explorer/projects/backedby.md
@@ -12,7 +12,7 @@ tags:
 tech:
   - ipfs
 image:
-  url: /assets/images/backedby.webp
+  src: /assets/images/backedby.webp
   alt: BackedBy Logo
 website: https://backed.by/
 featured-content:

--- a/src/content/ecosystem-explorer/projects/banyan.md
+++ b/src/content/ecosystem-explorer/projects/banyan.md
@@ -16,7 +16,7 @@ tech:
   - filecoin
   - ipfs
 image:
-  url: /assets/images/659872e1c489a49f48f519b0_banyan_logo_white.png
+  src: /assets/images/659872e1c489a49f48f519b0_banyan_logo_white.png
   alt: Banyan Logo
 website: "https://www.banyan.computer"
 featured-content: "https://www.youtube.com/watch?v=SaIGrSjOMP4&list=PLp3zrT1ewY0micCUXk2G1B1-ukbpuclJy&index=11"

--- a/src/content/ecosystem-explorer/projects/basic-beasts.md
+++ b/src/content/ecosystem-explorer/projects/basic-beasts.md
@@ -10,7 +10,7 @@ tags:
 tech:
   - ipfs
 image:
-  url: /assets/images/66073290babeabe27e0b8354_basicbeasts.png
+  src: /assets/images/66073290babeabe27e0b8354_basicbeasts.png
   alt: Basic Beasts Logo
 website: https://www.basicbeasts.io/
 featured-content:

--- a/src/content/ecosystem-explorer/projects/beryx.md
+++ b/src/content/ecosystem-explorer/projects/beryx.md
@@ -12,7 +12,7 @@ tags:
 tech:
   - filecoin
 image:
-  url: /assets/images/beryx_logo_white.png
+  src: /assets/images/beryx_logo_white.png
   alt: Beryx Logo
 website: www.beryx.io
 featured-content:

--- a/src/content/ecosystem-explorer/projects/bifrost-finance.md
+++ b/src/content/ecosystem-explorer/projects/bifrost-finance.md
@@ -14,7 +14,7 @@ tags:
 tech:
   - filecoin
 image:
-  url: /assets/images/660732908635f037e25b982f_bifrost.png
+  src: /assets/images/660732908635f037e25b982f_bifrost.png
   alt: Bifrost Finance Logo
 website: https://bifrost.finance/
 featured-content:

--- a/src/content/ecosystem-explorer/projects/bildo.md
+++ b/src/content/ecosystem-explorer/projects/bildo.md
@@ -13,7 +13,7 @@ tags:
 tech:
   - filecoin
 image:
-  url: /assets/images/bidlo.png
+  src: /assets/images/bidlo.png
   alt: Bidlo Logo
 website: https://bidlo.vercel.app/
 featured-content:

--- a/src/content/ecosystem-explorer/projects/blocz.md
+++ b/src/content/ecosystem-explorer/projects/blocz.md
@@ -13,7 +13,7 @@ tags:
 tech:
   - filecoin
 image:
-  url: /assets/images/blocz.png
+  src: /assets/images/blocz.png
   alt: Blocz Logo
 website: https://www.blocz.io/
 featured-content:

--- a/src/content/ecosystem-explorer/projects/built-different.md
+++ b/src/content/ecosystem-explorer/projects/built-different.md
@@ -12,7 +12,7 @@ tags:
 tech:
   - filecoin
 image:
-  url: /assets/images/660734bb2f8beb060933dd1d_builtdifferent.png
+  src: /assets/images/660734bb2f8beb060933dd1d_builtdifferent.png
   alt: Built Different Logo
 website: https://www.builtdifferent.foundation/
 featured-content:

--- a/src/content/ecosystem-explorer/projects/catalyst.md
+++ b/src/content/ecosystem-explorer/projects/catalyst.md
@@ -17,7 +17,7 @@ tech:
   - filecoin
   - ipfs
 image:
-  url:
+  src:
   alt: Catalyst Logo
 website: https://the-freaking-catalyst.vercel.app
 featured-content:

--- a/src/content/ecosystem-explorer/projects/cavalry.md
+++ b/src/content/ecosystem-explorer/projects/cavalry.md
@@ -13,7 +13,7 @@ tech:
   - filecoin
   - ipfs
 image:
-  url: /assets/images/6597471366ba5cff0f03dfe7_cavalry_logo.png
+  src: /assets/images/6597471366ba5cff0f03dfe7_cavalry_logo.png
   alt: Cavalry Logo
 website: "https://cavalry.scenegroup.co"
 featured-content:

--- a/src/content/ecosystem-explorer/projects/ceramic-network-3box.md
+++ b/src/content/ecosystem-explorer/projects/ceramic-network-3box.md
@@ -10,7 +10,7 @@ tags:
 tech:
   - ipfs
 image:
-  url: /assets/images/660732902f8beb060931f9cb_ceramic.png
+  src: /assets/images/660732902f8beb060931f9cb_ceramic.png
   alt: Ceramic Network (3Box)
 website: https://ceramic.network/
 featured-content:

--- a/src/content/ecosystem-explorer/projects/chainstack.md
+++ b/src/content/ecosystem-explorer/projects/chainstack.md
@@ -13,7 +13,7 @@ tags:
 tech:
   - filecoin
 image:
-  url: /assets/images/660732912d6d72ba4a9774ea_chainstack.png
+  src: /assets/images/660732912d6d72ba4a9774ea_chainstack.png
   alt: Chainstack Logo
 website: https://chainstack.com/
 featured-content:

--- a/src/content/ecosystem-explorer/projects/chemotronix.md
+++ b/src/content/ecosystem-explorer/projects/chemotronix.md
@@ -13,7 +13,7 @@ tags:
 tech:
   - filecoin
 image:
-  url: /assets/images/66073291e29bf5086866ba7e_chemotronix.png
+  src: /assets/images/66073291e29bf5086866ba7e_chemotronix.png
   alt: Chemotronix Logo
 website: https://chemotronix.org/
 featured-content:

--- a/src/content/ecosystem-explorer/projects/cidgravity.md
+++ b/src/content/ecosystem-explorer/projects/cidgravity.md
@@ -10,7 +10,7 @@ tags:
 tech:
   - filecoin
 image:
-  url: /assets/images/cid-gravity.jpeg
+  src: /assets/images/cid-gravity.jpeg
   alt: CIDgravity Logo
 website: https://www.cidgravity.com/
 featured-content:

--- a/src/content/ecosystem-explorer/projects/clover.md
+++ b/src/content/ecosystem-explorer/projects/clover.md
@@ -10,7 +10,7 @@ tags:
 tech:
   - filecoin
 image:
-  url: /assets/images/660732916a689d42cb0e1eb4_clover.png
+  src: /assets/images/660732916a689d42cb0e1eb4_clover.png
   alt: Clover Logo
 website: https://useclover.xyz/
 featured-content:

--- a/src/content/ecosystem-explorer/projects/collectif-dao.md
+++ b/src/content/ecosystem-explorer/projects/collectif-dao.md
@@ -13,7 +13,7 @@ tags:
 tech:
   - filecoin
 image:
-  url: /assets/images/collectoflogo.png
+  src: /assets/images/collectoflogo.png
   alt: Collectif DAO Logo
 website: "https://collectif.finance/"
 featured-content:

--- a/src/content/ecosystem-explorer/projects/cookbook-dev.md
+++ b/src/content/ecosystem-explorer/projects/cookbook-dev.md
@@ -12,7 +12,7 @@ tags:
 tech:
   - filecoin
 image:
-  url: /assets/images/cookbook.dev.png
+  src: /assets/images/cookbook.dev.png
   alt: Cookbook Logo
 website: https://www.cookbook.dev/
 featured-content:

--- a/src/content/ecosystem-explorer/projects/cooperdb.md
+++ b/src/content/ecosystem-explorer/projects/cooperdb.md
@@ -12,7 +12,7 @@ tags:
 tech:
   - filecoin
 image:
-  url:
+  src:
   alt: CooperDB Logo
 website: https://cooper-db.vercel.app/
 featured-content:

--- a/src/content/ecosystem-explorer/projects/coophive.md
+++ b/src/content/ecosystem-explorer/projects/coophive.md
@@ -11,7 +11,7 @@ tech:
   - filecoin
   - ipfs
 image:
-  url: /assets/images/finalnewcoophives-01.png
+  src: /assets/images/finalnewcoophives-01.png
   alt: CoopHive Logo
 website: https://www.coophive.network/
 featured-content:

--- a/src/content/ecosystem-explorer/projects/corgi-1.md
+++ b/src/content/ecosystem-explorer/projects/corgi-1.md
@@ -12,7 +12,7 @@ tags:
 tech:
   - filecoin
 image:
-  url: /assets/images/corgi_logo_white.png
+  src: /assets/images/corgi_logo_white.png
   alt: CORGI Logo
 website: "https://filecorgi.xyz/"
 featured-content:

--- a/src/content/ecosystem-explorer/projects/crossfi.md
+++ b/src/content/ecosystem-explorer/projects/crossfi.md
@@ -15,7 +15,7 @@ tags:
 tech:
   - filecoin
 image:
-  url: /assets/images/crossfi_logo_white.png
+  src: /assets/images/crossfi_logo_white.png
   alt: CrossFi Logo
 website: "https://crossfimain.com/"
 featured-content:

--- a/src/content/ecosystem-explorer/projects/cryptoworth.md
+++ b/src/content/ecosystem-explorer/projects/cryptoworth.md
@@ -12,7 +12,7 @@ tags:
 tech:
   - filecoin
 image:
-  url: /assets/images/cw-logo-square-1-.png
+  src: /assets/images/cw-logo-square-1-.png
   alt: Cryptoworth Logo
 website: https://Cryptoworth.com
 featured-content:

--- a/src/content/ecosystem-explorer/projects/daln.md
+++ b/src/content/ecosystem-explorer/projects/daln.md
@@ -4,7 +4,7 @@ created-on: 2024-04-03T16:51:43.448Z
 updated-on: 2024-04-03T16:51:43.470Z
 published-on: 2024-04-03T16:51:43.478Z
 image:
-  url: /assets/images/daln.png
+  src: /assets/images/daln.png
   alt: Data as Labor Network (DALN) Logo
 category: storage
 subcategories:

--- a/src/content/ecosystem-explorer/projects/datahaus.md
+++ b/src/content/ecosystem-explorer/projects/datahaus.md
@@ -13,7 +13,7 @@ tags:
 tech:
   - filecoin
 image:
-  url: /assets/images/6607329442b3d343f69c52d7_datahaus.png
+  src: /assets/images/6607329442b3d343f69c52d7_datahaus.png
   alt: DataHaus Logo
 featured-content:
 website: https://datahaus.vercel.app/

--- a/src/content/ecosystem-explorer/projects/datalatte.md
+++ b/src/content/ecosystem-explorer/projects/datalatte.md
@@ -12,7 +12,7 @@ tags:
 tech:
   - filecoin
 image:
-  url: /assets/images/66073567a94418c44efc8fa2_datalatte.png
+  src: /assets/images/66073567a94418c44efc8fa2_datalatte.png
   alt: Datalatte Logo
 featured-content:
 website: https://www.datalatte.com/

--- a/src/content/ecosystem-explorer/projects/dcent.md
+++ b/src/content/ecosystem-explorer/projects/dcent.md
@@ -15,7 +15,7 @@ tech:
   - filecoin
   - ipfs
 image:
-  url: /assets/images/6597471cd556a0c37caf9706_dcent_logo.png
+  src: /assets/images/6597471cd556a0c37caf9706_dcent_logo.png
   alt: DCENT Logo
 website: https://dcent.nl
 featured-content: https://fil.org/blog/filecoin-storage-provider-spotlight-dcent/

--- a/src/content/ecosystem-explorer/projects/ddrive.md
+++ b/src/content/ecosystem-explorer/projects/ddrive.md
@@ -11,7 +11,7 @@ tags:
 tech:
   - ipfs
 image:
-  url: /assets/images/bafkreial2z6akpzox3bbrzhf6ocguzs265ymhb37ektremkdigdexo25vu.png
+  src: /assets/images/bafkreial2z6akpzox3bbrzhf6ocguzs265ymhb37ektremkdigdexo25vu.png
   alt: dDrive Logo
 featured-content:
 website: https://app.valist.io/d-drive/d-drive-pwa

--- a/src/content/ecosystem-explorer/projects/decentroge.md
+++ b/src/content/ecosystem-explorer/projects/decentroge.md
@@ -4,7 +4,7 @@ created-on: 2024-04-03T17:57:20.097Z
 updated-on: 2024-04-03T17:57:20.173Z
 published-on: 2024-04-03T17:57:20.191Z
 image:
-  url: /assets/images/decentroge.png
+  src: /assets/images/decentroge.png
   alt: Decentroge Logo
 category: storage
 subcategories:

--- a/src/content/ecosystem-explorer/projects/defluencer.md
+++ b/src/content/ecosystem-explorer/projects/defluencer.md
@@ -12,7 +12,7 @@ tags:
 tech:
   - ipfs
 image:
-  url: /assets/images/defluencer_logo_blur.svg
+  src: /assets/images/defluencer_logo_blur.svg
   alt: Defluencer Logo
 featured-content:
 website: https://social.defluencer.eth.limo/#/

--- a/src/content/ecosystem-explorer/projects/democracys-library.md
+++ b/src/content/ecosystem-explorer/projects/democracys-library.md
@@ -15,7 +15,7 @@ tech:
   - ipfs
   - filecoin
 image:
-  url: /assets/images/democracys-library-logo.png
+  src: /assets/images/democracys-library-logo.png
   alt: Democracy's Library Logo
 website: https://archive.org/details/democracys-library
 featured-content: https://fil.org/blog/democracy%E2%80%99s-library-announces-more-than-a-petabyte-of-government-data-uploaded-to-the-filecoin-network/

--- a/src/content/ecosystem-explorer/projects/desci-labs.md
+++ b/src/content/ecosystem-explorer/projects/desci-labs.md
@@ -13,7 +13,7 @@ tech:
   - filecoin
   - ipfs
 image:
-  url: /assets/images/659872e921cfae476602eef2_desci_logo_white.png
+  src: /assets/images/659872e921cfae476602eef2_desci_logo_white.png
   alt: DeSci Labs Logo
 website: https://desci.com
 featured-content: https://fil.org/blog/case-study-desci-labs-and-filecoin-enabling-a-future-of-open-science/

--- a/src/content/ecosystem-explorer/projects/domainfns.md
+++ b/src/content/ecosystem-explorer/projects/domainfns.md
@@ -4,7 +4,7 @@ created-on: 2024-05-16T14:33:32.585Z
 updated-on: 2024-05-16T14:33:32.598Z
 published-on: 2024-05-16T14:33:32.612Z
 image:
-  url: /assets/images/domainfns.png
+  src: /assets/images/domainfns.png
   alt: DomainFNS Logo
 category: tooling-productivity
 subcategories:

--- a/src/content/ecosystem-explorer/projects/dosier.md
+++ b/src/content/ecosystem-explorer/projects/dosier.md
@@ -4,7 +4,7 @@ created-on: 2024-04-05T23:07:24.299Z
 updated-on: 2024-04-05T23:07:24.311Z
 published-on: 2024-04-05T23:07:24.324Z
 image:
-  url: /assets/images/dosier.png
+  src: /assets/images/dosier.png
   alt: Dosier Logo
 category: storage
 subcategories:

--- a/src/content/ecosystem-explorer/projects/drpc.md
+++ b/src/content/ecosystem-explorer/projects/drpc.md
@@ -10,7 +10,7 @@ tags:
 tech:
   - filecoin
 image:
-  url: /assets/images/drpc_symbol_fullcolor-2x.png
+  src: /assets/images/drpc_symbol_fullcolor-2x.png
   alt: dRPC Logo
 featured-content:
 website: https://drpc.org/

--- a/src/content/ecosystem-explorer/projects/dvol.md
+++ b/src/content/ecosystem-explorer/projects/dvol.md
@@ -4,7 +4,7 @@ created-on: 2024-04-05T00:07:23.530Z
 updated-on: 2024-04-05T00:07:23.555Z
 published-on: 2024-04-05T00:07:23.578Z
 image:
-  url: /assets/images/dvol.png
+  src: /assets/images/dvol.png
   alt: DVol Logo
 category: storage
 subcategories:

--- a/src/content/ecosystem-explorer/projects/e-ipfs.md
+++ b/src/content/ecosystem-explorer/projects/e-ipfs.md
@@ -12,7 +12,7 @@ tech:
   - ipfs
   - filecoin
 image:
-  url:
+  src:
   alt: E-IPFS Logo
 featured-content:
 website: https://e-ipfs.web.app/

--- a/src/content/ecosystem-explorer/projects/easier-data-initiative.md
+++ b/src/content/ecosystem-explorer/projects/easier-data-initiative.md
@@ -14,7 +14,7 @@ tags:
 tech:
   - filecoin
 image:
-  url: /assets/images/easier-data-initiative.png
+  src: /assets/images/easier-data-initiative.png
   alt: EASIER Data Initiative Logo
 website: https://easierdata.org/
 featured-content: https://ffdweb.org/blog/ffdw-and-easier-data-initiative-collaborate-to-upload-spatial-data-to-filecoin-network/

--- a/src/content/ecosystem-explorer/projects/eastore.md
+++ b/src/content/ecosystem-explorer/projects/eastore.md
@@ -10,7 +10,7 @@ tags:
 tech:
   - filecoin
 image:
-  url: /assets/images/eastore-logo.png
+  src: /assets/images/eastore-logo.png
   alt: Eastore Logo
 featured-content:
 website: https://devfolio.co/projects/eastore-e336

--- a/src/content/ecosystem-explorer/projects/ecko.md
+++ b/src/content/ecosystem-explorer/projects/ecko.md
@@ -4,7 +4,7 @@ created-on: 2024-04-05T00:20:25.907Z
 updated-on: 2024-04-05T00:20:25.917Z
 published-on: 2024-04-05T00:20:25.930Z
 image:
-  url: /assets/images/ecko.png
+  src: /assets/images/ecko.png
   alt: Ecko Logo
 category: tooling-productivity
 subcategories:

--- a/src/content/ecosystem-explorer/projects/elastic.md
+++ b/src/content/ecosystem-explorer/projects/elastic.md
@@ -13,7 +13,7 @@ tags:
 tech:
   - ipfs
 image:
-  url:
+  src:
   alt: Elastic Logo
 featured-content:
 website: https://elastic-nft-renting-protocol.netlify.app/

--- a/src/content/ecosystem-explorer/projects/encryption-pinner.md
+++ b/src/content/ecosystem-explorer/projects/encryption-pinner.md
@@ -13,7 +13,7 @@ tags:
 tech:
   - ipfs
 image:
-  url:
+  src:
   alt: Encryption Pinner Logo
 featured-content:
 website: https://devpost.com/software/encryption-pinner?ref_content=user-portfolio&ref_feature=in_progress

--- a/src/content/ecosystem-explorer/projects/eqty-lab-arc-collective.md
+++ b/src/content/ecosystem-explorer/projects/eqty-lab-arc-collective.md
@@ -14,7 +14,7 @@ tags:
 tech:
   - filecoin
 image:
-  url: /assets/images/6607329226071981e4a3559d_eqty.png
+  src: /assets/images/6607329226071981e4a3559d_eqty.png
   alt: EQTY Lab Logo
 featured-content:
 website: https://eqtylab.io

--- a/src/content/ecosystem-explorer/projects/ethereum-name-service.md
+++ b/src/content/ecosystem-explorer/projects/ethereum-name-service.md
@@ -4,7 +4,7 @@ created-on: 2024-04-05T01:47:43.262Z
 updated-on: 2024-04-05T01:47:43.284Z
 published-on: 2024-04-05T01:47:43.298Z
 image:
-  url: /assets/images/ethereum-name-service.png
+  src: /assets/images/ethereum-name-service.png
   alt: Ethereum Name Service Logo
 category: tooling-productivity
 subcategories:

--- a/src/content/ecosystem-explorer/projects/expanso.md
+++ b/src/content/ecosystem-explorer/projects/expanso.md
@@ -12,7 +12,7 @@ tags:
 tech:
   - filecoin
 image:
-  url: /assets/images/66073293f3fde26e66fedef5_expanso.png
+  src: /assets/images/66073293f3fde26e66fedef5_expanso.png
   alt: Expanso Logo
 featured-content:
 website: https://expanso.io

--- a/src/content/ecosystem-explorer/projects/filecoin-foundation-for-the-decentralized-web.md
+++ b/src/content/ecosystem-explorer/projects/filecoin-foundation-for-the-decentralized-web.md
@@ -16,7 +16,7 @@ tech:
   - filecoin
   - ipfs
 image:
-  url: /assets/images/659733d8ebbc2392eda725b0_nidrogvqqb87r8e6c8ygsc2llv7o2zu11hlqz-blvti.png
+  src: /assets/images/659733d8ebbc2392eda725b0_nidrogvqqb87r8e6c8ygsc2llv7o2zu11hlqz-blvti.png
   alt: Filecoin Foundation for the Decentralized Web Logo
 website: https://ffdweb.org
 featured-content: https://ffdweb.org/resources/

--- a/src/content/ecosystem-explorer/projects/filecoin-foundation.md
+++ b/src/content/ecosystem-explorer/projects/filecoin-foundation.md
@@ -15,7 +15,7 @@ tech:
   - filecoin
   - ipfs
 image:
-  url: /assets/images/659733d82e7f66b9fcc1207e_f6wivrnb4g_jcnxz5nbjgibuwdr2lejvhqh4hpyebuc.svg
+  src: /assets/images/659733d82e7f66b9fcc1207e_f6wivrnb4g_jcnxz5nbjgibuwdr2lejvhqh4hpyebuc.svg
   alt: Filecoin Foundation Logo
 website: https://fil.org
 featured-content: https://fil.org/blog/

--- a/src/content/ecosystem-explorer/projects/filecoin-green.md
+++ b/src/content/ecosystem-explorer/projects/filecoin-green.md
@@ -15,7 +15,7 @@ tech:
   - filecoin
   - ipfs
 image:
-  url: /assets/images/65974726d10f3992a40f40f6_fil_green_outline.png
+  src: /assets/images/65974726d10f3992a40f40f6_fil_green_outline.png
   alt: Filecoin Green Logo
 website: https://green.filecoin.io
 featured-content:

--- a/src/content/ecosystem-explorer/projects/filecoin-incentive-designlabs.md
+++ b/src/content/ecosystem-explorer/projects/filecoin-incentive-designlabs.md
@@ -16,7 +16,7 @@ tags:
 tech:
   - filecoin
 image:
-  url: /assets/images/logo-alpha.png
+  src: /assets/images/logo-alpha.png
   alt: Filecoin Incentive DesignLabs Logo
 featured-content:
 website: https://fidl.tech

--- a/src/content/ecosystem-explorer/projects/filecoin-saturn.md
+++ b/src/content/ecosystem-explorer/projects/filecoin-saturn.md
@@ -14,7 +14,7 @@ tech:
   - filecoin
   - ipfs
 image:
-  url: /assets/images/659872f1c67584b1fd35fdf7_filecoinsaturn_logo_white.png
+  src: /assets/images/659872f1c67584b1fd35fdf7_filecoinsaturn_logo_white.png
   alt: Filecoin Saturn Logo
 website: https://saturn.tech
 featured-content:

--- a/src/content/ecosystem-explorer/projects/filecoin-station.md
+++ b/src/content/ecosystem-explorer/projects/filecoin-station.md
@@ -15,7 +15,7 @@ tech:
   - filecoin
   - ipfs
 image:
-  url: /assets/images/65974732c5826a2570dfd210_filecoin-station-logo.png
+  src: /assets/images/65974732c5826a2570dfd210_filecoin-station-logo.png
   alt: Filecoin Station Logo
 website: "https://www.filstation.app"
 repo: "https://github.com/filecoin-station/desktop"

--- a/src/content/ecosystem-explorer/projects/filedrive.md
+++ b/src/content/ecosystem-explorer/projects/filedrive.md
@@ -13,7 +13,7 @@ tech:
   - filecoin
   - ipfs
 image:
-  url: /assets/images/659872fd67c584b3534c7331_filedrive_logo_white.png
+  src: /assets/images/659872fd67c584b3534c7331_filedrive_logo_white.png
   alt: FileDrive Logo
 website: "https://filedrive.io"
 featured-content:

--- a/src/content/ecosystem-explorer/projects/filemarket.md
+++ b/src/content/ecosystem-explorer/projects/filemarket.md
@@ -17,7 +17,7 @@ tech:
   - filecoin
   - ipfs
 image:
-  url: /assets/images/filemarket_logo_white.png
+  src: /assets/images/filemarket_logo_white.png
   alt: FileMarket Logo
 website: "https://filemarket.xyz"
 featured-content:

--- a/src/content/ecosystem-explorer/projects/filenova.md
+++ b/src/content/ecosystem-explorer/projects/filenova.md
@@ -4,7 +4,7 @@ created-on: 2024-04-24T19:39:19.905Z
 updated-on: 2024-04-24T19:39:19.923Z
 published-on: 2024-04-24T19:39:19.935Z
 image:
-  url: /assets/images/filenova.png
+  src: /assets/images/filenova.png
   alt: Filenova Logo
 category: storage
 subcategories:

--- a/src/content/ecosystem-explorer/projects/filet-finance.md
+++ b/src/content/ecosystem-explorer/projects/filet-finance.md
@@ -10,7 +10,7 @@ tags:
 tech:
   - filecoin
 image:
-  url: /assets/images/66073292d3ce5e439caf9f7f_filetfinance.png
+  src: /assets/images/66073292d3ce5e439caf9f7f_filetfinance.png
   alt: Filet Finance Logo
 featured-content:
 website: https://www.filet.finance

--- a/src/content/ecosystem-explorer/projects/fileverse.md
+++ b/src/content/ecosystem-explorer/projects/fileverse.md
@@ -13,7 +13,7 @@ tech:
   - filecoin
   - ipfs
 image:
-  url: /assets/images/65987305cbcf4ef8c43f229e_fileverse_logo_white.png
+  src: /assets/images/65987305cbcf4ef8c43f229e_fileverse_logo_white.png
   alt: Fileverse Logo
 website: "https://fileverse.io"
 featured-content: "https://www.youtube.com/watch?v=-RTvaZVSzi0&list=PL_0VrY55uV1_B19kuAg-ExQ-Wa2d1hCbf&index=5"

--- a/src/content/ecosystem-explorer/projects/filezilla.md
+++ b/src/content/ecosystem-explorer/projects/filezilla.md
@@ -13,7 +13,7 @@ tags:
 tech:
   - filecoin
 image:
-  url: /assets/images/zilla_logo_white.png
+  src: /assets/images/zilla_logo_white.png
   alt: FileZilla Logo
 featured-content:
 website: https://file-zilla.pro/

--- a/src/content/ecosystem-explorer/projects/filfi.md
+++ b/src/content/ecosystem-explorer/projects/filfi.md
@@ -12,7 +12,7 @@ tags:
 tech:
   - filecoin
 image:
-  url: /assets/images/filfi_logo_white.png
+  src: /assets/images/filfi_logo_white.png
   alt: FilFi Logo
 featured-content:
 website: https://filfi.io

--- a/src/content/ecosystem-explorer/projects/filliquid.md
+++ b/src/content/ecosystem-explorer/projects/filliquid.md
@@ -13,7 +13,7 @@ tech:
   - filecoin
   - ipfs
 image:
-  url: /assets/images/filliquid_logo_white.png
+  src: /assets/images/filliquid_logo_white.png
   alt: FILLiquid Logo
 website: "https://filliquid.io/"
 featured-content:

--- a/src/content/ecosystem-explorer/projects/filscan.md
+++ b/src/content/ecosystem-explorer/projects/filscan.md
@@ -14,7 +14,7 @@ tech:
   - filecoin
   - ipfs
 image:
-  url: /assets/images/65974a1e84648b50ab0c7214_filscanlogo-text.png
+  src: /assets/images/65974a1e84648b50ab0c7214_filscanlogo-text.png
   alt: Filscan Logo
 website: https://filscan.io/en
 featured-content:

--- a/src/content/ecosystem-explorer/projects/filscriptions.md
+++ b/src/content/ecosystem-explorer/projects/filscriptions.md
@@ -11,7 +11,7 @@ tech:
   - filecoin
   - ipfs
 image:
-  url: /assets/images/filscriptions_logo_white.png
+  src: /assets/images/filscriptions_logo_white.png
   alt: Filscriptions Logo
 website: https://www.filscriptions.market/
 featured-content:

--- a/src/content/ecosystem-explorer/projects/fission.md
+++ b/src/content/ecosystem-explorer/projects/fission.md
@@ -13,7 +13,7 @@ tech:
   - filecoin
   - ipfs
 image:
-  url: /assets/images/65974a282128bbdde2005e43_fission.png
+  src: /assets/images/65974a282128bbdde2005e43_fission.png
   alt: Fission Logo
 website: https://fission.codes
 featured-content:

--- a/src/content/ecosystem-explorer/projects/flame-launch.md
+++ b/src/content/ecosystem-explorer/projects/flame-launch.md
@@ -10,7 +10,7 @@ tags:
 tech:
   - filecoin
 image:
-  url: /assets/images/flame.png
+  src: /assets/images/flame.png
   alt: Flame Launch Logo
 website: https://www.flamelaunch.com/
 featured-content:

--- a/src/content/ecosystem-explorer/projects/flare-api-portal.md
+++ b/src/content/ecosystem-explorer/projects/flare-api-portal.md
@@ -4,7 +4,7 @@ created-on: 2024-04-05T13:18:56.133Z
 updated-on: 2024-04-05T13:18:56.169Z
 published-on: 2024-04-05T13:18:56.214Z
 image:
-  url: /assets/images/flare.png
+  src: /assets/images/flare.png
   alt: Flare API Portal Logo
 category: tooling-productivity
 subcategories:

--- a/src/content/ecosystem-explorer/projects/fleek.md
+++ b/src/content/ecosystem-explorer/projects/fleek.md
@@ -15,7 +15,7 @@ tech:
   - filecoin
   - ipfs
 image:
-  url: /assets/images/65974a30749bbcefd1c904e3_fleek-xyz-logo-dark-866fe3a5fd4b25673eebd25c841bfe30.png
+  src: /assets/images/65974a30749bbcefd1c904e3_fleek-xyz-logo-dark-866fe3a5fd4b25673eebd25c841bfe30.png
   alt: Fleek Logo
 website: "https://fleek.co"
 repo: "https://github.com/FleekHQ"

--- a/src/content/ecosystem-explorer/projects/fluence.md
+++ b/src/content/ecosystem-explorer/projects/fluence.md
@@ -11,7 +11,7 @@ tech:
   - filecoin
   - ipfs
 image:
-  url: /assets/images/65974a3978ec3f84fca9004a_fluence-logo_wordmark_black.png
+  src: /assets/images/65974a3978ec3f84fca9004a_fluence-logo_wordmark_black.png
   alt: Fluence Logo
 website: "https://fluence.network"
 repo: "https://github.com/fluencelabs"

--- a/src/content/ecosystem-explorer/projects/fog-works-inc.md
+++ b/src/content/ecosystem-explorer/projects/fog-works-inc.md
@@ -16,7 +16,7 @@ tech:
   - ipfs
   - filecoin
 image:
-  url: /assets/images/fog-works-logo-white.png
+  src: /assets/images/fog-works-logo-white.png
   alt: Fog Works Logo
 website: fogworks.io
 featured-content:

--- a/src/content/ecosystem-explorer/projects/force-community.md
+++ b/src/content/ecosystem-explorer/projects/force-community.md
@@ -13,7 +13,7 @@ tags:
 tech:
   - filecoin
 image:
-  url: /assets/images/66073292f68243b0fc173909_forcecommunity.png
+  src: /assets/images/66073292f68243b0fc173909_forcecommunity.png
   alt: Force Community
 website: https://forcecommunity.io/
 featured-content:

--- a/src/content/ecosystem-explorer/projects/foxwallet.md
+++ b/src/content/ecosystem-explorer/projects/foxwallet.md
@@ -12,7 +12,7 @@ tags:
 tech:
   - filecoin
 image:
-  url: /assets/images/screenshot-2024-02-07-at-11.20.48-am.png
+  src: /assets/images/screenshot-2024-02-07-at-11.20.48-am.png
   alt: FoxWallet Logo
 website: "https://foxwallet.com/en"
 repo: "github.com/foxwallet"

--- a/src/content/ecosystem-explorer/projects/froghub.md
+++ b/src/content/ecosystem-explorer/projects/froghub.md
@@ -11,7 +11,7 @@ tags:
 tech:
   - filecoin
 image:
-  url: /assets/images/froghub.png
+  src: /assets/images/froghub.png
   alt: FrogHub Logo
 website: https://froghub.io/
 featured-content:

--- a/src/content/ecosystem-explorer/projects/functionland-fula.md
+++ b/src/content/ecosystem-explorer/projects/functionland-fula.md
@@ -12,7 +12,7 @@ tags:
 tech:
   - ipfs
 image:
-  url: /assets/images/functionland_logo_white.png
+  src: /assets/images/functionland_logo_white.png
   alt: "Functionland Logo: A Decentralized storage replacement for cloud"
 website: "https://fx.land/"
 repo: "https://github.com/functionland"

--- a/src/content/ecosystem-explorer/projects/fvm-dapp.md
+++ b/src/content/ecosystem-explorer/projects/fvm-dapp.md
@@ -13,7 +13,7 @@ tags:
 tech:
   - filecoin
 image:
-  url: /assets/images/fvm-dapp.png
+  src: /assets/images/fvm-dapp.png
   alt: FVM Dapp Logo
 website: https://www.npmjs.com/package/create-fvm-dapp
 featured-content:

--- a/src/content/ecosystem-explorer/projects/gainforest.md
+++ b/src/content/ecosystem-explorer/projects/gainforest.md
@@ -13,7 +13,7 @@ tech:
   - filecoin
   - ipfs
 image:
-  url: /assets/images/6598730db2c229176c8afc29_gainforest_logo_white.png
+  src: /assets/images/6598730db2c229176c8afc29_gainforest_logo_white.png
   alt: Gainforest Logo
 website: https://gainforest.earth
 featured-content: https://green.filecoin.io/web3-and-the-sustainable-data-movement/

--- a/src/content/ecosystem-explorer/projects/genrait.md
+++ b/src/content/ecosystem-explorer/projects/genrait.md
@@ -14,7 +14,7 @@ tech:
   - filecoin
   - ipfs
 image:
-  url: /assets/images/65974a4a0cea1eb2d9c5b69b_genrait-logo.png
+  src: /assets/images/65974a4a0cea1eb2d9c5b69b_genrait-logo.png
   alt: GenRAIT Logo
 website: "https://www.genrait.com"
 featured-content: "https://fil.org/blog/case-study-genrait-leverages-filecoin-network-for-greater-visibility-access-and-storage-of-genomic-data/"

--- a/src/content/ecosystem-explorer/projects/ghostdrive-global.md
+++ b/src/content/ecosystem-explorer/projects/ghostdrive-global.md
@@ -4,7 +4,7 @@ created-on: 2024-03-29T21:28:50.750Z
 updated-on: 2024-05-16T14:59:06.623Z
 published-on: 2024-05-16T14:59:06.634Z
 image:
-  url: /assets/images/gohstdrive.png
+  src: /assets/images/gohstdrive.png
   alt: Ghost Drive
 category: storage
 subcategories:

--- a/src/content/ecosystem-explorer/projects/glif.md
+++ b/src/content/ecosystem-explorer/projects/glif.md
@@ -12,7 +12,7 @@ tags:
 tech:
   - filecoin
 image:
-  url: /assets/images/long_white.png
+  src: /assets/images/long_white.png
   alt: GLIF Logo
 website: https://glif.io
 repo: https://github.com/glifio

--- a/src/content/ecosystem-explorer/projects/glitter-protocol.md
+++ b/src/content/ecosystem-explorer/projects/glitter-protocol.md
@@ -10,7 +10,7 @@ tags:
 tech:
   - filecoin
 image:
-  url: /assets/images/66073293f19c58932d89ebea_glitter.png
+  src: /assets/images/66073293f19c58932d89ebea_glitter.png
   alt: Glitter Protocol
 website: https://glitterprotocol.io/
 featured-content:

--- a/src/content/ecosystem-explorer/projects/hamster.md
+++ b/src/content/ecosystem-explorer/projects/hamster.md
@@ -11,7 +11,7 @@ tags:
 tech:
   - filecoin
 image:
-  url: /assets/images/660732932560f8884ec24d4c_hamster.png
+  src: /assets/images/660732932560f8884ec24d4c_hamster.png
   alt: Hamster
 website: https://hamsternet.io/
 featured-content:

--- a/src/content/ecosystem-explorer/projects/hashguard.md
+++ b/src/content/ecosystem-explorer/projects/hashguard.md
@@ -12,7 +12,7 @@ tags:
 tech:
   - ipfs
 image:
-  url: /assets/images/hashgaurd_logo_white.png
+  src: /assets/images/hashgaurd_logo_white.png
   alt: Hashguard
 website: https://hashguard.io/
 featured-content:

--- a/src/content/ecosystem-explorer/projects/hashmix.md
+++ b/src/content/ecosystem-explorer/projects/hashmix.md
@@ -10,7 +10,7 @@ tags:
 tech:
   - filecoin
 image:
-  url: /assets/images/6607329439c3fa2c2d0c7b18_hashmix.png
+  src: /assets/images/6607329439c3fa2c2d0c7b18_hashmix.png
   alt: HashMix
 website: https://fvm.hashmix.org/
 featured-content:

--- a/src/content/ecosystem-explorer/projects/hauska-ai.md
+++ b/src/content/ecosystem-explorer/projects/hauska-ai.md
@@ -13,7 +13,7 @@ tech:
   - filecoin
   - ipfs
 image:
-  url: /assets/images/hauska_logo_white.png
+  src: /assets/images/hauska_logo_white.png
   alt: Hauska   Design | Protect | Exchange
 website: https://www.hauska.ai/
 featured-content:

--- a/src/content/ecosystem-explorer/projects/haven.md
+++ b/src/content/ecosystem-explorer/projects/haven.md
@@ -12,7 +12,7 @@ tags:
 tech:
   - filecoin
 image:
-  url: /assets/images/660732939d359eb7bc732049_haven.png
+  src: /assets/images/660732939d359eb7bc732049_haven.png
   alt: Haven
 website: https://havendp.com
 featured-content:

--- a/src/content/ecosystem-explorer/projects/huddle01.md
+++ b/src/content/ecosystem-explorer/projects/huddle01.md
@@ -14,7 +14,7 @@ tech:
   - filecoin
   - ipfs
 image:
-  url: /assets/images/65974a51b7581c4ee8e3b899_huddle.png
+  src: /assets/images/65974a51b7581c4ee8e3b899_huddle.png
   alt: Huddle01 Logo
 website: "https://www.huddle01.com"
 featured-content:

--- a/src/content/ecosystem-explorer/projects/human-rights-data-analysis-group-hrdag.md
+++ b/src/content/ecosystem-explorer/projects/human-rights-data-analysis-group-hrdag.md
@@ -15,7 +15,7 @@ tech:
   - filecoin
   - ipfs
 image:
-  url: /assets/images/hrdag_logo_white.png
+  src: /assets/images/hrdag_logo_white.png
   alt: Human Rights Data Analysis Group (HRDAG) Logo
 website: https://hrdag.org/
 featured-content: https://ffdweb.org/blog/can-filecoin-be-the-storage-network-for-human-rights-data/

--- a/src/content/ecosystem-explorer/projects/internet-development-studio-company.md
+++ b/src/content/ecosystem-explorer/projects/internet-development-studio-company.md
@@ -15,7 +15,7 @@ tech:
   - filecoin
   - ipfs
 image:
-  url: /assets/images/idsc_logo_white.png
+  src: /assets/images/idsc_logo_white.png
   alt: Internet Development Studio Company Logo
 website: https://internet.dev
 featured-content:

--- a/src/content/ecosystem-explorer/projects/jackrabbit-finance.md
+++ b/src/content/ecosystem-explorer/projects/jackrabbit-finance.md
@@ -10,7 +10,7 @@ tags:
 tech:
   - filecoin
 image:
-  url: /assets/images/screenshot-2024-04-03-at-8.47-1.png
+  src: /assets/images/screenshot-2024-04-03-at-8.47-1.png
   alt: Jackrabbit Finance Logo
 website: http://www.jackrabbitfinance.xyz/
 featured-content:

--- a/src/content/ecosystem-explorer/projects/kamu.md
+++ b/src/content/ecosystem-explorer/projects/kamu.md
@@ -13,7 +13,7 @@ tags:
 tech:
   - filecoin
 image:
-  url: /assets/images/kamu-logo.svg
+  src: /assets/images/kamu-logo.svg
   alt: Kamu Logo
 website: https://www.kamu.dev/
 featured-content:

--- a/src/content/ecosystem-explorer/projects/ken-labs.md
+++ b/src/content/ecosystem-explorer/projects/ken-labs.md
@@ -4,7 +4,7 @@ created-on: 2024-04-04T01:31:54.103Z
 updated-on: 2024-04-04T01:31:54.122Z
 published-on: 2024-04-04T01:31:54.137Z
 image:
-  url: /assets/images/ken.png
+  src: /assets/images/ken.png
   alt: KEN Labs Logo
 category: tooling-productivity
 subcategories:

--- a/src/content/ecosystem-explorer/projects/labdao.md
+++ b/src/content/ecosystem-explorer/projects/labdao.md
@@ -11,7 +11,7 @@ tags:
 tech:
   - ipfs
 image:
-  url: /assets/images/66073294cc627368322b763a_labdao.png
+  src: /assets/images/66073294cc627368322b763a_labdao.png
   alt: LabDAO
 website: https://labdao.xyz/
 featured-content:

--- a/src/content/ecosystem-explorer/projects/lagrange-dao.md
+++ b/src/content/ecosystem-explorer/projects/lagrange-dao.md
@@ -13,7 +13,7 @@ tech:
   - "filecoin"
   - "ipfs"
 image:
-  url: /assets/images/659873b32cdb61e3755fc1c7_langrange_dao_logo_white.png
+  src: /assets/images/659873b32cdb61e3755fc1c7_langrange_dao_logo_white.png
   alt: "Lagrange DAO Logo"
 website: "https://lagrangedao.org"
 featured-content:

--- a/src/content/ecosystem-explorer/projects/ledgermail.md
+++ b/src/content/ecosystem-explorer/projects/ledgermail.md
@@ -10,7 +10,7 @@ tags:
 tech:
   - filecoin
 image:
-  url: /assets/images/66073295e0ea12e6b43cd691_ledgermail.png
+  src: /assets/images/66073295e0ea12e6b43cd691_ledgermail.png
   alt: LedgerMail Logo
 website: https://ledgermail.io
 featured-content:

--- a/src/content/ecosystem-explorer/projects/leto.md
+++ b/src/content/ecosystem-explorer/projects/leto.md
@@ -11,7 +11,7 @@ tags:
 tech:
   - ipfs
 image:
-  url: /assets/images/leto-logo.png
+  src: /assets/images/leto-logo.png
   alt: Leto Logo
 website: https://leto.gg/
 featured-content:

--- a/src/content/ecosystem-explorer/projects/lighthouse.md
+++ b/src/content/ecosystem-explorer/projects/lighthouse.md
@@ -13,7 +13,7 @@ tech:
   - filecoin
   - ipfs
 image:
-  url: /assets/images/65974a6233564725198bb791_lighthouse.storage.png
+  src: /assets/images/65974a6233564725198bb791_lighthouse.storage.png
   alt: Lighthouse Logo
 website: https://www.lighthouse.storage
 featured-content: https://filecoin.io/blog/posts/lighthouse-makes-permanent-storage-on-filecoin-easy-and-affordable/

--- a/src/content/ecosystem-explorer/projects/liquicert.md
+++ b/src/content/ecosystem-explorer/projects/liquicert.md
@@ -4,7 +4,7 @@ created-on: 2024-03-22T16:24:25.057Z
 updated-on: 2024-03-22T16:24:25.069Z
 published-on: 2024-03-22T16:24:25.078Z
 image:
-  url: /assets/images/liquicert.png
+  src: /assets/images/liquicert.png
   alt: Liquicert Logo
 category: tooling-productivity
 subcategories:

--- a/src/content/ecosystem-explorer/projects/livepeer.md
+++ b/src/content/ecosystem-explorer/projects/livepeer.md
@@ -15,7 +15,7 @@ tech:
   - "filecoin"
   - "ipfs"
 image:
-  url: /assets/images/659751d1ccb76baf40759190_livepeer-logo-primary-1200px-white-transparent-computer-backpack.png
+  src: /assets/images/659751d1ccb76baf40759190_livepeer-logo-primary-1200px-white-transparent-computer-backpack.png
   alt: "Livepeer Logo"
 website: "https://livepeer.org"
 featured-content: "https://medium.com/livepeer-blog/video-streaming-with-fvm-and-livepeer-5646eee1ba78"

--- a/src/content/ecosystem-explorer/projects/lotus.md
+++ b/src/content/ecosystem-explorer/projects/lotus.md
@@ -12,7 +12,7 @@ tags:
 tech:
   - ipfs
 image:
-  url: # "/assets/images/lotus-logo-big-1-.png"
+  src: # "/assets/images/lotus-logo-big-1-.png"
   alt:
     "Lotus: The gateway to secure and decentralized digital storage on the Filecoin
     network."

--- a/src/content/ecosystem-explorer/projects/lurk-lab.md
+++ b/src/content/ecosystem-explorer/projects/lurk-lab.md
@@ -4,7 +4,7 @@ created-on: 2024-03-29T21:28:53.087Z
 updated-on: 2024-03-29T21:45:16.786Z
 published-on: 2024-03-29T21:45:16.786Z
 image:
-  url: /assets/images/lurk.png
+  src: /assets/images/lurk.png
   alt: Lurk Lab Logo
 category: storage
 subcategories:

--- a/src/content/ecosystem-explorer/projects/marlin-protocol.md
+++ b/src/content/ecosystem-explorer/projects/marlin-protocol.md
@@ -16,7 +16,7 @@ tags:
 tech:
   - ipfs
 image:
-  url: /assets/images/marlin-logo-whitehigh-res.png
+  src: /assets/images/marlin-logo-whitehigh-res.png
   alt: Marlin Logo
 featured-content:
 website: www.marlin.org

--- a/src/content/ecosystem-explorer/projects/merklebot.md
+++ b/src/content/ecosystem-explorer/projects/merklebot.md
@@ -14,7 +14,7 @@ tags:
 tech:
   - filecoin
 image:
-  url: /assets/images/merklebot.png
+  src: /assets/images/merklebot.png
   alt: MerkleBot Logo
 featured-content:
 website: https://merklebot.com

--- a/src/content/ecosystem-explorer/projects/metapals.md
+++ b/src/content/ecosystem-explorer/projects/metapals.md
@@ -13,7 +13,7 @@ tags:
 tech:
   - ipfs
 image:
-  url: /assets/images/6607367ee29bf508686a1043_metapals.png
+  src: /assets/images/6607367ee29bf508686a1043_metapals.png
   alt: MetaPals Logo
 featured-content:
 website: https://metapals.pet/

--- a/src/content/ecosystem-explorer/projects/mona.md
+++ b/src/content/ecosystem-explorer/projects/mona.md
@@ -4,7 +4,7 @@ created-on: 2024-03-29T21:28:53.652Z
 updated-on: 2024-03-29T21:45:56.946Z
 published-on: 2024-03-29T21:45:56.946Z
 image:
-  url: /assets/images/mona.png
+  src: /assets/images/mona.png
   alt: Mona
 category: media-entertainment
 subcategories:

--- a/src/content/ecosystem-explorer/projects/mosaia.md
+++ b/src/content/ecosystem-explorer/projects/mosaia.md
@@ -11,7 +11,7 @@ tags:
 tech:
   - "filecoin"
 image:
-  url: "/assets/images/mosaia_logo_white.png"
+  src: "/assets/images/mosaia_logo_white.png"
 website: "https://www.mosaia.io/"
 featured-content:
 repo:

--- a/src/content/ecosystem-explorer/projects/muckrock.md
+++ b/src/content/ecosystem-explorer/projects/muckrock.md
@@ -14,7 +14,7 @@ tech:
   - "filecoin"
   - "ipfs"
 image:
-  url: "/assets/images/muckrock_logo_white.png"
+  src: "/assets/images/muckrock_logo_white.png"
   alt: "MuckRock Logo Filecoin Ecosystem Explorer"
 website: "https://www.muckrock.com/"
 featured-content: "https://ffdweb.org/blog/empowering-a-more-informed-transparent-society-with-decentralized-technology/"

--- a/src/content/ecosystem-explorer/projects/murmuration-labs.md
+++ b/src/content/ecosystem-explorer/projects/murmuration-labs.md
@@ -10,7 +10,7 @@ tags:
 tech:
   - filecoin
 image:
-  url: /assets/images/660736a78635f037e25f71c5_murmurationlabs.png
+  src: /assets/images/660736a78635f037e25f71c5_murmurationlabs.png
   alt: Murmuration Labs Logo
 website: https://murmuration.ai/
 featured-content:

--- a/src/content/ecosystem-explorer/projects/museum-of-crypto-art-m-c.md
+++ b/src/content/ecosystem-explorer/projects/museum-of-crypto-art-m-c.md
@@ -14,7 +14,7 @@ tech:
   - "filecoin"
   - "ipfs"
 image:
-  url: /assets/images/659751c70b1ecbf25f6faaf3_moca.png
+  src: /assets/images/659751c70b1ecbf25f6faaf3_moca.png
   alt: "Museum of Crypto Art Logo"
 website: "https://museumofcryptoart.com"
 featured-content:

--- a/src/content/ecosystem-explorer/projects/nd-labs.md
+++ b/src/content/ecosystem-explorer/projects/nd-labs.md
@@ -12,7 +12,7 @@ tags:
 tech:
   - filecoin
 image:
-  url: /assets/images/nd-logo-1-.png
+  src: /assets/images/nd-logo-1-.png
   alt: ND LABS Logo
 website: https://www.ndlabs.io/#/
 featured-content:

--- a/src/content/ecosystem-explorer/projects/nebula-block.md
+++ b/src/content/ecosystem-explorer/projects/nebula-block.md
@@ -17,7 +17,7 @@ tags:
 tech:
   - filecoin
 image:
-  url: /assets/images/nebulahblock_logo_white.png
+  src: /assets/images/nebulahblock_logo_white.png
   alt: Nebula Block Logo
 featured-content:
 website: https://www.nebulablock.com/

--- a/src/content/ecosystem-explorer/projects/neyra-ai-from-wise-data-pte.md
+++ b/src/content/ecosystem-explorer/projects/neyra-ai-from-wise-data-pte.md
@@ -12,7 +12,7 @@ tags:
 tech:
   - filecoin
 image:
-  url: # "/assets/images/logo-2-.png"
+  src: # "/assets/images/logo-2-.png"
   alt: "Neyra AI"
 website: "https://drive.neyra.ai/"
 featured-content:

--- a/src/content/ecosystem-explorer/projects/nft-storage.md
+++ b/src/content/ecosystem-explorer/projects/nft-storage.md
@@ -12,7 +12,7 @@ tech:
   - "filecoin"
   - "ipfs"
 image:
-  url: /assets/images/6598749d492fd7a346d84c3b_nft.storage_logo_white.png
+  src: /assets/images/6598749d492fd7a346d84c3b_nft.storage_logo_white.png
   alt: "NFT.Storage Logo"
 website: "https://nft.storage"
 featured-content:

--- a/src/content/ecosystem-explorer/projects/niftyguilds.md
+++ b/src/content/ecosystem-explorer/projects/niftyguilds.md
@@ -11,7 +11,7 @@ tags:
 tech:
   - ipfs
 image:
-  url: /assets/images/660736b1d3ce5e439cb32029_niftyguilds.png
+  src: /assets/images/660736b1d3ce5e439cb32029_niftyguilds.png
   alt: NiftyGuilds Logo
 featured-content:
 website: https://niftyguilds.vercel.app/

--- a/src/content/ecosystem-explorer/projects/ntent.md
+++ b/src/content/ecosystem-explorer/projects/ntent.md
@@ -12,7 +12,7 @@ tags:
 tech:
   - "ipfs"
 image:
-  url: /assets/images/659873ecd5b28bbed5b03be9_ntent_logo_white.png
+  src: /assets/images/659873ecd5b28bbed5b03be9_ntent_logo_white.png
   alt: "Ntent Logo"
 website: "https://www.ntent.art"
 featured-content:

--- a/src/content/ecosystem-explorer/projects/nuklai.md
+++ b/src/content/ecosystem-explorer/projects/nuklai.md
@@ -4,7 +4,8 @@ created-on: 2024-07-08T10:11:00.000Z
 updated-on: 2024-07-08T10:11:00.000Z
 published-on: 2024-07-08T10:11:00.000Z
 image:
-  url: /assets/images/nuklai.png
+  src: /assets/images/nuklai.png
+  alt: Nuklai Logo
 category: artificial-intelligence
 subcategories:
   - artificial-productivity-utilities

--- a/src/content/ecosystem-explorer/projects/nulink.md
+++ b/src/content/ecosystem-explorer/projects/nulink.md
@@ -10,7 +10,7 @@ tags:
 tech:
   - filecoin
 image:
-  url: /assets/images/nulink.png
+  src: /assets/images/nulink.png
   alt: NuLink Logo
 website: https://www.nulink.org/
 featured-content:

--- a/src/content/ecosystem-explorer/projects/numbers-protocol.md
+++ b/src/content/ecosystem-explorer/projects/numbers-protocol.md
@@ -14,7 +14,7 @@ tech:
   - "filecoin"
   - "ipfs"
 image:
-  url: /assets/images/6597243838833597a71f11e6_icngy4es52inzwhpzt2c0uodiwktmytv6cqlvo6kya8.png
+  src: /assets/images/6597243838833597a71f11e6_icngy4es52inzwhpzt2c0uodiwktmytv6cqlvo6kya8.png
   alt: "Numbers Protocol Logo"
 website: "https://numbersprotocol.org"
 featured-content:

--- a/src/content/ecosystem-explorer/projects/ocean-protocol.md
+++ b/src/content/ecosystem-explorer/projects/ocean-protocol.md
@@ -13,7 +13,7 @@ tech:
   - "filecoin"
   - "ipfs"
 image:
-  url: /assets/images/659751a52d6836af7fb440be_ocean-protocol-logo.png
+  src: /assets/images/659751a52d6836af7fb440be_ocean-protocol-logo.png
   alt: "Ocean Protocol Logo"
 website: "https://oceanprotocol.com"
 featured-content:

--- a/src/content/ecosystem-explorer/projects/okcontract.md
+++ b/src/content/ecosystem-explorer/projects/okcontract.md
@@ -13,7 +13,7 @@ tags:
 tech:
   - "ipfs"
 image:
-  url: "/assets/images/okcontract-logo-white.png"
+  src: "/assets/images/okcontract-logo-white.png"
   alt: "OKcontract"
 website: "https://okcontract.com/"
 featured-content:

--- a/src/content/ecosystem-explorer/projects/opengate.md
+++ b/src/content/ecosystem-explorer/projects/opengate.md
@@ -13,7 +13,7 @@ tags:
 tech:
   - ipfs
 image:
-  url: /assets/images/659751960cea1eb2d9ca9d33_opengate_logo.png
+  src: /assets/images/659751960cea1eb2d9ca9d33_opengate_logo.png
   alt: OpenGate Logo
 website: "www.opengatenft.com"
 featured-content:

--- a/src/content/ecosystem-explorer/projects/opsci.md
+++ b/src/content/ecosystem-explorer/projects/opsci.md
@@ -15,7 +15,7 @@ tech:
   - filecoin
   - ipfs
 image:
-  url: /assets/images/6597519ebea972da31ebe933_opsci_clear-withtext_666x206.png
+  src: /assets/images/6597519ebea972da31ebe933_opsci_clear-withtext_666x206.png
   alt: OpSci Logo
 website: "https://www.opsci.io"
 featured-content:

--- a/src/content/ecosystem-explorer/projects/orbitvault.md
+++ b/src/content/ecosystem-explorer/projects/orbitvault.md
@@ -10,7 +10,7 @@ tags:
 tech:
   - filecoin
 image:
-  url: /assets/images/orbitvault_logo_white.png
+  src: /assets/images/orbitvault_logo_white.png
   alt: OrbitVault Logo
 website: http://orbitvault.io/
 featured-content:

--- a/src/content/ecosystem-explorer/projects/parasail.md
+++ b/src/content/ecosystem-explorer/projects/parasail.md
@@ -13,7 +13,7 @@ tags:
 tech:
   - filecoin
 image:
-  url: /assets/images/parasail-white-logo-transparent-background.png
+  src: /assets/images/parasail-white-logo-transparent-background.png
   alt: Parasail Logo
 website: http://parasail.network/
 featured-content:

--- a/src/content/ecosystem-explorer/projects/piknik.md
+++ b/src/content/ecosystem-explorer/projects/piknik.md
@@ -16,7 +16,7 @@ tech:
   - filecoin
   - ipfs
 image:
-  url: /assets/images/6597518e66ba5cff0f0ab78f_piknik-logo.png
+  src: /assets/images/6597518e66ba5cff0f0ab78f_piknik-logo.png
   alt: PikNik Logo
 website: "https://www.piknik.com"
 featured-content:

--- a/src/content/ecosystem-explorer/projects/portrait.md
+++ b/src/content/ecosystem-explorer/projects/portrait.md
@@ -13,7 +13,7 @@ tech:
   - filecoin
   - ipfs
 image:
-  url: /assets/images/659751868be4ed306bb8b8df_portrait.png
+  src: /assets/images/659751868be4ed306bb8b8df_portrait.png
   alt: Portrait Logo
 website: "https://portrait.gg/"
 featured-content:

--- a/src/content/ecosystem-explorer/projects/project-dokaz.md
+++ b/src/content/ecosystem-explorer/projects/project-dokaz.md
@@ -15,7 +15,7 @@ tech:
   - ipfs
   - filecoin
 image:
-  url: /assets/images/dokaz_logo_white.png
+  src: /assets/images/dokaz_logo_white.png
 website: "https://www.starlinglab.org/"
 featured-content: "https://www.cnn.com/2022/06/10/tech/ukraine-war-crimes-blockchain/index.html"
 repo:

--- a/src/content/ecosystem-explorer/projects/proofmode-by-guardian-project.md
+++ b/src/content/ecosystem-explorer/projects/proofmode-by-guardian-project.md
@@ -14,7 +14,7 @@ tech:
   - filecoin
   - ipfs
 image:
-  url: /assets/images/proofmode.png
+  src: /assets/images/proofmode.png
   alt: ProofMode by Guardian Project
 website: "https://proofmode.org"
 featured-content: "https://www.ffdweb.org/blog/guardian-project-annoucement/"

--- a/src/content/ecosystem-explorer/projects/pyth-network.md
+++ b/src/content/ecosystem-explorer/projects/pyth-network.md
@@ -4,7 +4,7 @@ created-on: 2024-04-16T20:04:49.383Z
 updated-on: 2024-04-16T20:04:49.406Z
 published-on: 2024-04-16T20:04:49.422Z
 image:
-  url: /assets/images/pyth.png
+  src: /assets/images/pyth.png
   alt: Pyth Logo
 category: tooling-productivity
 subcategories:

--- a/src/content/ecosystem-explorer/projects/quest-chains.md
+++ b/src/content/ecosystem-explorer/projects/quest-chains.md
@@ -13,7 +13,7 @@ tags:
 tech:
   - filecoin
 image:
-  url: /assets/images/66073295f68243b0fc173c94_questchains.png
+  src: /assets/images/66073295f68243b0fc173c94_questchains.png
   alt: Quest Chains Logo
 website: https://questchains.xyz/
 featured-content:

--- a/src/content/ecosystem-explorer/projects/quicknode.md
+++ b/src/content/ecosystem-explorer/projects/quicknode.md
@@ -10,7 +10,7 @@ tags:
 tech:
   - filecoin
 image:
-  url: /assets/images/66073296c00a4b6b1e84bf32_quicknode.png
+  src: /assets/images/66073296c00a4b6b1e84bf32_quicknode.png
   alt: QuickNode Logo
 website: https://www.quicknode.com/
 featured-content:

--- a/src/content/ecosystem-explorer/projects/renderhive.md
+++ b/src/content/ecosystem-explorer/projects/renderhive.md
@@ -13,7 +13,7 @@ tags:
 tech:
   - filecoin
 image:
-  url: /assets/images/66073711d5091847d128f8b2_renderhive.png
+  src: /assets/images/66073711d5091847d128f8b2_renderhive.png
   alt: Renderhive Logo
 website: https://www.renderhive.io/
 featured-content:

--- a/src/content/ecosystem-explorer/projects/repl.md
+++ b/src/content/ecosystem-explorer/projects/repl.md
@@ -15,7 +15,7 @@ tags:
 tech:
   - filecoin
 image:
-  url: /assets/images/repl_logo_white.png
+  src: /assets/images/repl_logo_white.png
   alt: Repl Logo
 website: "https://www.repl.fi/"
 featured-content:

--- a/src/content/ecosystem-explorer/projects/reppo.md
+++ b/src/content/ecosystem-explorer/projects/reppo.md
@@ -4,7 +4,7 @@ created-on: 2024-04-24T19:06:44.041Z
 updated-on: 2024-04-24T19:06:44.057Z
 published-on: 2024-04-24T19:06:44.068Z
 image:
-  url: /assets/images/reppo.png
+  src: /assets/images/reppo.png
   alt: Reppo Logo
 category: storage
 subcategories:

--- a/src/content/ecosystem-explorer/projects/seal-storage.md
+++ b/src/content/ecosystem-explorer/projects/seal-storage.md
@@ -13,7 +13,7 @@ tech:
   - filecoin
   - ipfs
 image:
-  url: /assets/images/659751688bb318bafb3d5892_seal2blogo2brgbd-1.png
+  src: /assets/images/659751688bb318bafb3d5892_seal2blogo2brgbd-1.png
   alt: Seal Storage Logo
 website: "https://www.sealstorage.io/"
 repo:

--- a/src/content/ecosystem-explorer/projects/secured-finance.md
+++ b/src/content/ecosystem-explorer/projects/secured-finance.md
@@ -10,7 +10,7 @@ tags:
 tech:
   - filecoin
 image:
-  url: /assets/images/660732963cc8098d637f66b8_securedfinance.png
+  src: /assets/images/660732963cc8098d637f66b8_securedfinance.png
   alt: Secured Finance Logo
 website: https://secured-finance.com/
 featured-content:

--- a/src/content/ecosystem-explorer/projects/seti-institute.md
+++ b/src/content/ecosystem-explorer/projects/seti-institute.md
@@ -14,7 +14,7 @@ tech:
   - filecoin
   - ipfs
 image:
-  url: /assets/images/6597517b30e548a865cc3d71_seti-institute-new-logo-design.png
+  src: /assets/images/6597517b30e548a865cc3d71_seti-institute-new-logo-design.png
   alt: SETI Institute Logo
 website: "https://www.seti.org/"
 repo:

--- a/src/content/ecosystem-explorer/projects/sft-chain.md
+++ b/src/content/ecosystem-explorer/projects/sft-chain.md
@@ -14,7 +14,7 @@ tags:
 tech:
   - filecoin
 image:
-  url: /assets/images/group.png
+  src: /assets/images/group.png
   alt: SFT Chain
 website: "https://www.sftproject.io/"
 featured-content:

--- a/src/content/ecosystem-explorer/projects/sinso.md
+++ b/src/content/ecosystem-explorer/projects/sinso.md
@@ -15,7 +15,7 @@ tech:
   - filecoin
   - ipfs
 image:
-  url: /assets/images/65975173625957e0087c7501_sinso_logo.png
+  src: /assets/images/65975173625957e0087c7501_sinso_logo.png
   alt: SINSO Logo
 website: "https://sinso.io/"
 featured-content:

--- a/src/content/ecosystem-explorer/projects/solmedia.md
+++ b/src/content/ecosystem-explorer/projects/solmedia.md
@@ -4,7 +4,7 @@ created-on: 2024-04-25T17:21:06.414Z
 updated-on: 2024-04-25T17:21:06.439Z
 published-on: 2024-04-25T17:21:06.448Z
 image:
-  url: /assets/images/solmedia.png
+  src: /assets/images/solmedia.png
   alt: Solmedia Logo
 category: storage
 subcategories:

--- a/src/content/ecosystem-explorer/projects/spex.md
+++ b/src/content/ecosystem-explorer/projects/spex.md
@@ -10,7 +10,7 @@ tags:
 tech:
   - filecoin
 image:
-  url: /assets/images/660732963533eb7277065843_spex.png
+  src: /assets/images/660732963533eb7277065843_spex.png
   alt: SPex Logo
 website: https://www.spex.website/
 featured-content:

--- a/src/content/ecosystem-explorer/projects/starboard.md
+++ b/src/content/ecosystem-explorer/projects/starboard.md
@@ -13,7 +13,7 @@ tech:
   - filecoin
   - ipfs
 image:
-  url: /assets/images/65974dc622e2d2883f4e585f_t7xpocnt_400x400.png
+  src: /assets/images/65974dc622e2d2883f4e585f_t7xpocnt_400x400.png
   alt: Starboard Logo
 website: "https://dashboard.starboard.ventures/dashboard"
 featured-content:

--- a/src/content/ecosystem-explorer/projects/starling-lab.md
+++ b/src/content/ecosystem-explorer/projects/starling-lab.md
@@ -15,7 +15,7 @@ tech:
   - filecoin
   - ipfs
 image:
-  url: /assets/images/starling_logo_white-1-.png
+  src: /assets/images/starling_logo_white-1-.png
   alt: Starling Lab Logo
 website: "https://www.starlinglab.org/"
 featured-content: "https://www.fastcompany.com/90731729/inside-starling-lab-a-moonshot-project-to-preserve-the-worlds-most-important-information"

--- a/src/content/ecosystem-explorer/projects/stfil.md
+++ b/src/content/ecosystem-explorer/projects/stfil.md
@@ -13,7 +13,7 @@ tags:
 tech:
   - filecoin
 image:
-  url: # "/assets/images/stfil-logo-dark-background-.png"
+  src: # "/assets/images/stfil-logo-dark-background-.png"
   alt: STFIL
 website: "stfil.io"
 featured-content:

--- a/src/content/ecosystem-explorer/projects/supranational.md
+++ b/src/content/ecosystem-explorer/projects/supranational.md
@@ -13,7 +13,7 @@ tech:
   - filecoin
   - ipfs
 image:
-  url: /assets/images/6597243a0061214bd86cb9b1_gkbtq5uuduql3wfgayraupovzkfhcxrwdk6iqhtmili.png
+  src: /assets/images/6597243a0061214bd86cb9b1_gkbtq5uuduql3wfgayraupovzkfhcxrwdk6iqhtmili.png
   alt: Supranational Logo
 twitter: "https://twitter.com/_Supranational"
 featured-content: >-

--- a/src/content/ecosystem-explorer/projects/swan.md
+++ b/src/content/ecosystem-explorer/projects/swan.md
@@ -11,7 +11,7 @@ tech:
   - filecoin
   - ipfs
 image:
-  url: /assets/images/65974d7eb7581c4ee8e5dcf7_swan-logo.png
+  src: /assets/images/65974d7eb7581c4ee8e5dcf7_swan-logo.png
   alt: Swan Logo
 website: "https://www.swanchain.io"
 featured-content:

--- a/src/content/ecosystem-explorer/projects/tableland.md
+++ b/src/content/ecosystem-explorer/projects/tableland.md
@@ -13,7 +13,7 @@ tech:
   - filecoin
   - ipfs
 image:
-  url: /assets/images/6597243bf8de2cf989b5d1c0_xoug5yutdhfs_s1ziwypy3knkkxygigdict_0jnxcxm.svg
+  src: /assets/images/6597243bf8de2cf989b5d1c0_xoug5yutdhfs_s1ziwypy3knkkxygigdict_0jnxcxm.svg
   alt: Tableland Logo
 website: "https://tableland.xyz/"
 featured-content: "https://mirror.xyz/tableland.eth/cLDRyLa7aMEf1y2sy-PhQtllnZ1YK_oxoS-U2Sf30_Y"

--- a/src/content/ecosystem-explorer/projects/tellor.md
+++ b/src/content/ecosystem-explorer/projects/tellor.md
@@ -10,7 +10,7 @@ tags:
 tech:
   - filecoin
 image:
-  url: /assets/images/66073297e6e8ec9445d76d19_tellor.png
+  src: /assets/images/66073297e6e8ec9445d76d19_tellor.png
   alt: Tellor Logo
 website: https://tellor.io/
 featured-content:

--- a/src/content/ecosystem-explorer/projects/themis-protocol.md
+++ b/src/content/ecosystem-explorer/projects/themis-protocol.md
@@ -10,7 +10,7 @@ tags:
 tech:
   - filecoin
 image:
-  url: /assets/images/ThemisProtocol.png
+  src: /assets/images/ThemisProtocol.png
   alt: Themis Logo
 website: https://themis.capital
 featured-content:

--- a/src/content/ecosystem-explorer/projects/third-storage.md
+++ b/src/content/ecosystem-explorer/projects/third-storage.md
@@ -12,7 +12,7 @@ tags:
 tech:
   - filecoin
 image:
-  url: /assets/images/66073297a94418c44efa178a_thirdstorage.png
+  src: /assets/images/66073297a94418c44efa178a_thirdstorage.png
   alt: Third Storage Logo
 website: https://thirdstorage.com
 featured-content:

--- a/src/content/ecosystem-explorer/projects/titan-network.md
+++ b/src/content/ecosystem-explorer/projects/titan-network.md
@@ -14,7 +14,7 @@ tags:
   - data-storage-management
   - developer-tools
 image:
-  url: /assets/images/65974d743ddd7ef7851595fe_titan-svg2.png
+  src: /assets/images/65974d743ddd7ef7851595fe_titan-svg2.png
   alt: Titan Network Logo
 tech:
   - filecoin

--- a/src/content/ecosystem-explorer/projects/titan-storage.md
+++ b/src/content/ecosystem-explorer/projects/titan-storage.md
@@ -12,7 +12,7 @@ tags:
 tech:
   - filecoin
 image:
-  url: /assets/images/titan-storage_logo_white.png
+  src: /assets/images/titan-storage_logo_white.png
   alt: Titan Storage Logo
 website: https://storage.titannet.io
 featured-content:

--- a/src/content/ecosystem-explorer/projects/transfer-data-trust.md
+++ b/src/content/ecosystem-explorer/projects/transfer-data-trust.md
@@ -15,7 +15,7 @@ tech:
   - "ipfs"
   - "filecoin"
 image:
-  url: /assets/images/transfer_logo_white.png
+  src: /assets/images/transfer_logo_white.png
   alt: "TRANSFER Data Trust Logo"
 website: "http://transfer.art"
 repo: "https://github.com/TRANSFERArchive"

--- a/src/content/ecosystem-explorer/projects/tres-finance.md
+++ b/src/content/ecosystem-explorer/projects/tres-finance.md
@@ -16,7 +16,7 @@ tags:
 tech:
   - "filecoin"
 image:
-  url: "/assets/images/tres_logo_white.png"
+  src: "/assets/images/tres_logo_white.png"
   alt: "TRES.Finance Logo"
 website: "https://tres.finance/"
 featured-content:

--- a/src/content/ecosystem-explorer/projects/twin-quasar.md
+++ b/src/content/ecosystem-explorer/projects/twin-quasar.md
@@ -15,7 +15,7 @@ tech:
   - "filecoin"
   - "ipfs"
 image:
-  url: /assets/images/6597243633c341e0379b9712_nj6wqvn7kai05ws5irrbrcma4zz_ctatdako4sxlrio.png
+  src: /assets/images/6597243633c341e0379b9712_nj6wqvn7kai05ws5irrbrcma4zz_ctatdako4sxlrio.png
   alt: "Twin Quasar Logo"
 website: "https://www.twinquasar.io/"
 repo:

--- a/src/content/ecosystem-explorer/projects/uc-berkeley-underground-physics-group.md
+++ b/src/content/ecosystem-explorer/projects/uc-berkeley-underground-physics-group.md
@@ -14,7 +14,7 @@ tech:
   - "filecoin"
   - "ipfs"
 image:
-  url: /assets/images/65974d64d556a0c37cb3ddbb_logo-ucberkeley-white.png
+  src: /assets/images/65974d64d556a0c37cb3ddbb_logo-ucberkeley-white.png
   alt: "UC Berkeley Underground Physics Group Logo"
 website: "https://underground.physics.berkeley.edu/"
 repo:

--- a/src/content/ecosystem-explorer/projects/university-of-utah.md
+++ b/src/content/ecosystem-explorer/projects/university-of-utah.md
@@ -16,7 +16,7 @@ tech:
   - "filecoin"
   - "ipfs"
 image:
-  url: /assets/images/65974d55ccb76baf40726b38_university_of_utah_horizontal_logo.svg.png
+  src: /assets/images/65974d55ccb76baf40726b38_university_of_utah_horizontal_logo.svg.png
   alt: "University of Utah Logo"
 website: "http://cedmav.org/"
 repo:

--- a/src/content/ecosystem-explorer/projects/victor-chang-research-institute.md
+++ b/src/content/ecosystem-explorer/projects/victor-chang-research-institute.md
@@ -14,7 +14,7 @@ tech:
   - filecoin
   - ipfs
 image:
-  url: /assets/images/65974d4b3b6a7ed29e34e0b7_victor-chang-logo-1.png
+  src: /assets/images/65974d4b3b6a7ed29e34e0b7_victor-chang-logo-1.png
   alt: Victor Chang Research Institute Logo
 website: "https://www.victorchang.edu.au/"
 featured-content: "https://destor.com/victor-chang-cardiac-research-institute-case-study"

--- a/src/content/ecosystem-explorer/projects/vsharecloud.md
+++ b/src/content/ecosystem-explorer/projects/vsharecloud.md
@@ -4,7 +4,7 @@ created-on: 2024-04-05T14:14:29.910Z
 updated-on: 2024-04-05T14:14:29.925Z
 published-on: 2024-04-05T14:14:29.937Z
 image:
-  url: /assets/images/vsharecloud.png
+  src: /assets/images/vsharecloud.png
   alt: VshareCloud Logo
 category: storage
 subcategories:

--- a/src/content/ecosystem-explorer/projects/waterlily-ai.md
+++ b/src/content/ecosystem-explorer/projects/waterlily-ai.md
@@ -15,7 +15,7 @@ tech:
   - filecoin
   - ipfs
 image:
-  url: /assets/images/659872da19567f4307ba3b38_bacalhua_logo_white.png
+  src: /assets/images/659872da19567f4307ba3b38_bacalhua_logo_white.png
   alt: Waterlily.ai Logo
 website: "https://www.waterlily.ai/"
 featured-content: "https://fil.org/blog/decentralizing-art-a-deep-dive-into-waterlily-ais-use-of-fvm-and-ai/"

--- a/src/content/ecosystem-explorer/projects/weatherxm.md
+++ b/src/content/ecosystem-explorer/projects/weatherxm.md
@@ -11,7 +11,7 @@ tags:
 tech:
   - ipfs
 image:
-  url: /assets/images/6597243713b6cbe85dad7ea4_tkwzgqypzrhnrp1i_jixqqpgoeqydofsk6p7muppqji.png
+  src: /assets/images/6597243713b6cbe85dad7ea4_tkwzgqypzrhnrp1i_jixqqpgoeqydofsk6p7muppqji.png
   alt: WeatherXM Logo
 website: "https://weatherxm.com/"
 featured-content:

--- a/src/content/ecosystem-explorer/projects/web3-storage.md
+++ b/src/content/ecosystem-explorer/projects/web3-storage.md
@@ -13,7 +13,7 @@ tech:
   - filecoin
   - ipfs
 image:
-  url: /assets/images/65974d3c02cb39557a1ffd52_web3.Storage-Logo.png
+  src: /assets/images/65974d3c02cb39557a1ffd52_web3.Storage-Logo.png
   alt: Web3.Storage Logo
 website: "https://web3.storage/"
 featured-content:

--- a/src/content/ecosystem-explorer/projects/web3mine.md
+++ b/src/content/ecosystem-explorer/projects/web3mine.md
@@ -10,7 +10,7 @@ tags:
 tech:
   - filecoin
 image:
-  url: /assets/images/66073297bc9a092bda5eb6d8_web3mine.png
+  src: /assets/images/66073297bc9a092bda5eb6d8_web3mine.png
   alt: Web3mine Logo
 website: https://web3mine.io/
 featured-content:

--- a/src/content/ecosystem-explorer/projects/xbanking.md
+++ b/src/content/ecosystem-explorer/projects/xbanking.md
@@ -13,7 +13,7 @@ tags:
 tech:
   - filecoin
 image:
-  url: /assets/images/xbanking_logo_white.png
+  src: /assets/images/xbanking_logo_white.png
   alt: XBANKING Logo
 website: "https://xbanking.org"
 featured-content:

--- a/src/content/ecosystem-explorer/projects/zentachain.md
+++ b/src/content/ecosystem-explorer/projects/zentachain.md
@@ -17,7 +17,7 @@ tech:
   - filecoin
   - ipfs
 image:
-  url: /assets/images/zentachain-white.png
+  src: /assets/images/zentachain-white.png
   alt: Zentachain Logo Chain Network
 website: "https://zentachain.io/"
 featured-content:

--- a/src/content/ecosystem-explorer/projects/zondax.md
+++ b/src/content/ecosystem-explorer/projects/zondax.md
@@ -13,7 +13,7 @@ tech:
   - filecoin
   - ipfs
 image:
-  url: /assets/images/65974d3422e2d2883f4dff8f_zondax_logo.png
+  src: /assets/images/65974d3422e2d2883f4dff8f_zondax_logo.png
   alt: Zondax Logo
 website: "https://zondax.ch/"
 featured-content:

--- a/src/content/events/agi-cryptography-security-multipolar-scenarios-workshop.md
+++ b/src/content/events/agi-cryptography-security-multipolar-scenarios-workshop.md
@@ -9,7 +9,7 @@ start-date: 2024-05-14T15:48:19.518Z
 end-date: 2024-05-15T15:48:19.530Z
 updated-on: 2024-02-21T16:48:19.493Z
 image:
-  url: /assets/images/foresight.svg
+  src: /assets/images/foresight.svg
   alt: ForeSight Institute Logo
 involvement: sponsored
 seo:

--- a/src/content/events/april-2021-notary-governance-meeting.md
+++ b/src/content/events/april-2021-notary-governance-meeting.md
@@ -9,7 +9,7 @@ start-date: 2021-04-12T22:00:00.000Z
 end-date: null
 updated-on: 2023-05-03T08:06:31.219Z
 image:
-  url: /assets/images/governance-logo.jpg
+  src: /assets/images/governance-logo.jpg
   alt: Filecoin Governance Logo
 involvement: hosted
 seo:

--- a/src/content/events/asia-hackathon-season-2021.md
+++ b/src/content/events/asia-hackathon-season-2021.md
@@ -9,7 +9,7 @@ start-date: 2021-07-31T22:00:00.000Z
 end-date: 2021-10-30T22:00:00.000Z
 updated-on: 2023-05-03T08:06:33.937Z
 image:
-  url: /assets/images/filorg_imagefallback.png
+  src: /assets/images/filorg_imagefallback.png
   alt: Filecoin Foundation Holder Image
 involvement: supported
 seo:

--- a/src/content/events/august-2021-notary-governance-meeting.md
+++ b/src/content/events/august-2021-notary-governance-meeting.md
@@ -9,7 +9,7 @@ external-link: https://www.youtube.com/watch?v=o0nPBRM-aMQ
 end-date: null
 start-date: 2021-08-30T22:00:00.000Z
 image:
-  url: /assets/images/governance-logo.jpg
+  src: /assets/images/governance-logo.jpg
   alt: Filecoin Governance Logo
 involvement: hosted
 seo:

--- a/src/content/events/consensus-filecoin-orbit-event.md
+++ b/src/content/events/consensus-filecoin-orbit-event.md
@@ -10,7 +10,7 @@ start-date: 2024-05-29T14:50:42.632Z
 end-date: 2024-05-31T14:50:42.640Z
 updated-on: 2024-01-29T15:50:42.614Z
 image:
-  url: /assets/images/consensus-2024.png
+  src: /assets/images/consensus-2024.png
   alt: Consensus Logo
 involvement: supported
 seo:

--- a/src/content/events/decentralized-web-gateway-davos.md
+++ b/src/content/events/decentralized-web-gateway-davos.md
@@ -13,7 +13,7 @@ start-date: 2022-05-21T16:00:39.000Z
 end-date: null
 updated-on: 2023-05-03T08:15:41.280Z
 image:
-  url: /assets/images/64521829e09e4e566257e24c_dweb-gateway-davos.jpg
+  src: /assets/images/64521829e09e4e566257e24c_dweb-gateway-davos.jpg
   alt: ""
 involvement: hosted
 seo:

--- a/src/content/events/decentralized-web-gateway-sxsw.md
+++ b/src/content/events/decentralized-web-gateway-sxsw.md
@@ -13,7 +13,7 @@ external-link: https://www.youtube.com/watch?v=EHTFVtWDqJc&list=PLp3zrT1ewY0mvhU
 start-date: "2022-03-15T07:23:50.000Z"
 end-date:
 image:
-  url: /assets/images/64521857e09e4edc0d57e6df_dweb-gateway-sxsw.jpg
+  src: /assets/images/64521857e09e4edc0d57e6df_dweb-gateway-sxsw.jpg
   alt:
 involvement: sponsored
 seo:

--- a/src/content/events/destorhk.md
+++ b/src/content/events/destorhk.md
@@ -9,7 +9,7 @@ external-link: https://fil-hk.io/destor-en/
 start-date: "2023-04-15T15:30:53.222Z"
 end-date:
 image:
-  url: /assets/images/destore-hk-2023.png
+  src: /assets/images/destore-hk-2023.png
   alt:
 involvement: supported
 seo:

--- a/src/content/events/dweb-camp-1.md
+++ b/src/content/events/dweb-camp-1.md
@@ -9,7 +9,7 @@ external-link: https://dwebcamp.org/
 start-date: "2023-06-21T15:30:00.000Z"
 end-date: "2023-06-25T15:30:55.996Z"
 image:
-  url: /assets/images/dweb-camp.png
+  src: /assets/images/dweb-camp.png
   alt:
 involvement: hosted
 seo:

--- a/src/content/events/dweb-camp-2024.md
+++ b/src/content/events/dweb-camp-2024.md
@@ -10,7 +10,7 @@ start-date: "2024-08-07T14:55:19.871Z"
 
 end-date: "2024-08-11T14:55:19.882Z"
 image:
-  url: /assets/images/dweb-camp24.png
+  src: /assets/images/dweb-camp24.png
   alt: DWeb Camp Logo
 involvement: hosted
 seo:

--- a/src/content/events/dweb-camp.md
+++ b/src/content/events/dweb-camp.md
@@ -9,7 +9,7 @@ external-link: https://dwebcamp.org/
 start-date: "2023-08-24T15:30:55.987Z"
 end-date: "2023-08-28T15:30:55.996Z"
 image:
-  url: /assets/images/dweb-camp.png
+  src: /assets/images/dweb-camp.png
   alt:
 involvement: hosted
 seo:

--- a/src/content/events/espa-bootcamp-cohort-4.md
+++ b/src/content/events/espa-bootcamp-cohort-4.md
@@ -9,7 +9,7 @@ external-link: https://www.web3espa.io/
 start-date: "2022-10-13T00:00:00.000Z"
 end-date: "2022-10-13T00:00:00.000Z"
 image:
-  url: /assets/images/645215e7b97133359d88d3a0_177648477-ed976b8e-ae0d-4f18-8d91-2d8512d3fb54_hua7fa79449114663eebf6af324bdad7a2_1514667_1333x0_resize_q90_linear_2.png
+  src: /assets/images/645215e7b97133359d88d3a0_177648477-ed976b8e-ae0d-4f18-8d91-2d8512d3fb54_hua7fa79449114663eebf6af324bdad7a2_1514667_1333x0_resize_q90_linear_2.png
   alt:
 involvement: supported
 seo:

--- a/src/content/events/eth-denver-filecoin-booth-filecoin-orbit-event.md
+++ b/src/content/events/eth-denver-filecoin-booth-filecoin-orbit-event.md
@@ -9,7 +9,7 @@ external-link: https://hub.fil.org/ethdenver2024
 start-date: "2024-02-28T15:38:54.833Z"
 end-date: "2024-03-03T15:38:54.840Z"
 image:
-  url: /assets/images/ethdenver24.png
+  src: /assets/images/ethdenver24.png
   alt: ETH Denver Logo
 involvement: sponsored
 seo:

--- a/src/content/events/eth-san-francisco-filecoin-orbit-event.md
+++ b/src/content/events/eth-san-francisco-filecoin-orbit-event.md
@@ -9,7 +9,7 @@ external-link:
 start-date: "2024-10-18T15:16:41.373Z"
 end-date: "2024-10-19T15:16:41.380Z"
 image:
-  url: /assets/images/ethsf24.png
+  src: /assets/images/ethsf24.png
   alt: ETH San Francisco Logo
 involvement: sponsored
 seo:

--- a/src/content/events/ethcc-5.md
+++ b/src/content/events/ethcc-5.md
@@ -9,7 +9,7 @@ external-link: https://ethcc.io/
 start-date: "2022-07-19T00:00:00.000Z"
 end-date: "2022-07-21T00:00:00.000Z"
 image:
-  url: /assets/images/645215ed18e20de7428046f6_ethcc.png
+  src: /assets/images/645215ed18e20de7428046f6_ethcc.png
   alt:
 involvement: supported
 seo:

--- a/src/content/events/ethcc-filecoin-booth.md
+++ b/src/content/events/ethcc-filecoin-booth.md
@@ -9,7 +9,7 @@ external-link:
 start-date: "2024-07-10T14:51:57.398Z"
 end-date: "2024-07-11T14:51:57.409Z"
 image:
-  url: /assets/images/ethcc-24.png
+  src: /assets/images/ethcc-24.png
   alt: EthCC Logo
 involvement: sponsored
 seo:

--- a/src/content/events/ethdenver.md
+++ b/src/content/events/ethdenver.md
@@ -9,7 +9,7 @@ external-link: https://m.fil.org/filecoin-at-ethdenver
 start-date: "2022-02-11T06:57:49.000Z"
 end-date:
 image:
-  url: /assets/images/645215f9a2b74616855546de_ethdenver.png
+  src: /assets/images/645215f9a2b74616855546de_ethdenver.png
   alt:
 involvement: supported
 seo:

--- a/src/content/events/ethereal-2021.md
+++ b/src/content/events/ethereal-2021.md
@@ -9,7 +9,7 @@ external-link: https://www.youtube.com/watch?v=JRsvz6pRtZE&t=454s
 start-date: "2021-05-05T22:00:00.000Z"
 end-date:
 image:
-  url: /assets/images/64521600a359ff88f536ffc5_ethereal-2021.png
+  src: /assets/images/64521600a359ff88f536ffc5_ethereal-2021.png
   alt:
 involvement: supported
 seo:

--- a/src/content/events/ethereal-2022.md
+++ b/src/content/events/ethereal-2022.md
@@ -9,7 +9,7 @@ external-link: https://decrypt.co/videos/interviews/BW49Ik6c/edward-snowden-talk
 start-date: "2022-02-26T16:00:00.000Z"
 end-date:
 image:
-  url: /assets/images/645215f7455b5b63d0f5b5e8_marta-snowden.png
+  src: /assets/images/645215f7455b5b63d0f5b5e8_marta-snowden.png
   alt:
 involvement: supported
 seo:

--- a/src/content/events/fil-austin.md
+++ b/src/content/events/fil-austin.md
@@ -11,7 +11,7 @@ external-link: https://events.bizzabo.com/filaustin
 start-date: "2023-11-13T18:35:31.331Z"
 end-date:
 image:
-  url: /assets/images/645218c34b08773d70df834b_fil-austin.jpg
+  src: /assets/images/645218c34b08773d70df834b_fil-austin.jpg
   alt:
 involvement: hosted
 seo:

--- a/src/content/events/fil-bangalore.md
+++ b/src/content/events/fil-bangalore.md
@@ -9,7 +9,7 @@ external-link: https://fil-bangalore.io/
 start-date: "2022-11-29T16:50:53.914Z"
 end-date: "2022-11-30T16:50:00.000Z"
 image:
-  url: /assets/images/fil-bangalore-2022.png
+  src: /assets/images/fil-bangalore-2022.png
   alt:
 involvement: hosted
 seo:

--- a/src/content/events/fil-bangkok.md
+++ b/src/content/events/fil-bangkok.md
@@ -9,7 +9,7 @@ external-link:
 start-date: "2024-11-10T16:18:33.964Z"
 end-date: "2024-11-15T16:18:33.972Z"
 image:
-  url: /assets/images/filbangkok-24.png
+  src: /assets/images/filbangkok-24.png
   alt: FIL Bangkok Logo
 involvement: hosted
 seo:

--- a/src/content/events/fil-brussels.md
+++ b/src/content/events/fil-brussels.md
@@ -14,7 +14,7 @@ external-link: https://www.fil-brussels.io/
 end-date: 2024-07-11T14:53:57.438Z
 start-date: 2024-07-08T14:53:57.431Z
 image:
-  url: /assets/images/fil-brussels.svg
+  src: /assets/images/fil-brussels.svg
   alt: FIL Brussels Logo
 involvement: hosted
 seo:

--- a/src/content/events/fil-capetown.md
+++ b/src/content/events/fil-capetown.md
@@ -9,7 +9,7 @@ external-link: https://fil-capetown.io/
 start-date: "2023-11-21T13:58:58.117Z"
 end-date:
 image:
-  url: /assets/images/filcapetown.png
+  src: /assets/images/filcapetown.png
   alt: FIL Cape Town Logo
 involvement: hosted
 seo:

--- a/src/content/events/fil-dev-summit-1.md
+++ b/src/content/events/fil-dev-summit-1.md
@@ -9,7 +9,7 @@ external-link: https://fildev.io/
 start-date: "2023-09-12T15:46:33.626Z"
 end-date: "2023-09-14T15:46:33.644Z"
 image:
-  url: /assets/images/fil-dev-summit.png
+  src: /assets/images/fil-dev-summit.png
   alt:
 involvement: hosted
 seo:

--- a/src/content/events/fil-dev-summit-singapore.md
+++ b/src/content/events/fil-dev-summit-singapore.md
@@ -9,7 +9,7 @@ external-link: https://fildev.io/
 start-date: "2023-09-25T14:00:04.428Z"
 end-date:
 image:
-  url: /assets/images/fil-dev-summit.png
+  src: /assets/images/fil-dev-summit.png
   alt:
 involvement: hosted
 seo:

--- a/src/content/events/fil-hong-kong-hosted-by-ndlabs.md
+++ b/src/content/events/fil-hong-kong-hosted-by-ndlabs.md
@@ -9,7 +9,7 @@ external-link: https://fil-hk.io/
 start-date: "2024-04-05T14:42:24.931Z"
 end-date: "2024-04-08T14:42:24.941Z"
 image:
-  url: /assets/images/filhk24.png
+  src: /assets/images/filhk24.png
   alt: FIL Hong Kong Logo
 involvement: hosted
 seo:

--- a/src/content/events/fil-hong-kong.md
+++ b/src/content/events/fil-hong-kong.md
@@ -8,7 +8,7 @@ external-link: https://fil-hk.io/
 start-date: "2023-04-12T15:30:53.302Z"
 end-date: "2023-04-15T15:30:53.477Z"
 image:
-  url: /assets/images/fil-hong-kong.png
+  src: /assets/images/fil-hong-kong.png
   alt:
 involvement: hosted
 seo:

--- a/src/content/events/fil-jakarta.md
+++ b/src/content/events/fil-jakarta.md
@@ -9,7 +9,7 @@ external-link: https://www.fil-jakarta.io/
 start-date: "2023-09-02T11:00:23.071Z"
 end-date:
 image:
-  url: /assets/images/fil-jakarta.png
+  src: /assets/images/fil-jakarta.png
   alt:
 involvement: hosted
 seo:

--- a/src/content/events/fil-lisbon.md
+++ b/src/content/events/fil-lisbon.md
@@ -9,7 +9,7 @@ external-link: https://fil-lisbon.io/
 start-date: "2022-10-31T00:00:00.000Z"
 end-date: "2022-11-04T00:00:00.000Z"
 image:
-  url: /assets/images/645217c53763d71fa57e55a0_fil-lisbon.jpg
+  src: /assets/images/645217c53763d71fa57e55a0_fil-lisbon.jpg
   alt:
 involvement: hosted
 seo:

--- a/src/content/events/fil-paris.md
+++ b/src/content/events/fil-paris.md
@@ -9,7 +9,7 @@ external-link: https://fil-paris.io/
 start-date: "2023-07-15T15:38:07.119Z"
 end-date: "2023-07-21T15:38:07.128Z"
 image:
-  url: /assets/images/fil-paris-pic.png
+  src: /assets/images/fil-paris-pic.png
   alt:
 involvement: hosted
 seo:

--- a/src/content/events/fil-seoul-network-base-1.md
+++ b/src/content/events/fil-seoul-network-base-1.md
@@ -9,7 +9,7 @@ external-link: https://www.fil-seoul.com/
 start-date: "2023-09-06T07:06:47.822Z"
 end-date: "2023-09-07T07:06:47.832Z"
 image:
-  url: /assets/images/fil-seoul-bg.png
+  src: /assets/images/fil-seoul-bg.png
   alt:
 involvement: hosted
 seo:

--- a/src/content/events/fil-seoul-network-base-2.md
+++ b/src/content/events/fil-seoul-network-base-2.md
@@ -9,7 +9,7 @@ external-link:
 start-date: "2024-09-04T15:09:58.111Z"
 end-date: "2024-09-10T15:09:58.126Z"
 image:
-  url: /assets/images/fil-seoul-24.png
+  src: /assets/images/fil-seoul-24.png
   alt: FIL Seoul Network Base Logo
 involvement: hosted
 seo:

--- a/src/content/events/fil-singapore-1.md
+++ b/src/content/events/fil-singapore-1.md
@@ -9,7 +9,7 @@ external-link:
 start-date: "2024-09-18T15:14:23.235Z"
 end-date: "2024-09-19T15:14:23.249Z"
 image:
-  url: /assets/images/fil-singapore-24.png
+  src: /assets/images/fil-singapore-24.png
   alt: FIL Singapore Logo
 involvement: hosted
 seo:

--- a/src/content/events/fil-singapore.md
+++ b/src/content/events/fil-singapore.md
@@ -9,7 +9,7 @@ external-link: https://fil-singapore.io/
 start-date: "2022-09-24T00:00:00.000Z"
 end-date: "2022-09-26T00:00:00.000Z"
 image:
-  url: /assets/images/645218e87f5430741f6d9bd6_fil-singapore.jpg
+  src: /assets/images/645218e87f5430741f6d9bd6_fil-singapore.jpg
   alt:
 involvement: hosted
 seo:

--- a/src/content/events/fil-vegas.md
+++ b/src/content/events/fil-vegas.md
@@ -9,7 +9,7 @@ external-link: https://fil-vegas.io/
 start-date: "2023-10-03T17:09:07.043Z"
 end-date: "2023-10-05T17:09:07.051Z"
 image:
-  url: /assets/images/fil-vegas-event-header.png
+  src: /assets/images/fil-vegas-event-header.png
   alt:
 involvement: hosted
 seo:

--- a/src/content/events/filecoin-club.md
+++ b/src/content/events/filecoin-club.md
@@ -12,8 +12,7 @@ external-link: https://www.encode.club/filecoin-club
 start-date: "2021-09-30T22:00:00.000Z"
 end-date: "2021-12-30T23:00:00.000Z"
 image:
-  url: >-
-    /assets/images/64521608455b5bc68cf5c6fa_filecoin-club.png
+  src: /assets/images/64521608455b5bc68cf5c6fa_filecoin-club.png
   alt:
 involvement: supported
 seo:

--- a/src/content/events/filecoin-day.md
+++ b/src/content/events/filecoin-day.md
@@ -9,7 +9,7 @@ external-link: "https://lu.ma/vk9pnofg"
 start-date: "2023-11-14T14:00:00.000Z"
 end-date: "2023-11-14T18:30:36.580Z"
 image:
-  url: /assets/images/signal-2023-11-12-145615_002.jpeg
+  src: /assets/images/signal-2023-11-12-145615_002.jpeg
   alt:
 involvement: hosted
 seo:

--- a/src/content/events/filecoin-grant-global-online-hackathon.md
+++ b/src/content/events/filecoin-grant-global-online-hackathon.md
@@ -9,7 +9,7 @@ external-link: https://www.eventbrite.com/e/share-115k-prizes-filecoin-grant-onl
 start-date: "2021-04-30T22:00:00.000Z"
 end-date: "2021-07-17T22:00:00.000Z"
 image:
-  url:
+  src:
   alt:
 involvement: supported
 seo:

--- a/src/content/events/filecoin-network-base.md
+++ b/src/content/events/filecoin-network-base.md
@@ -6,7 +6,7 @@ published-on: "2023-06-27T15:46:15.140Z"
 description:
 location: Austin, Texas
 image:
-  url: /assets/images/network-base-austin-2023-pic.png
+  src: /assets/images/network-base-austin-2023-pic.png
   alt:
 external-link: https://networkbase.io/austin/
 start-date: "2023-04-24T15:46:15.146Z"

--- a/src/content/events/filecoin-network-day-south-korea.md
+++ b/src/content/events/filecoin-network-day-south-korea.md
@@ -9,7 +9,7 @@ external-link:
 start-date: "2022-12-15T17:21:11.381Z"
 end-date:
 image:
-  url: /assets/images/network-day-korea-2022.png
+  src: /assets/images/network-day-korea-2022.png
   alt:
 involvement: hosted
 seo:

--- a/src/content/events/filecoin-orbit-lounge-at-dc-fintech-week.md
+++ b/src/content/events/filecoin-orbit-lounge-at-dc-fintech-week.md
@@ -11,8 +11,7 @@ external-link: https://www.eventbrite.com/e/filecoin-orbit-lounge-at-dc-fintech-
 start-date: "2021-10-19T22:00:00.000Z"
 end-date:
 image:
-  url: >-
-    /assets/images/645215fc18e20d1c30805b6c_2021-filecoin-orbit-lounge-event.png
+  src: /assets/images/645215fc18e20d1c30805b6c_2021-filecoin-orbit-lounge-event.png
   alt:
 involvement: sponsored
 seo:

--- a/src/content/events/filecoin-plus-day-1.md
+++ b/src/content/events/filecoin-plus-day-1.md
@@ -9,7 +9,7 @@ external-link: https://23.labweek.io/fil-plus
 start-date: "2023-11-14T19:30:00.264Z"
 end-date: "2023-11-14T22:00:00.270Z"
 image:
-  url: /assets/images/03292023-filplusmission.png
+  src: /assets/images/03292023-filplusmission.png
   alt:
 involvement: hosted
 seo:

--- a/src/content/events/filecoin-plus-day-5.md
+++ b/src/content/events/filecoin-plus-day-5.md
@@ -9,7 +9,7 @@ external-link: https://www.youtube.com/watch?v=wP4Bk8lBNUc
 start-date: "2021-05-10T22:00:00.000Z"
 end-date:
 image:
-  url: /assets/images/6452191a0250ed07cbd15415_luma-_-fil-day.jpg
+  src: /assets/images/6452191a0250ed07cbd15415_luma-_-fil-day.jpg
   alt:
 involvement: hosted
 seo:

--- a/src/content/events/filecoin-plus-day.md
+++ b/src/content/events/filecoin-plus-day.md
@@ -9,7 +9,7 @@ external-link:
 start-date: "2022-05-11T06:00:24.000Z"
 end-date:
 image:
-  url:
+  src:
   alt:
 involvement: hosted
 seo:

--- a/src/content/events/filecoin-station-at-web-summit.md
+++ b/src/content/events/filecoin-station-at-web-summit.md
@@ -9,7 +9,7 @@ external-link: https://websummit.com/blog/web-summit-2022-2-for-1-tickets
 start-date: "2022-11-01T15:30:57.167Z"
 end-date: "2022-11-04T15:30:57.184Z"
 image:
-  url: /assets/images/websummit-2023.png
+  src: /assets/images/websummit-2023.png
   alt:
 involvement: sponsored
 seo:

--- a/src/content/events/filecoin-virtual-machine-hacker-base-1.md
+++ b/src/content/events/filecoin-virtual-machine-hacker-base-1.md
@@ -9,7 +9,7 @@ external-link: https://events.fil.org/fvm-hackerbase
 start-date: "2023-02-28T16:39:25.712Z"
 end-date: "2023-03-01T16:39:25.716Z"
 image:
-  url: /assets/images/fvm-hackerbase-2023.png
+  src: /assets/images/fvm-hackerbase-2023.png
   alt:
 involvement: hosted
 seo:

--- a/src/content/events/funding-the-commons.md
+++ b/src/content/events/funding-the-commons.md
@@ -9,7 +9,7 @@ external-link:
 start-date: "2024-04-13T14:47:33.396Z"
 end-date: "2024-04-14T14:47:33.405Z"
 image:
-  url: /assets/images/funding-the-commons24.png
+  src: /assets/images/funding-the-commons24.png
   alt: Funding the Commons SF Logo
 involvement: supported
 seo:

--- a/src/content/events/gbbc-virtual-members-forum-with-marta-belcher-board-chair-at-the-filecoin-foundation.md
+++ b/src/content/events/gbbc-virtual-members-forum-with-marta-belcher-board-chair-at-the-filecoin-foundation.md
@@ -11,7 +11,7 @@ external-link: https://www.youtube.com/watch?v=LU_WjU0mUuM
 start-date: "2021-03-04T23:00:00.000Z"
 end-date:
 image:
-  url:
+  src:
   alt:
 involvement: supported
 seo:

--- a/src/content/events/hackathon-browsers-3000.md
+++ b/src/content/events/hackathon-browsers-3000.md
@@ -9,7 +9,7 @@ external-link: https://events.protocol.ai/2021/browsers3000/
 start-date: "2021-07-07T22:00:00.000Z"
 end-date: "2021-08-19T22:00:00.000Z"
 image:
-  url:
+  src:
   alt:
 involvement: supported
 seo:

--- a/src/content/events/hackfs.md
+++ b/src/content/events/hackfs.md
@@ -9,7 +9,7 @@ external-link: https://www.youtube.com/watch?v=RWxd9X2bKfo
 start-date: "2021-07-29T22:00:00.000Z"
 end-date: "2021-08-19T22:00:00.000Z"
 image:
-  url:
+  src:
   alt:
 involvement: supported
 seo:

--- a/src/content/events/hyperledger-global-forum.md
+++ b/src/content/events/hyperledger-global-forum.md
@@ -9,7 +9,7 @@ external-link: https://www.youtube.com/watch?v=B8lDaJcSiX0
 start-date: "2021-06-07T22:00:00.000Z"
 end-date: "2021-06-09T22:00:00.000Z"
 image:
-  url: /assets/images/645215feaee26f3101cebc4b_hyperledger-global-forum.jpeg
+  src: /assets/images/645215feaee26f3101cebc4b_hyperledger-global-forum.jpeg
   alt:
 involvement: supported
 seo:

--- a/src/content/events/metaverse-hackathon.md
+++ b/src/content/events/metaverse-hackathon.md
@@ -11,7 +11,7 @@ external-link: https://kencloud.com/hack.html
 start-date: "2022-04-19T16:00:45.000Z"
 end-date:
 image:
-  url: /assets/images/645215fba2b7469c5c5546ea_image_ldbpld.png
+  src: /assets/images/645215fba2b7469c5c5546ea_image_ldbpld.png
   alt:
 involvement: supported
 seo:

--- a/src/content/events/nft-gallery-at-consensus-2022.md
+++ b/src/content/events/nft-gallery-at-consensus-2022.md
@@ -12,8 +12,7 @@ external-link:
 start-date: "2022-06-08T16:00:10.000Z"
 end-date:
 image:
-  url: >-
-    /assets/images/645215f075d57ed1e4d02693_nft-gallery-at-consensus.png
+  src: /assets/images/645215f075d57ed1e4d02693_nft-gallery-at-consensus.png
   alt:
 involvement: supported
 seo:

--- a/src/content/events/nft-vision-hack.md
+++ b/src/content/events/nft-vision-hack.md
@@ -9,7 +9,7 @@ external-link: https://www.nftvisionhack.com/
 start-date: "2021-06-30T22:00:00.000Z"
 end-date: "2021-08-30T22:00:00.000Z"
 image:
-  url:
+  src:
   alt:
 involvement: supported
 seo:

--- a/src/content/events/protocol-village-at-consensus-2023.md
+++ b/src/content/events/protocol-village-at-consensus-2023.md
@@ -9,7 +9,7 @@ external-link: https://consensus2023.coindesk.com/agenda/venue/-protocol-village
 start-date: "2023-04-26T15:31:08.683Z"
 end-date: "2023-04-28T15:31:08.707Z"
 image:
-  url: /assets/images/protocol-village-2023.png
+  src: /assets/images/protocol-village-2023.png
   alt:
 involvement: supported
 seo:

--- a/src/content/events/puerto-rico-blockchain-week.md
+++ b/src/content/events/puerto-rico-blockchain-week.md
@@ -9,7 +9,7 @@ external-link: https://www.prblockchainweek.io/
 start-date: "2022-12-05T18:15:30.421Z"
 end-date: "2022-12-10T18:15:00.000Z"
 image:
-  url: /assets/images/pr-blockchain-2022.png
+  src: /assets/images/pr-blockchain-2022.png
   alt:
 involvement: supported
 seo:

--- a/src/content/events/sbs-boston.md
+++ b/src/content/events/sbs-boston.md
@@ -9,7 +9,7 @@ external-link: https://sbs.tech/
 start-date: "2023-04-13T15:36:02.820Z"
 end-date: "2023-04-13T15:36:00.000Z"
 image:
-  url: /assets/images/sbs-boston-2023.png
+  src: /assets/images/sbs-boston-2023.png
   alt:
 involvement: supported
 seo:

--- a/src/content/events/singapore-storage-provider-meetup.md
+++ b/src/content/events/singapore-storage-provider-meetup.md
@@ -9,7 +9,7 @@ external-link: https://lu.ma/singapore-sp-meetup
 start-date: "2022-08-16T00:00:00.000Z"
 end-date: "2022-08-16T00:00:00.000Z"
 image:
-  url: /assets/images/6452194af82dbf21df953f96_singapore-sp.jpg
+  src: /assets/images/6452194af82dbf21df953f96_singapore-sp.jpg
   alt:
 involvement: hosted
 seo:

--- a/src/content/events/social-impact-summit-2024-cohosted-by-blockchain-law-for-social-good-center-ffdw.md
+++ b/src/content/events/social-impact-summit-2024-cohosted-by-blockchain-law-for-social-good-center-ffdw.md
@@ -11,7 +11,7 @@ external-link: https://www.eventbrite.com/e/social-impact-summit-2024-tickets-75
 start-date: "2024-02-27T14:00:51.036Z"
 end-date: "2024-02-27T21:00:51.050Z"
 image:
-  url: /assets/images/sis24.png
+  src: /assets/images/sis24.png
   alt:
 involvement: cohosted
 seo:

--- a/src/content/events/south-korea-storage-provider-meetup.md
+++ b/src/content/events/south-korea-storage-provider-meetup.md
@@ -9,7 +9,7 @@ external-link: https://lu.ma/sp-korea-meetup
 start-date: "2022-08-12T00:00:00.000Z"
 end-date:
 image:
-  url: /assets/images/6452196b59d1f8a352664f3b_korea-sp.jpg
+  src: /assets/images/6452196b59d1f8a352664f3b_korea-sp.jpg
   alt:
 involvement: hosted
 seo:

--- a/src/content/events/storage-provider-working-group-meeting.md
+++ b/src/content/events/storage-provider-working-group-meeting.md
@@ -9,7 +9,7 @@ external-link: https://www.youtube.com/watch?v=zGUIUVN75gA
 start-date: "2021-08-24T22:00:00.000Z"
 end-date:
 image:
-  url: /assets/images/64521604a359ff699f3705ec_storage-provider-working-group.png
+  src: /assets/images/64521604a359ff699f3705ec_storage-provider-working-group.png
   alt:
 involvement: hosted
 seo:

--- a/src/content/events/sustainable-blockchain-summit.md
+++ b/src/content/events/sustainable-blockchain-summit.md
@@ -9,7 +9,7 @@ external-link: https://sbs.tech/
 start-date: "2022-07-22T00:00:00.000Z"
 end-date: "2022-07-23T00:00:00.000Z"
 image:
-  url: /assets/images/645215eb05e191292b09744d_sbs.png
+  src: /assets/images/645215eb05e191292b09744d_sbs.png
   alt:
 involvement: supported
 seo:

--- a/src/content/events/synbiobeta.md
+++ b/src/content/events/synbiobeta.md
@@ -9,7 +9,7 @@ external-link: https://sbs.tech/
 start-date: "2023-05-23T15:30:00.000Z"
 end-date:
 image:
-  url: /assets/images/synbiobeta-2023.png
+  src: /assets/images/synbiobeta-2023.png
   alt:
 involvement: supported
 seo:

--- a/src/content/events/taipei-blockchain-week.md
+++ b/src/content/events/taipei-blockchain-week.md
@@ -9,7 +9,7 @@ external-link: https://www.taipeiblockchainweek.com/
 start-date: "2022-12-12T18:19:06.330Z"
 end-date: "2022-12-17T18:19:00.000Z"
 image:
-  url: /assets/images/tapei-blockchain-2022.png
+  src: /assets/images/tapei-blockchain-2022.png
   alt:
 involvement: supported
 seo:

--- a/src/content/events/teamz-web3-ai-summit-conference-2024.md
+++ b/src/content/events/teamz-web3-ai-summit-conference-2024.md
@@ -9,7 +9,7 @@ external-link: https://en.web3.teamz.co.jp/
 start-date: 2024-04-13T16:47:39.948000Z
 end-date: 2024-04-14T16:47:39.955000Z
 image:
-  url: /assets/images/teamz-conference.webp
+  src: /assets/images/teamz-conference.webp
   alt:
 involvement: supported
 seo:

--- a/src/content/events/the-crypties.md
+++ b/src/content/events/the-crypties.md
@@ -9,7 +9,7 @@ external-link: https://cryptiesawards.com/
 start-date: "2022-11-30T18:24:48.715Z"
 end-date:
 image:
-  url: /assets/images/crypties-2022.png
+  src: /assets/images/crypties-2022.png
   alt:
 involvement: supported
 seo:

--- a/src/content/events/the-filecoin-sanctuary-davos-2024.md
+++ b/src/content/events/the-filecoin-sanctuary-davos-2024.md
@@ -9,7 +9,7 @@ external-link:
 start-date: "2024-01-15T14:03:29.762Z"
 end-date: "2024-01-19T14:03:29.769Z"
 image:
-  url: /assets/images/davos-2023-pic.png
+  src: /assets/images/davos-2023-pic.png
   alt:
 involvement: hosted
 seo:

--- a/src/content/events/the-filecoin-sanctuary-davos.md
+++ b/src/content/events/the-filecoin-sanctuary-davos.md
@@ -9,7 +9,7 @@ external-link:
 start-date: "2023-01-15T16:51:17.049Z"
 end-date: "2023-01-20T16:51:17.055Z"
 image:
-  url: /assets/images/davos-2023-pic.png
+  src: /assets/images/davos-2023-pic.png
   alt:
 involvement: hosted
 seo:

--- a/src/content/events/token2049-dubai-filecoin-orbit-event.md
+++ b/src/content/events/token2049-dubai-filecoin-orbit-event.md
@@ -9,7 +9,7 @@ external-link:
 start-date: "2024-04-16T14:45:39.324Z"
 end-date: "2024-04-19T14:45:39.332Z"
 image:
-  url: /assets/images/token2049_dubai24.png
+  src: /assets/images/token2049_dubai24.png
   alt: Token2049 Dubai Logo
 involvement: sponsored
 seo:

--- a/src/content/events/unfinished-live.md
+++ b/src/content/events/unfinished-live.md
@@ -9,7 +9,7 @@ external-link: https://live.unfinished.com/
 start-date: "2022-09-21T00:00:00.000Z"
 end-date: "2022-08-24T00:00:00.000Z"
 image:
-  url: /assets/images/645215e44977982552923065_unfinished-live.png
+  src: /assets/images/645215e44977982552923065_unfinished-live.png
   alt:
 involvement: supported
 seo:

--- a/src/content/events/vision-weekend-us.md
+++ b/src/content/events/vision-weekend-us.md
@@ -9,7 +9,7 @@ external-link: https://foresight.org/vision-weekends-2022/
 start-date: "2022-12-02T18:27:58.553Z"
 end-date: "2022-12-04T18:27:00.000Z"
 image:
-  url: /assets/images/vision-sf-2022.png
+  src: /assets/images/vision-sf-2022.png
   alt:
 involvement: supported
 seo:

--- a/src/content/events/vision-weekend-usa-2023.md
+++ b/src/content/events/vision-weekend-usa-2023.md
@@ -10,7 +10,7 @@ start-date: "2023-12-01T14:08:27.294Z"
 end-date: "2023-12-03T14:08:27.299Z"
 
 image:
-  url: /assets/images/vision-weekend.jpeg
+  src: /assets/images/vision-weekend.jpeg
   alt:
 involvement: supported
 seo:

--- a/src/content/events/web3-hacker-house-at-sxsw.md
+++ b/src/content/events/web3-hacker-house-at-sxsw.md
@@ -12,7 +12,7 @@ external-link:
 start-date: "2022-03-13T16:00:00.000Z"
 end-date:
 image:
-  url: /assets/images/645215f691cf5c91a16146aa_https___cdn-evbuc-com_images_239998219_264947572824_1_original.jpeg
+  src: /assets/images/645215f691cf5c91a16146aa_https___cdn-evbuc-com_images_239998219_264947572824_1_original.jpeg
   alt:
 involvement: supported
 seo:

--- a/src/content/events/web3-infrastructure-summit-2023.md
+++ b/src/content/events/web3-infrastructure-summit-2023.md
@@ -9,7 +9,7 @@ external-link: https://rockscarmedia.com/events/web3-infrastructure-summit-2023/
 start-date: "2023-06-15T17:43:52.060Z"
 end-date:
 image:
-  url: /assets/images/web3-infra-2023.png
+  src: /assets/images/web3-infra-2023.png
 involvement: supported
 seo:
   title: Web3 Infrastructure Summit 2023


### PR DESCRIPTION
This PR replaces all `url` fields with `src` to match `ImageProps` / the native HTML attribute for image tags.

I used VS Code's global search with this regexp `image:\n\s*url:` to automatically update all content entries.

Now the changes are done, searching with `image:\n\s*src:` should return 411 results, which is the number of files updated by this commit https://github.com/FilecoinFoundationWeb/filecoin-foundation/pull/253/commits/4532eca879ec35678a8bc1bac90472f9929666d5

```
git diff --stat 4532eca 4532eca~1

411 files changed, 459 insertions(+), 411 deletions(-)
```