### PR TITLE
Fix cta xs devices

### DIFF
--- a/src/app/_components/Button.tsx
+++ b/src/app/_components/Button.tsx
@@ -47,7 +47,7 @@ export function Button({
   ...rest
 }: ButtonProps) {
   className = clsx(
-    'focus:brand-outline inline-flex items-center justify-center gap-2 rounded-lg border px-9 py-3 font-semibold transition hover:no-underline sm:whitespace-nowrap',
+    'focus:brand-outline inline-flex items-center justify-center gap-2 rounded-lg border px-6 sm:px-9 py-3 font-semibold transition hover:no-underline sm:whitespace-nowrap',
     variantStyles[variant],
     className,
   )

--- a/src/app/_components/Button.tsx
+++ b/src/app/_components/Button.tsx
@@ -47,7 +47,7 @@ export function Button({
   ...rest
 }: ButtonProps) {
   className = clsx(
-    'focus:brand-outline inline-flex items-center justify-center gap-2 rounded-lg border px-6 sm:px-9 py-3 font-semibold transition hover:no-underline sm:whitespace-nowrap',
+    'inline-flex items-center justify-center gap-2 rounded-lg border px-6 py-3 font-semibold transition focus:brand-outline hover:no-underline sm:whitespace-nowrap sm:px-9',
     variantStyles[variant],
     className,
   )


### PR DESCRIPTION
This PR fixes the text layout on `Button` on xs devices.

I initially centered that text in the button, as agreed on the [ticket](https://www.notion.so/filecoin/FF-V4-BUG-Main-CTA-onXS-devices-1a9052b368b645c6bf8a61cd45d78ec8?pvs=4), but I thought it looked weird with the `ArrowUpRight` icon on secondary buttons.

![CleanShot 2024-06-25 at 14 05 19](https://github.com/FilecoinFoundationWeb/filecoin-foundation/assets/20277959/78be363d-5f67-4879-923a-0633afab65c6)

---

So, instead, I reduced the horizontal padding to give enough room to the text and make sure everything fits on one line.

This solution looks better to me, and I'd love your opinion, @filipagr. I'm happy to revert to the first option idea if you think it's best.

![CleanShot 2024-06-25 at 14 12 09](https://github.com/FilecoinFoundationWeb/filecoin-foundation/assets/20277959/fbf8d794-e96f-4605-b6cd-77b3cba85fd7)

