### PR TITLE
[ORBIT] Add Statistics Section

### DIFF
--- a/src/app/_components/CardGrid.tsx
+++ b/src/app/_components/CardGrid.tsx
@@ -15,7 +15,7 @@ type CardGridProps = {
   children: React.ReactNode
 }
 
-const baseGridStyles = 'grid grid-cols-1 gap-4'
+const baseGridStyles = 'grid grid-cols-1 gap-4 auto-rows-fr'
 const extendedGridStyles: Record<GridColumnConfig, string> = {
   smTwoLgThree: 'sm:grid-cols-2 sm:gap-6 lg:grid-cols-3',
   smTwo: 'sm:grid-cols-2 sm:gap-6',

--- a/src/app/_components/Icon.tsx
+++ b/src/app/_components/Icon.tsx
@@ -2,13 +2,14 @@ import { type Icon } from '@phosphor-icons/react'
 
 export type IconProps = {
   component: Icon
-  color?: 'inherit' | 'brand-300' | 'brand-400'
+  color?: keyof typeof colorStyles
   size?: number
   weight?: 'light' | 'regular' | 'bold'
 }
 
 const colorStyles = {
   inherit: 'text-inherit',
+  'brand-200': 'text-brand-200',
   'brand-300': 'text-brand-300',
   'brand-400': 'text-brand-400',
 }

--- a/src/app/_components/StatisticCard.tsx
+++ b/src/app/_components/StatisticCard.tsx
@@ -1,12 +1,16 @@
 import { Icon, type IconProps } from '@/components/Icon'
 
 export type StatisticCardProps = {
-  stat: number
   icon: IconProps['component']
+  value: number
   description: string
 }
 
-export function StatisticCard({ icon, stat, description }: StatisticCardProps) {
+export function StatisticCard({
+  icon,
+  value,
+  description,
+}: StatisticCardProps) {
   return (
     <li className="flex min-h-32 rounded-lg border border-brand-300 p-1">
       <figure className="grid w-1/3 place-items-center rounded bg-brand-500">
@@ -16,7 +20,7 @@ export function StatisticCard({ icon, stat, description }: StatisticCardProps) {
       <div className="flex w-2/3 place-items-center p-4">
         <div className="space-y-2">
           <span className="text-4xl font-light text-brand-100">
-            {stat.toLocaleString()}+
+            {value.toLocaleString()}+
           </span>
           <p className="text-sm leading-4 text-brand-200">{description}</p>
         </div>

--- a/src/app/_components/StatisticCard.tsx
+++ b/src/app/_components/StatisticCard.tsx
@@ -1,9 +1,9 @@
 import { Icon, type IconProps } from '@/components/Icon'
 
-type StatisticCardProps = {
+export type StatisticCardProps = {
   stat: number | `+${number}`
   icon: IconProps['component']
-  description: string | JSX.Element
+  description: JSX.Element
 }
 
 export function StatisticCard({ icon, stat, description }: StatisticCardProps) {
@@ -18,12 +18,8 @@ export function StatisticCard({ icon, stat, description }: StatisticCardProps) {
           <h3 className="pb-2 text-4xl font-light text-brand-100">
             {formatNumber(stat)}
           </h3>
-          <span className="text-sm leading-4 text-brand-200">
-            {typeof description === 'string' ? (
-              <p>{description}</p>
-            ) : (
-              description
-            )}
+          <span className="text-xs leading-4 text-brand-200">
+            {description}
           </span>
         </div>
       </div>

--- a/src/app/_components/StatisticCard.tsx
+++ b/src/app/_components/StatisticCard.tsx
@@ -1,37 +1,24 @@
 import { Icon, type IconProps } from '@/components/Icon'
 
 export type StatisticCardProps = {
-  stat: number | `+${number}`
+  stat: number
   icon: IconProps['component']
-  description: JSX.Element
-}
-
-function formatNumber(stat: StatisticCardProps['stat']) {
-  if (typeof stat === 'number') {
-    return stat.toLocaleString('en-US')
-  }
-
-  const stringWithoutPlus = stat.slice(1)
-  const formattedNumber = Number(stringWithoutPlus).toLocaleString('en-US')
-
-  return `+${formattedNumber}`
+  description: string
 }
 
 export function StatisticCard({ icon, stat, description }: StatisticCardProps) {
   return (
-    <li className="flex rounded-lg border border-brand-300 p-1">
-      <div className="flex h-40 w-32 shrink-0 items-center justify-center rounded bg-brand-500 sm:h-36 lg:h-32">
-        <Icon component={icon} color="brand-200" size={44} />
-      </div>
+    <li className="flex min-h-32 rounded-lg border border-brand-300 p-1">
+      <figure className="grid w-1/3 place-items-center rounded bg-brand-500">
+        <Icon component={icon} color="brand-200" size={40} />
+      </figure>
 
-      <div className="flex grow flex-col justify-center p-4">
-        <div>
-          <h3 className="pb-2 text-4xl font-light text-brand-100">
-            {formatNumber(stat)}
-          </h3>
-          <span className="text-xs leading-4 text-brand-200">
-            {description}
+      <div className="flex w-2/3 place-items-center p-4">
+        <div className="space-y-2">
+          <span className="text-4xl font-light text-brand-100">
+            {stat.toLocaleString()}+
           </span>
+          <p className="text-sm leading-4 text-brand-200">{description}</p>
         </div>
       </div>
     </li>

--- a/src/app/_components/StatisticCard.tsx
+++ b/src/app/_components/StatisticCard.tsx
@@ -1,0 +1,43 @@
+import { Icon, type IconProps } from '@/components/Icon'
+
+type StatisticCardProps = {
+  stat: number | `+${number}`
+  icon: IconProps['component']
+  description: string | JSX.Element
+}
+
+export function StatisticCard({ icon, stat, description }: StatisticCardProps) {
+  return (
+    <li className="relative flex rounded-lg border border-brand-300 p-1">
+      <div className="flex h-40 w-28 shrink-0 items-center justify-center rounded-md bg-brand-500 sm:h-36 lg:h-28">
+        <Icon component={icon} color="brand-200" size={40} />
+      </div>
+
+      <div className="flex grow flex-col justify-center p-4">
+        <div>
+          <h3 className="pb-2 text-4xl font-light text-brand-100">
+            {formatNumber(stat)}
+          </h3>
+          <span className="text-sm leading-4 text-brand-200">
+            {typeof description === 'string' ? (
+              <p>{description}</p>
+            ) : (
+              description
+            )}
+          </span>
+        </div>
+      </div>
+    </li>
+  )
+}
+
+export function formatNumber(stat: StatisticCardProps['stat']) {
+  if (typeof stat === 'number') {
+    return stat.toLocaleString('en-US')
+  }
+
+  const stringWithoutPlus = stat.slice(1)
+  const formattedNumber = Number(stringWithoutPlus).toLocaleString('en-US')
+
+  return `+${formattedNumber}`
+}

--- a/src/app/_components/StatisticCard.tsx
+++ b/src/app/_components/StatisticCard.tsx
@@ -6,9 +6,20 @@ export type StatisticCardProps = {
   description: JSX.Element
 }
 
+function formatNumber(stat: StatisticCardProps['stat']) {
+  if (typeof stat === 'number') {
+    return stat.toLocaleString('en-US')
+  }
+
+  const stringWithoutPlus = stat.slice(1)
+  const formattedNumber = Number(stringWithoutPlus).toLocaleString('en-US')
+
+  return `+${formattedNumber}`
+}
+
 export function StatisticCard({ icon, stat, description }: StatisticCardProps) {
   return (
-    <li className="relative flex rounded-lg border border-brand-300 p-1">
+    <li className="flex rounded-lg border border-brand-300 p-1">
       <div className="flex h-40 w-32 shrink-0 items-center justify-center rounded bg-brand-500 sm:h-36 lg:h-32">
         <Icon component={icon} color="brand-200" size={44} />
       </div>
@@ -25,15 +36,4 @@ export function StatisticCard({ icon, stat, description }: StatisticCardProps) {
       </div>
     </li>
   )
-}
-
-export function formatNumber(stat: StatisticCardProps['stat']) {
-  if (typeof stat === 'number') {
-    return stat.toLocaleString('en-US')
-  }
-
-  const stringWithoutPlus = stat.slice(1)
-  const formattedNumber = Number(stringWithoutPlus).toLocaleString('en-US')
-
-  return `+${formattedNumber}`
 }

--- a/src/app/_components/StatisticCard.tsx
+++ b/src/app/_components/StatisticCard.tsx
@@ -9,8 +9,8 @@ export type StatisticCardProps = {
 export function StatisticCard({ icon, stat, description }: StatisticCardProps) {
   return (
     <li className="relative flex rounded-lg border border-brand-300 p-1">
-      <div className="flex h-40 w-28 shrink-0 items-center justify-center rounded-md bg-brand-500 sm:h-36 lg:h-28">
-        <Icon component={icon} color="brand-200" size={40} />
+      <div className="flex h-40 w-32 shrink-0 items-center justify-center rounded bg-brand-500 sm:h-36 lg:h-32">
+        <Icon component={icon} color="brand-200" size={44} />
       </div>
 
       <div className="flex grow flex-col justify-center p-4">

--- a/src/app/orbit/data/statisticsData.tsx
+++ b/src/app/orbit/data/statisticsData.tsx
@@ -1,0 +1,54 @@
+import {
+  GlobeHemisphereWest,
+  GraduationCap,
+  Trophy,
+  UsersThree,
+} from '@phosphor-icons/react/dist/ssr'
+
+import type { StatisticCardProps } from '@/components/StatisticCard'
+
+export const statisticsData: Array<StatisticCardProps> = [
+  {
+    icon: UsersThree,
+    stat: 147,
+    description: (
+      <p>
+        <span className="font-bold">Orbit Ambassadors</span>
+        <br />
+        around the world
+      </p>
+    ),
+  },
+  {
+    icon: GraduationCap,
+    stat: 10_000,
+    description: (
+      <p>
+        <span className="font-bold">
+          Early-career developers, students, and enthusiasts
+        </span>{' '}
+        have been introduced to the Filecoin ecosystem through Orbit
+      </p>
+    ),
+  },
+  {
+    icon: Trophy,
+    stat: 190,
+    description: (
+      <p>
+        <span className="font-bold">Workshops and community hackathons</span>
+      </p>
+    ),
+  },
+  {
+    icon: GlobeHemisphereWest,
+    stat: '+40',
+    description: (
+      <p>
+        <span className="font-bold">Countries</span>
+        <br />
+        have hosted Orbit events
+      </p>
+    ),
+  },
+]

--- a/src/app/orbit/data/statisticsData.tsx
+++ b/src/app/orbit/data/statisticsData.tsx
@@ -7,26 +7,26 @@ import {
 
 import type { StatisticCardProps } from '@/components/StatisticCard'
 
-export const statisticsData: Array<StatisticCardProps> = [
+export const statisticsData: StatisticCardProps[] = [
   {
     icon: UsersThree,
-    stat: 145,
+    value: 145,
     description: 'Orbit Ambassadors active worldwide',
   },
   {
     icon: GraduationCap,
-    stat: 10_000,
+    value: 10_000,
     description:
       'Early-career developers, students, and enthusiasts introduced to the Filecoin ecosystem',
   },
   {
     icon: Trophy,
-    stat: 190,
+    value: 190,
     description: 'Workshops and community hackathons hosted',
   },
   {
     icon: GlobeHemisphereWest,
-    stat: 40,
+    value: 40,
     description: 'Countries that have hosted Orbit events',
   },
 ]

--- a/src/app/orbit/data/statisticsData.tsx
+++ b/src/app/orbit/data/statisticsData.tsx
@@ -10,45 +10,23 @@ import type { StatisticCardProps } from '@/components/StatisticCard'
 export const statisticsData: Array<StatisticCardProps> = [
   {
     icon: UsersThree,
-    stat: 147,
-    description: (
-      <p>
-        <span className="font-bold">Orbit Ambassadors</span>
-        <br />
-        around the world
-      </p>
-    ),
+    stat: 145,
+    description: 'Orbit Ambassadors active worldwide',
   },
   {
     icon: GraduationCap,
     stat: 10_000,
-    description: (
-      <p>
-        <span className="font-bold">
-          Early-career developers, students, and enthusiasts
-        </span>{' '}
-        have been introduced to the Filecoin ecosystem through Orbit
-      </p>
-    ),
+    description:
+      'Early-career developers, students, and enthusiasts introduced to the Filecoin ecosystem',
   },
   {
     icon: Trophy,
     stat: 190,
-    description: (
-      <p>
-        <span className="font-bold">Workshops and community hackathons</span>
-      </p>
-    ),
+    description: 'Workshops and community hackathons hosted',
   },
   {
     icon: GlobeHemisphereWest,
-    stat: '+40',
-    description: (
-      <p>
-        <span className="font-bold">Countries</span>
-        <br />
-        have hosted Orbit events
-      </p>
-    ),
+    stat: 40,
+    description: 'Countries that have hosted Orbit events',
   },
 ]

--- a/src/app/orbit/page.tsx
+++ b/src/app/orbit/page.tsx
@@ -38,7 +38,7 @@ export default function Orbit() {
 
       {/* <PageSection kicker="Goals" title="Main Goals of This Program" /> */}
 
-      <PageSection kicker="Statistics" title="Since Program Launch in 2020">
+      <PageSection kicker="Statistics" title="Key Statistics Since 2020">
         <CardGrid cols="smTwo">
           {statisticsData.map((statistic, index) => (
             <StatisticCard key={index} {...statistic} />

--- a/src/app/orbit/page.tsx
+++ b/src/app/orbit/page.tsx
@@ -39,7 +39,7 @@ export default function Orbit() {
       {/* <PageSection kicker="Goals" title="Main Goals of This Program" /> */}
 
       <PageSection kicker="Statistics" title="Since Program Launch in 2020">
-        <CardGrid cols="mdTwo">
+        <CardGrid cols="smTwo">
           {statisticsData.map((statistic, index) => (
             <StatisticCard key={index} {...statistic} />
           ))}

--- a/src/app/orbit/page.tsx
+++ b/src/app/orbit/page.tsx
@@ -1,9 +1,11 @@
 import { Button } from '@/components/Button'
+import { CardGrid } from '@/components/CardGrid'
 import { CTASection } from '@/components/CTASection'
 import { OrbitAmbassadorCard } from '@/components/OrbitAmbassadorCard'
 import { PageHeader } from '@/components/PageHeader'
 import { PageLayout } from '@/components/PageLayout'
 import { PageSection } from '@/components/PageSection'
+import { StatisticCard } from '@/components/StatisticCard'
 
 import { attributes } from '@/content/pages/orbit.md'
 
@@ -11,6 +13,7 @@ import { FILECOIN_FOUNDATION_URLS } from '@/constants/siteMetadata'
 import { graphicsData } from '@/data/graphicsData'
 
 import { ambassadorsData } from './data/ambassadorsData'
+import { statisticsData } from './data/statisticsData'
 
 const { header } = attributes
 
@@ -36,7 +39,11 @@ export default function Orbit() {
       {/* <PageSection kicker="Goals" title="Main Goals of This Program" /> */}
 
       <PageSection kicker="Statistics" title="Since Program Launch in 2020">
-        <p>TODO</p>
+        <CardGrid cols="mdTwo">
+          {statisticsData.map((statistic, index) => (
+            <StatisticCard key={index} {...statistic} />
+          ))}
+        </CardGrid>
       </PageSection>
 
       <PageSection


### PR DESCRIPTION
This PR adds the cards in the Statistics section of the orbit page.

---

![CleanShot 2024-06-27 at 15 19 34](https://github.com/FilecoinFoundationWeb/filecoin-foundation/assets/20277959/fb048b8d-3e27-4cd9-8bd2-8546f15a9457)

[Notion](https://www.notion.so/filecoin/FF-V4-ORBIT-Create-Statistics-Card-0bb8fb50f6ab48a296c15389f06eabd3?pvs=4)