### PR TITLE
Orbit Page - Orbit Explore Section

### DIFF
--- a/src/app/orbit/data/exploreOrbitData.ts
+++ b/src/app/orbit/data/exploreOrbitData.ts
@@ -1,4 +1,8 @@
-import { BookOpen, Clipboard, Envelope } from '@phosphor-icons/react/dist/ssr'
+import {
+  BookOpen,
+  ClipboardText,
+  Envelope,
+} from '@phosphor-icons/react/dist/ssr'
 
 import type { IconProps } from '@/components/Icon'
 
@@ -43,7 +47,7 @@ export const exploreOrbitData: ExploreOrbitData[] = [
   {
     heading: {
       title: "Ambassador's Portal",
-      icon: Clipboard,
+      icon: ClipboardText,
     },
     description: 'Access the private portal with tools and resources.',
     cta: {

--- a/src/app/orbit/data/exploreOrbitData.ts
+++ b/src/app/orbit/data/exploreOrbitData.ts
@@ -2,7 +2,6 @@ import { BookOpen, Clipboard, Envelope } from '@phosphor-icons/react/dist/ssr'
 
 import type { IconProps } from '@/components/Icon'
 
-import { PATHS } from '@/constants/paths'
 import { FILECOIN_FOUNDATION_URLS } from '@/constants/siteMetadata'
 
 type ExploreOrbitData = {

--- a/src/app/orbit/data/exploreOrbitData.ts
+++ b/src/app/orbit/data/exploreOrbitData.ts
@@ -1,0 +1,55 @@
+import { BookOpen, Clipboard, Envelope } from '@phosphor-icons/react/dist/ssr'
+
+import type { IconProps } from '@/components/Icon'
+
+import { PATHS } from '@/constants/paths'
+import { FILECOIN_FOUNDATION_URLS } from '@/constants/siteMetadata'
+
+type ExploreOrbitData = {
+  heading: {
+    title: string
+    icon: IconProps['component']
+  }
+  description: string
+  cta: {
+    href: string
+    text: string
+  }
+}
+
+export const exploreOrbitData: ExploreOrbitData[] = [
+  {
+    heading: {
+      title: '2023 Orbit Recap',
+      icon: BookOpen,
+    },
+    description: 'Discover the highlights and milestones from our past year.',
+    cta: {
+      href: '',
+      text: 'Check 2023 Orbit Recap',
+    },
+  },
+  {
+    heading: {
+      title: 'Get in Touch',
+      icon: Envelope,
+    },
+    description:
+      'Connect with the Orbit Team for more information and support.',
+    cta: {
+      href: '',
+      text: 'Email Us',
+    },
+  },
+  {
+    heading: {
+      title: "Ambassador's Portal",
+      icon: Clipboard,
+    },
+    description: 'Access the private portal with tools and resources.',
+    cta: {
+      href: FILECOIN_FOUNDATION_URLS.orbit.ambassadorsPortal,
+      text: 'Access Private Portal',
+    },
+  },
+]

--- a/src/app/orbit/page.tsx
+++ b/src/app/orbit/page.tsx
@@ -2,6 +2,7 @@ import { Button } from '@/components/Button'
 import { CardGrid } from '@/components/CardGrid'
 import { CTASection } from '@/components/CTASection'
 import { FocusAreaCard } from '@/components/FocusAreaCard'
+import { HomeExploreSectionCard } from '@/components/HomeExploreSectionCard'
 import { OrbitAmbassadorCard } from '@/components/OrbitAmbassadorCard'
 import { PageHeader } from '@/components/PageHeader'
 import { PageLayout } from '@/components/PageLayout'
@@ -18,6 +19,7 @@ import { FILECOIN_FOUNDATION_URLS } from '@/constants/siteMetadata'
 import { graphicsData } from '@/data/graphicsData'
 
 import { ambassadorsData } from './data/ambassadorsData'
+import { exploreOrbitData } from './data/exploreOrbitData'
 import { programGoalsData } from './data/programGoalsData'
 import { statisticsData } from './data/statisticsData'
 import { generateStructuredData } from './utils/generateStructuredData'
@@ -99,7 +101,34 @@ export default function Orbit() {
         ]}
       /> */}
 
-      {/* <PageSection kicker="Get Involved" title="Explore Orbit" /> */}
+      <PageSection kicker="Get Involved" title="Explore Orbit">
+        <CardGrid cols="smTwo">
+          {exploreOrbitData.map((data, index) => {
+            const {
+              heading: { title, icon },
+              description,
+              cta,
+            } = data
+
+            return (
+              <HomeExploreSectionCard
+                key={index}
+                cta={cta}
+                heading={{
+                  tag: 'h3',
+                  variant: 'lg',
+                  children: title,
+                  iconProps: {
+                    component: icon,
+                  },
+                }}
+              >
+                {description}
+              </HomeExploreSectionCard>
+            )
+          })}
+        </CardGrid>
+      </PageSection>
 
       <PageSection kicker="Testimonials" title="Hear From Our Ambassadors">
         {ambassadorsData.map((ambassadorData, index) => {

--- a/src/app/orbit/page.tsx
+++ b/src/app/orbit/page.tsx
@@ -102,7 +102,7 @@ export default function Orbit() {
       /> */}
 
       <PageSection kicker="Get Involved" title="Explore Orbit">
-        <CardGrid cols="smTwo">
+        <CardGrid cols="lgThree">
           {exploreOrbitData.map((data, index) => {
             const {
               heading: { title, icon },


### PR DESCRIPTION
This PR styles the Orbit Explore Section on the Orbit Page.

Note:

- Waiting for two links to be provided
- Using the `HomeExploreSectionCard` for now. This will be refactored once we pick up the Card Refactoring ticket.

---

[Notion](https://www.notion.so/filecoin/FF-Orbit-Page-Explore-Orbit-Section-62efa5c1f4594164abfdc1a5b83b7077?pvs=4) | [Figma](https://www.figma.com/design/0pBfQs5tKI6bx5ypPIfVRA/FIL.org-V4-Prototypes?node-id=2932-35120&t=kitr4iBq2hbfmZlI-4)

---

<img width="669" alt="Screenshot 2024-07-03 at 08 36 54" src="https://github.com/FilecoinFoundationWeb/filecoin-foundation/assets/26620750/9c1923af-fc07-4496-abd9-966bf0d2adbf">
