### PR TITLE
Fix Card Grid Bug - Introduce hasGridAutoRows prop

### DIFF
--- a/src/app/_components/CardGrid.tsx
+++ b/src/app/_components/CardGrid.tsx
@@ -11,11 +11,12 @@ type GridColumnConfig =
 
 type CardGridProps = {
   cols: GridColumnConfig
+  useGridAutoRows?: boolean
   as?: React.ElementType
   children: React.ReactNode
 }
 
-const baseGridStyles = 'grid grid-cols-1 gap-4 auto-rows-fr'
+const baseGridStyles = 'grid grid-cols-1 gap-4'
 const extendedGridStyles: Record<GridColumnConfig, string> = {
   smTwoLgThree: 'sm:grid-cols-2 sm:gap-6 lg:grid-cols-3',
   smTwo: 'sm:grid-cols-2 sm:gap-6',
@@ -26,9 +27,18 @@ const extendedGridStyles: Record<GridColumnConfig, string> = {
   lgThree: 'lg:grid-cols-3 lg:gap-6',
 }
 
-export function CardGrid({ cols, as: Tag = 'ul', children }: CardGridProps) {
+export function CardGrid({
+  cols,
+  useGridAutoRows = true,
+  as: Tag = 'ul',
+  children,
+}: CardGridProps) {
+  const autoRowsStyles = useGridAutoRows && 'auto-rows-fr'
+
   return (
-    <Tag className={clsx(baseGridStyles, extendedGridStyles[cols])}>
+    <Tag
+      className={clsx(baseGridStyles, extendedGridStyles[cols], autoRowsStyles)}
+    >
       {children}
     </Tag>
   )

--- a/src/app/_components/CardGrid.tsx
+++ b/src/app/_components/CardGrid.tsx
@@ -11,7 +11,7 @@ type GridColumnConfig =
 
 type CardGridProps = {
   cols: GridColumnConfig
-  useGridAutoRows?: boolean
+  hasGridAutoRows?: boolean
   as?: React.ElementType
   children: React.ReactNode
 }
@@ -29,11 +29,11 @@ const extendedGridStyles: Record<GridColumnConfig, string> = {
 
 export function CardGrid({
   cols,
-  useGridAutoRows = true,
+  hasGridAutoRows = true,
   as: Tag = 'ul',
   children,
 }: CardGridProps) {
-  const autoRowsStyles = useGridAutoRows && 'auto-rows-fr'
+  const autoRowsStyles = hasGridAutoRows && 'auto-rows-fr'
 
   return (
     <Tag

--- a/src/app/about/page.tsx
+++ b/src/app/about/page.tsx
@@ -82,7 +82,7 @@ export default function About() {
       </PageSection>
 
       <PageSection kicker="Insights" title="Reports">
-        <CardGrid cols="lgTwo">
+        <CardGrid cols="lgTwo" useGridAutoRows={false}>
           {reportsData.map(({ title, description, link, image }, index) => {
             const imageProp = image && {
               ...image,

--- a/src/app/about/page.tsx
+++ b/src/app/about/page.tsx
@@ -82,7 +82,7 @@ export default function About() {
       </PageSection>
 
       <PageSection kicker="Insights" title="Reports">
-        <CardGrid cols="lgTwo" useGridAutoRows={false}>
+        <CardGrid cols="lgTwo" hasGridAutoRows={false}>
           {reportsData.map(({ title, description, link, image }, index) => {
             const imageProp = image && {
               ...image,

--- a/src/app/security/page.tsx
+++ b/src/app/security/page.tsx
@@ -52,7 +52,7 @@ export default function Security() {
       />
 
       <PageSection kicker="Audits" title="Security Audits">
-        <CardGrid cols="smTwo">
+        <CardGrid cols="smTwo" useGridAutoRows={false}>
           <StaticImage
             {...graphicsData.security3}
             className="h-full w-full rounded-lg"

--- a/src/app/security/page.tsx
+++ b/src/app/security/page.tsx
@@ -52,7 +52,7 @@ export default function Security() {
       />
 
       <PageSection kicker="Audits" title="Security Audits">
-        <CardGrid cols="smTwo" useGridAutoRows={false}>
+        <CardGrid cols="smTwo" hasGridAutoRows={false}>
           <StaticImage
             {...graphicsData.security3}
             className="h-full w-full rounded-lg"


### PR DESCRIPTION
This pull request addresses a bug in the `CardGrid` component by introducing a new optional prop `hasGridAutoRows`. This prop allows for more flexible grid row configurations.

**Changes:**
1. **CardGrid Component (`CardGrid.tsx`):**
   - Added `hasGridAutoRows` prop to control auto-row styling.
   - Adjusted `baseGridStyles` to conditionally include `auto-rows-fr` based on the new prop.

2. **About Page (`about/page.tsx`):**
   - Updated `CardGrid` usage to set `hasGridAutoRows` to `false`.

3. **Security Page (`security/page.tsx`):**
   - Updated `CardGrid` usage to set `hasGridAutoRows` to `false`.

These changes enhance the layout flexibility and resolve the existing grid bug.