### PR TITLE
Orbit & Security Pages - Change SEO copy

### DIFF
--- a/cypress/e2e/about_page_spec.cy.ts
+++ b/cypress/e2e/about_page_spec.cy.ts
@@ -2,5 +2,5 @@ import { PATHS } from '../../src/app/_constants/paths'
 import { testPageMetadata } from '../support/test-utils'
 
 describe('About Page', function () {
-  testPageMetadata({ path: PATHS.ABOUT, useAbsoluteTitle: true})
+  testPageMetadata({ path: PATHS.ABOUT, overrideDefaultTitle: true })
 })

--- a/cypress/e2e/blog_page_spec.cy.ts
+++ b/cypress/e2e/blog_page_spec.cy.ts
@@ -2,5 +2,9 @@ import { PATHS } from '../../src/app/_constants/paths'
 import { testPageMetadata } from '../support/test-utils'
 
 describe('Blog Page', function () {
-  testPageMetadata({ path: PATHS.BLOG, includesFeaturedEntry: true, useAbsoluteTitle: true})
+  testPageMetadata({
+    path: PATHS.BLOG,
+    includesFeaturedEntry: true,
+    overrideDefaultTitle: true,
+  })
 })

--- a/cypress/e2e/ecosystem-explorer_page_spec.cy.ts
+++ b/cypress/e2e/ecosystem-explorer_page_spec.cy.ts
@@ -2,5 +2,8 @@ import { PATHS } from '../../src/app/_constants/paths'
 import { testPageMetadata } from '../support/test-utils'
 
 describe('Ecosystem Explorer Page', function () {
-  testPageMetadata({ path: PATHS.ECOSYSTEM_EXPLORER, useAbsoluteTitle: true })
+  testPageMetadata({
+    path: PATHS.ECOSYSTEM_EXPLORER,
+    overrideDefaultTitle: true,
+  })
 })

--- a/cypress/e2e/events_page_spec.cy.ts
+++ b/cypress/e2e/events_page_spec.cy.ts
@@ -2,5 +2,9 @@ import { PATHS } from '../../src/app/_constants/paths'
 import { testPageMetadata } from '../support/test-utils'
 
 describe('Events Page', function () {
-  testPageMetadata({ path: PATHS.EVENTS, includesFeaturedEntry: true, useAbsoluteTitle: true})
+  testPageMetadata({
+    path: PATHS.EVENTS,
+    includesFeaturedEntry: true,
+    overrideDefaultTitle: true,
+  })
 })

--- a/cypress/e2e/governance_page_spec.cy.ts
+++ b/cypress/e2e/governance_page_spec.cy.ts
@@ -2,5 +2,5 @@ import { PATHS } from '../../src/app/_constants/paths'
 import { testPageMetadata } from '../support/test-utils'
 
 describe('Governance Page', function () {
-  testPageMetadata({ path: PATHS.GOVERNANCE, useAbsoluteTitle: true})
+  testPageMetadata({ path: PATHS.GOVERNANCE, overrideDefaultTitle: true })
 })

--- a/cypress/e2e/grants_page_spec.cy.ts
+++ b/cypress/e2e/grants_page_spec.cy.ts
@@ -2,5 +2,5 @@ import { PATHS } from '../../src/app/_constants/paths'
 import { testPageMetadata } from '../support/test-utils'
 
 describe('Grants Page', function () {
-  testPageMetadata({ path: PATHS.GRANTS, useAbsoluteTitle: true})
+  testPageMetadata({ path: PATHS.GRANTS, overrideDefaultTitle: true })
 })

--- a/cypress/e2e/home_page_spec.cy.ts
+++ b/cypress/e2e/home_page_spec.cy.ts
@@ -2,5 +2,5 @@ import { PATHS } from '../../src/app/_constants/paths'
 import { testPageMetadata } from '../support/test-utils'
 
 describe('Home Page', function () {
-  testPageMetadata({ path: PATHS.HOME, useAbsoluteTitle: true})
+  testPageMetadata({ path: PATHS.HOME, overrideDefaultTitle: true })
 })

--- a/cypress/support/test-utils.ts
+++ b/cypress/support/test-utils.ts
@@ -8,12 +8,12 @@ export function testPageMetadata({
   path: { mainContentPath, path, entriesContentPath },
   hasPageHeaderDescription = true,
   includesFeaturedEntry = false,
-  useAbsoluteTitle = false,
+  overrideDefaultTitle = false,
 }: {
   path: PathConfig
   hasPageHeaderDescription?: boolean
   includesFeaturedEntry?: boolean
-  useAbsoluteTitle?: boolean
+  overrideDefaultTitle?: boolean
 }) {
   it(`should use the correct metadata from the markdown file`, function () {
     const filePath = `${mainContentPath}.md`
@@ -32,7 +32,7 @@ export function testPageMetadata({
       cy.visit(path)
       cy.percySnapshot()
 
-      verifyPageTitle(path, seo.title, useAbsoluteTitle)
+      verifyPageTitle(path, seo.title, overrideDefaultTitle)
 
       if (includesFeaturedEntry && featuredSlug) {
         handleFeaturedEntry(entriesContentPath as string, featuredSlug)

--- a/cypress/support/verifyMetadataUtil.ts
+++ b/cypress/support/verifyMetadataUtil.ts
@@ -19,11 +19,15 @@ export function verifyMetadata(
   // Retrieve and process the page's metadata
   cy.readFile(fullPath).then((markdownContent: string) => {
     const { seo } = matter(markdownContent).data as {
-      seo: { title: string; description: string; useAbsoluteTitle?: boolean }
+      seo: {
+        title: string
+        description: string
+        overrideDefaultTitle?: boolean
+      }
     }
 
     // Verify the page title and meta description
-    verifyPageTitle(pagePath, seo.title, seo.useAbsoluteTitle ?? false)
+    verifyPageTitle(pagePath, seo.title, seo.overrideDefaultTitle ?? false)
     verifyMetaDescription(seo.description)
   })
 }

--- a/cypress/support/verifyPageTitleUtil.ts
+++ b/cypress/support/verifyPageTitleUtil.ts
@@ -1,8 +1,12 @@
 import { PATHS } from '../../src/app/_constants/paths'
 import { ORGANIZATION_NAME } from '../../src/app/_constants/siteMetadata'
 
-export function verifyPageTitle(path: string, seoTitle: string, useAbsoluteTitle: boolean) {
-  const expectedTitle = useAbsoluteTitle
+export function verifyPageTitle(
+  path: string,
+  seoTitle: string,
+  overrideDefaultTitle: boolean,
+) {
+  const expectedTitle = overrideDefaultTitle
     ? seoTitle
     : path === PATHS.HOME.path
       ? `${ORGANIZATION_NAME} | Decentralized Storage Solutions`

--- a/src/app/_utils/createMetadata.ts
+++ b/src/app/_utils/createMetadata.ts
@@ -7,18 +7,18 @@ import { PathValues, DynamicPathValues } from '@/constants/paths'
 type CreateMetadataProps = {
   seo: SeoMetadata
   path: PathValues | DynamicPathValues
-  useAbsoluteTitle?: boolean
+  overrideDefaultTitle?: boolean
 }
 
 export function createMetadata({
   seo,
   path,
-  useAbsoluteTitle = false,
+  overrideDefaultTitle = false,
 }: CreateMetadataProps): NextMetadata {
   const { title, description } = seo
 
   return {
-    title: useAbsoluteTitle ? { absolute: title } : title,
+    title: overrideDefaultTitle ? { absolute: title } : title,
     description,
     alternates: {
       canonical: path,

--- a/src/app/about/page.tsx
+++ b/src/app/about/page.tsx
@@ -30,7 +30,7 @@ const { header, seo } = attributes
 export const metadata = createMetadata({
   seo,
   path: PATHS.ABOUT.path,
-  useAbsoluteTitle: true,
+  overrideDefaultTitle: true,
 })
 
 export default function About() {

--- a/src/app/blog/page.tsx
+++ b/src/app/blog/page.tsx
@@ -54,7 +54,7 @@ const featuredPost = getBlogPostData(featuredPostSlug || '')
 export const metadata = createMetadata({
   seo,
   path: PATHS.BLOG.path,
-  useAbsoluteTitle: true,
+  overrideDefaultTitle: true,
 })
 
 export default function Blog({ searchParams }: Props) {

--- a/src/app/ecosystem-explorer/page.tsx
+++ b/src/app/ecosystem-explorer/page.tsx
@@ -56,7 +56,7 @@ const { header, seo } = attributes
 export const metadata = createMetadata({
   seo,
   path: PATHS.ECOSYSTEM_EXPLORER.path,
-  useAbsoluteTitle: true,
+  overrideDefaultTitle: true,
 })
 
 const categoryData = getCategoryDataFromDirectory(

--- a/src/app/events/page.tsx
+++ b/src/app/events/page.tsx
@@ -56,7 +56,7 @@ const featuredEvent = getEventData(featuredEventSlug || '')
 export const metadata = createMetadata({
   seo,
   path: PATHS.EVENTS.path,
-  useAbsoluteTitle: true,
+  overrideDefaultTitle: true,
 })
 
 export default function Events({ searchParams }: Props) {

--- a/src/app/governance/page.tsx
+++ b/src/app/governance/page.tsx
@@ -23,7 +23,7 @@ const { header, seo } = attributes
 export const metadata = createMetadata({
   seo,
   path: PATHS.GOVERNANCE.path,
-  useAbsoluteTitle: true,
+  overrideDefaultTitle: true,
 })
 
 export default function Governance() {

--- a/src/app/grants/page.tsx
+++ b/src/app/grants/page.tsx
@@ -39,7 +39,7 @@ const grantGraduates = ecosystemProjects.filter((item) =>
 export const metadata = createMetadata({
   seo,
   path: PATHS.GRANTS.path,
-  useAbsoluteTitle: true,
+  overrideDefaultTitle: true,
 })
 
 export default function Grants() {

--- a/src/app/orbit/page.tsx
+++ b/src/app/orbit/page.tsx
@@ -34,7 +34,7 @@ const { header, seo } = attributes
 export const metadata = createMetadata({
   seo,
   path: PATHS.ORBIT.path,
-  useAbsoluteTitle: true,
+  overrideDefaultTitle: true,
 })
 
 export default function Orbit() {

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -36,7 +36,7 @@ const featuredEcosystemProjects = ecosystemProjects.filter((item) =>
 export const metadata = createMetadata({
   seo,
   path: PATHS.HOME.path,
-  useAbsoluteTitle: true,
+  overrideDefaultTitle: true,
 })
 
 export default function Home() {

--- a/src/app/security/coordinated-disclosure-policy/page.tsx
+++ b/src/app/security/coordinated-disclosure-policy/page.tsx
@@ -17,6 +17,7 @@ const { header, seo } = attributes
 export const metadata = createMetadata({
   seo,
   path: PATHS.COORDINATED_DISCLOSURE_POLICY.path,
+  useAbsoluteTitle: true,
 })
 
 export default function CoordinatedDisclosurePolicy() {

--- a/src/app/security/coordinated-disclosure-policy/page.tsx
+++ b/src/app/security/coordinated-disclosure-policy/page.tsx
@@ -17,7 +17,7 @@ const { header, seo } = attributes
 export const metadata = createMetadata({
   seo,
   path: PATHS.COORDINATED_DISCLOSURE_POLICY.path,
-  useAbsoluteTitle: true,
+  overrideDefaultTitle: true,
 })
 
 export default function CoordinatedDisclosurePolicy() {

--- a/src/app/security/page.tsx
+++ b/src/app/security/page.tsx
@@ -27,7 +27,7 @@ const { header, seo } = attributes
 export const metadata = createMetadata({
   seo,
   path: PATHS.SECURITY.path,
-  useAbsoluteTitle: true,
+  overrideDefaultTitle: true,
 })
 
 export default function Security() {

--- a/src/content/pages/coordinated-disclosure-policy.md
+++ b/src/content/pages/coordinated-disclosure-policy.md
@@ -3,8 +3,8 @@ header:
   title: "Coordinated Disclosure Policy"
   description: ""
 seo:
-  title: "Coordinated Disclosure Policy"
-  description: "Discover the Filecoin Foundation's Coordinated Disclosure Policy. Understand our bug bounty program, disclosure process, and commitment to network security. Report vulnerabilities and earn recognition."
+  title: "Filecoin Bug Bounty Program - Disclosure Policy"
+  description: "To help secure the Filecoin Network and encourage security research done in good faith, we have created a Filecoin Bug Bounty program."
 ---
 
 **Last Updated: April 05, 2024**

--- a/src/content/pages/orbit.md
+++ b/src/content/pages/orbit.md
@@ -7,6 +7,6 @@ header:
       "Whether you're passionate about hosting events, organizing hackathons, or sharing your expertise, there's a place for you here. From university workshops to community-led international conferences, our community is shaping the next generation of builders and innovators.",
     ]
 seo:
-  title: Filecoin Orbit Community Program
-  description: "With the Orbit program, we're on a mission to open the doors to a better internet for everyone. This community-led initiative invites you to join us in spreading the word about groundbreaking technologies like Filecoin and Interplanetary FileSystem (IPFS)"
+  title: Filecoin Orbit Community Program – Events, Hackathons, Initiatives
+  description: "Open the doors to a better internet for everyone. Join the Filecoin Orbit community of ambassadors, promoting revolutionary Filecoin and IPFS technology."
 ---

--- a/src/content/pages/security.md
+++ b/src/content/pages/security.md
@@ -3,6 +3,6 @@ header:
   title: "Filecoin Ecosystem Security"
   description: "Filecoin Foundation is deeply committed to the integrity and security of the Filecoin network. Robust security practices are vital for developing, maintaining, and operating resilient systems – enabling the Filecoin community to innovate and grow."
 seo:
-  title: "Filecoin Ecosystem Security"
-  description: "Filecoin Foundation is deeply committed to the integrity and security of the Filecoin network. Robust security practices are vital for developing, maintaining, and operating resilient systems – enabling the Filecoin community to innovate and grow."
+  title: "Filecoin Security | Audits, Incident Response and Monitoring"
+  description: "We are deeply committed to the integrity and security of the Filecoin ecosystem. Robust security practices are vital for developing, maintaining, and operating the Filecoin network"
 ---


### PR DESCRIPTION
This PR changes the SEO copy for the security pages fil.org/security and fil.org/security/coordinated-disclosure-policy

It also renames the property `hasCustomTitleFormatting` to `overrideDefaultTitle` for better clarity.
