### PR TITLE
Fix cancel icon on Search input

### DIFF
--- a/src/app/_components/Search.tsx
+++ b/src/app/_components/Search.tsx
@@ -40,8 +40,7 @@ export function Search({ query, id }: SearchProps) {
     DEBOUNCE_DELAY,
   )
 
-  function handleSearchChange(event: React.ChangeEvent<HTMLInputElement>) {
-    const newValue = event.target.value
+  function handleSearchChange(newValue: string) {
     setValue(newValue)
 
     const existingPageParam = params.get(PAGE_KEY)

--- a/src/app/_components/SearchInput.tsx
+++ b/src/app/_components/SearchInput.tsx
@@ -33,7 +33,7 @@ export function SearchInput({
         </div>
         {searchQuery && (
           <button
-            className="absolute inset-y-0 right-0 flex items-center px-3 text-brand-300 peer-hover:text-brand-400 peer-focus:text-brand-100"
+            className="absolute inset-y-0.5 right-0.5 flex items-center rounded-md px-3 text-brand-300 focus:brand-outline peer-hover:text-brand-400 peer-focus:text-brand-100"
             aria-label="Clear search input"
             onClick={() => onSearchChange('')}
           >

--- a/src/app/_components/SearchInput.tsx
+++ b/src/app/_components/SearchInput.tsx
@@ -1,13 +1,11 @@
-import { ChangeEvent } from 'react'
-
-import { MagnifyingGlass } from '@phosphor-icons/react/dist/ssr'
+import { MagnifyingGlass, X } from '@phosphor-icons/react/dist/ssr'
 
 import { Icon } from '@/components/Icon'
 
 type SearchInputProps = {
   id: React.ComponentProps<'input'>['id']
   searchQuery: string
-  onSearchChange: (event: ChangeEvent<HTMLInputElement>) => void
+  onSearchChange: (value: string) => void
 }
 
 export function SearchInput({
@@ -24,15 +22,24 @@ export function SearchInput({
         <input
           id={id}
           name="search"
-          className="form-input peer block w-full rounded-lg border border-brand-300 bg-brand-800 py-3 pl-10 pr-3 focus:brand-outline placeholder:text-brand-300 hover:border-brand-400 placeholder:hover:text-brand-400 focus:text-brand-100 placeholder:focus:text-brand-100 "
+          className="peer form-input block w-full rounded-lg border border-brand-300 bg-brand-800 py-3 pl-10 pr-9 focus:brand-outline placeholder:text-brand-300 hover:border-brand-400 placeholder:hover:text-brand-400 focus:text-brand-100 placeholder:focus:text-brand-100 [&::-webkit-search-cancel-button]:appearance-none"
           placeholder="Search"
           type="search"
           value={searchQuery}
-          onChange={onSearchChange}
+          onChange={(event) => onSearchChange(event.target.value)}
         />
-        <div className="pointer-events-none absolute inset-y-0 left-0 flex items-center pl-3 text-brand-300 peer-hover:text-brand-400 peer-focus:text-brand-100">
+        <div className="peer pointer-events-none absolute inset-y-0 left-0 flex items-center pl-3 text-brand-300 peer-hover:text-brand-400 peer-focus:text-brand-100">
           <Icon component={MagnifyingGlass} />
         </div>
+        {searchQuery && (
+          <button
+            className="absolute inset-y-0 right-0 flex items-center px-3 text-brand-300 peer-hover:text-brand-400 peer-focus:text-brand-100"
+            aria-label="Clear search input"
+            onClick={() => onSearchChange('')}
+          >
+            <Icon component={X} size={16} weight="bold" />
+          </button>
+        )}
       </div>
     </div>
   )

--- a/src/app/_components/SearchInput.tsx
+++ b/src/app/_components/SearchInput.tsx
@@ -22,7 +22,7 @@ export function SearchInput({
         <input
           id={id}
           name="search"
-          className="peer form-input block w-full rounded-lg border border-brand-300 bg-brand-800 py-3 pl-10 pr-9 focus:brand-outline placeholder:text-brand-300 hover:border-brand-400 placeholder:hover:text-brand-400 focus:text-brand-100 placeholder:focus:text-brand-100 [&::-webkit-search-cancel-button]:appearance-none"
+          className="peer form-input block w-full rounded-lg border border-brand-300 bg-brand-800 px-11 py-3 focus:brand-outline placeholder:text-brand-300 hover:border-brand-400 placeholder:hover:text-brand-400 focus:text-brand-100 placeholder:focus:text-brand-100 [&::-webkit-search-cancel-button]:appearance-none"
           placeholder="Search"
           type="search"
           value={searchQuery}
@@ -33,7 +33,7 @@ export function SearchInput({
         </div>
         {searchQuery && (
           <button
-            className="absolute inset-y-0.5 right-0.5 flex items-center rounded-md px-3 text-brand-300 focus:brand-outline peer-hover:text-brand-400 peer-focus:text-brand-100"
+            className="absolute right-1 top-1 flex size-[42px] items-center justify-center rounded text-brand-300 focus:brand-outline peer-hover:text-brand-400 peer-focus:text-brand-100"
             aria-label="Clear search input"
             onClick={() => onSearchChange('')}
           >


### PR DESCRIPTION
This PR fixes the `X` icon style on the Search input.

Before this PR, the Search showed the native X icon on Chrome/Safari, and nothing on Firefox. Now, the behavior is the same on all browsers.

To achieve this, I first hid with CSS native `X` icon using `[&::-webkit-search-cancel-button]:appearance-none`. It's a non-standard feature but is [supported](https://developer.mozilla.org/en-US/docs/Web/CSS/::-webkit-search-cancel-button#browser_compatibility) by Chrome-based browsers and Safari, where it's needed.

Second, I added a custom `X` icon with the same features:
1. Only appears when the search input is filled
2. Clears the search input when clicked

It's keyboard accessible and comes with an aria-label.

![CleanShot 2024-07-18 at 15 31 35](https://github.com/user-attachments/assets/8a9d3d3e-6b58-484d-bf82-da4c27331902)


[Notion](https://www.notion.so/filecoin/FF-V4-BUG-Fix-clear-icon-colour-in-Search-bar-567190e23ac24139853ecc6e6668ab64?pvs=4)