### PR TITLE
Fix Search with apostrophe

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -34,6 +34,7 @@
         "sass": "^1.69.5",
         "schema-dts": "^1.1.2",
         "sharp": "^0.33.4",
+        "slugify": "^1.6.6",
         "swr": "^2.2.5",
         "tailwindcss": "^3.4.0",
         "usehooks-ts": "^3.1.0",
@@ -17572,6 +17573,14 @@
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
       "dev": true
+    },
+    "node_modules/slugify": {
+      "version": "1.6.6",
+      "resolved": "https://registry.npmjs.org/slugify/-/slugify-1.6.6.tgz",
+      "integrity": "sha512-h+z7HKHYXj6wJU+AnS/+IH8Uh9fdcX1Lrhg1/VMdf9PwoBQXFcXiAdsy2tSK0P6gKwJLXp02r90ahUCqHk9rrw==",
+      "engines": {
+        "node": ">=8.0.0"
+      }
     },
     "node_modules/snake-case": {
       "version": "3.0.4",

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "sass": "^1.69.5",
     "schema-dts": "^1.1.2",
     "sharp": "^0.33.4",
+    "slugify": "^1.6.6",
     "swr": "^2.2.5",
     "tailwindcss": "^3.4.0",
     "usehooks-ts": "^3.1.0",


### PR DESCRIPTION
This PR improves the search experience by stripping away special characters and most diacritical marks - a fancy word chatGPT taught me - which refers to any mark attached to a letter, such as:
- accents (_résumé_)
- tilde (_jalapeño_)
- diaeresis (_naïve_)
- ... you get the point

To do so, it "slugifies" both the source value and the query to ensure they are in the same format before looking for matches.

It solves the original problem: searching with an apostrophe variant in the query would return nothing. Now both `democracy's` and `democracy’s` return the same results.

![CleanShot 2024-07-19 at 12 05 06](https://github.com/user-attachments/assets/818a447b-3110-4bfd-840d-9a4c4aa2bd3d)

![CleanShot 2024-07-19 at 12 10 34](https://github.com/user-attachments/assets/eea912e4-a18d-48d7-9a6c-335164f52d0a)

[Notion](https://www.notion.so/filecoin/FF-BUG-Fix-search-with-apostrophe-65d912df28cb4310bd85e3b5f42e7464?pvs=4)