### PR TITLE
Fix redirects with different casing

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -28,6 +28,7 @@ const nextConfig = {
   },
   async redirects() {
     return [
+      // BLOG POST REDIRECTS
       {
         source:
           '/blog/ecosystem-spotlight-ghostdrive%E2%80%99s-secure-decentralized-storage-now-on-mobile',
@@ -84,6 +85,32 @@ const nextConfig = {
         permanent: true,
       },
       {
+        source: '/ecosystem/project/bela-supernova',
+        destination:
+          '/blog/bela-supernova-awarded-chainlink-filecoin-joint-grant-to-support-public-health-data-oracle',
+        permanent: true,
+      },
+      {
+        source: '/filplus/%20%22Filecoin%20Plus%22',
+        destination:
+          '/blog/participating-in-the-filecoin-ecosystem-bounties-microgrants-and-fips',
+        permanent: true,
+      },
+      {
+        source: '/filplus',
+        destination:
+          '/blog/the-growth-of-filecoin-plus-and-upcoming-notary-elections',
+        permanent: true,
+      },
+      {
+        source: '/fips',
+        destination:
+          '/blog/participating-in-the-filecoin-ecosystem-bounties-microgrants-and-fips',
+        permanent: true,
+      },
+
+      // PAGE REDIRECTS
+      {
         source: '/board',
         destination: '/about',
         permanent: true,
@@ -101,65 +128,6 @@ const nextConfig = {
       {
         source: '/contact',
         destination: '/about',
-        permanent: true,
-      },
-      {
-        source: '/davos',
-        destination: '/events/the-filecoin-sanctuary-davos-2024',
-        permanent: true,
-      },
-      {
-        source: '/davos-registration',
-        destination: '/events/the-filecoin-sanctuary-davos-2024',
-        permanent: true,
-      },
-      {
-        source: '/ecosystem',
-        destination: '/ecosystem-explorer/',
-        permanent: true,
-      },
-      {
-        source: '/ecosystem-projects/:path*',
-        destination: '/ecosystem-explorer/:path*',
-        permanent: true,
-      },
-      {
-        source: '/ecosystem/project/bela-supernova',
-        destination:
-          '/blog/bela-supernova-awarded-chainlink-filecoin-joint-grant-to-support-public-health-data-oracle',
-        permanent: true,
-      },
-      {
-        source: '/ecosystem-explorer/solmedia/%E2%80%A6',
-        destination: '/ecosystem-explorer/solmedia',
-        permanent: true,
-      },
-      {
-        source: '/ecosystem/%5C%22',
-        destination: '/ecosystem-explorer',
-        permanent: true,
-      },
-      {
-        source: '/filplus/%20%22Filecoin%20Plus%22',
-        destination:
-          '/blog/participating-in-the-filecoin-ecosystem-bounties-microgrants-and-fips',
-        permanent: true,
-      },
-      {
-        source: '/filaustin',
-        destination: '/events/fil-austin',
-        permanent: true,
-      },
-      {
-        source: '/filplus',
-        destination:
-          '/blog/the-growth-of-filecoin-plus-and-upcoming-notary-elections',
-        permanent: true,
-      },
-      {
-        source: '/fips',
-        destination:
-          '/blog/participating-in-the-filecoin-ecosystem-bounties-microgrants-and-fips',
         permanent: true,
       },
       {
@@ -203,11 +171,6 @@ const nextConfig = {
         permanent: true,
       },
       {
-        source: '/security/bug-bounty',
-        destination: 'https://immunefi.com/bug-bounty/filecoin/',
-        permanent: false,
-      },
-      {
         source: '/terms',
         destination: '/terms-of-use',
         permanent: true,
@@ -221,6 +184,52 @@ const nextConfig = {
         source: '/research/research-text.htm',
         destination: '/',
         permanent: true,
+      },
+
+      // EVENT REDIRECTS
+      {
+        source: '/davos',
+        destination: '/events/the-filecoin-sanctuary-davos-2024',
+        permanent: true,
+      },
+      {
+        source: '/davos-registration',
+        destination: '/events/the-filecoin-sanctuary-davos-2024',
+        permanent: true,
+      },
+      {
+        source: '/filaustin',
+        destination: '/events/fil-austin',
+        permanent: true,
+      },
+
+      // ECOSYSTEM REDIRECTS
+      {
+        source: '/ecosystem',
+        destination: '/ecosystem-explorer/',
+        permanent: true,
+      },
+      {
+        source: '/ecosystem-projects/:path*',
+        destination: '/ecosystem-explorer/:path*',
+        permanent: true,
+      },
+      {
+        source: '/ecosystem-explorer/solmedia/%E2%80%A6',
+        destination: '/ecosystem-explorer/solmedia',
+        permanent: true,
+      },
+      {
+        source: '/ecosystem/%5C%22',
+        destination: '/ecosystem-explorer',
+        permanent: true,
+      },
+
+      // EXTERNAL REDIRECTS
+      {
+        source: '/security/bug-bounty',
+        destination: 'https://immunefi.com/bug-bounty/filecoin/',
+        permanent: false,
       },
     ]
   },

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -10,5 +10,5 @@ export default function middleware(request: NextRequest) {
 }
 
 export const config = {
-  matcher: '/blog/([A-Z][a-zA-Z0-9-]*$)',
+  matcher: '/blog/([A-Za-z0-9-]*[A-Z][A-Za-z0-9-]*)',
 }

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,14 +1,16 @@
 import { NextResponse, type NextRequest } from 'next/server'
 
-export default function middleware(request: NextRequest) {
+export default function redirectMiddleware(request: NextRequest) {
   const pathname = request.nextUrl.pathname
 
-  const capitalizedSlug = pathname.replace('/blog/', '')
-  const lowerCaseSlug = capitalizedSlug.toLowerCase()
+  const pathnameWithoutLeadingSlash = pathname.slice(1)
+  const [basePath, capitalizedSlug] = pathnameWithoutLeadingSlash.split('/')
 
-  return NextResponse.redirect(new URL('/blog/' + lowerCaseSlug, request.url))
+  return NextResponse.redirect(
+    new URL(`/${basePath}/` + capitalizedSlug.toLowerCase(), request.url),
+  )
 }
 
 export const config = {
-  matcher: '/blog/([A-Za-z0-9-]*[A-Z][A-Za-z0-9-]*)',
+  matcher: `/(blog|events|ecosystem-explorer)/([A-Za-z0-9-]*[A-Z][A-Za-z0-9-]*)`,
 }

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,0 +1,14 @@
+import { NextResponse, type NextRequest } from 'next/server'
+
+export default function middleware(request: NextRequest) {
+  const pathname = request.nextUrl.pathname
+
+  const capitalizedSlug = pathname.replace('/blog/', '')
+  const lowerCaseSlug = capitalizedSlug.toLowerCase()
+
+  return NextResponse.redirect(new URL('/blog/' + lowerCaseSlug, request.url))
+}
+
+export const config = {
+  matcher: '/blog/([A-Z][a-zA-Z0-9-]*$)',
+}

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,6 +1,14 @@
 import { NextResponse, type NextRequest } from 'next/server'
 
-export default function redirectMiddleware(request: NextRequest) {
+// This middleware rewrites potentially slugs (from the old site) to their lowercase equivalents.
+// For example, the old site had content entries with URLs like /blog/Filecoin-nv19-Lightning-Upgrade
+// On the new site, these URLs are now /blog/filecoin-nv19-lightning-upgrade
+// We cannot use Next.js redirects because they are case insensitive, leading to an infinite loop of redirects.
+// Instead, we use this middleware to handle all content entry links created before the launch of the new site that still may exist capitalized.
+
+export default function redirectCapitalizedSlugMiddleware(
+  request: NextRequest,
+) {
   const pathname = request.nextUrl.pathname
 
   const pathnameWithoutLeadingSlash = pathname.slice(1)


### PR DESCRIPTION
This PR adds a redirect from `/blog/Filecoin-nv19-Lightning-Upgrade` to `/blog/filecoin-nv19-lightning-upgrade` and ensures that any blog URL with capital letters is redirected to its lowercase equivalent.

### Problem
The standard redirect solution - `{ source: 'About', destination: '/about' }` in `next.config.js` - did not work because redirects are not case-sensitive. It created an infinite loop of redirects and eventually crashed the website.

### Solution
To solve this problem, I implemented Next's [middleware](https://nextjs.org/docs/app/building-your-application/routing/middleware) function, which runs after redirects but before the filesystem routes.

The middleware function lives at the root of the project, `src/middleware.ts`, and runs by default on each request. To limit the middleware to only blog URLs containing capital letters, I added a [matcher](https://nextjs.org/docs/app/building-your-application/routing/middleware#matcher).

```ts
export const config = {
  matcher: '/blog/([A-Za-z0-9-]*[A-Z][A-Za-z0-9-]*)',
}
```

Now `/blog/Filecoin-nv19-Lightning-Upgrade` redirects to `blog/filecoin-nv19-lightning-upgrade`.

Additionally, I cleaned the redirects in `next.config.js` by grouping them with this [commit](https://github.com/FilecoinFoundationWeb/filecoin-foundation/pull/370/commits/1e6abed91d9f02d749683396156a72e3e886ef9d). It's not essential to this PR and can be discarded if necessary.

---

[Notion](https://www.notion.so/filecoin/FF-BUG-Fix-redirects-for-same-URLs-with-different-casing-be287fccf1b04d69a0950a5a716cb315?pvs=4)