### PR TITLE
Sentry issue: multiple, different versions of MobX active

### DIFF
--- a/src/app/_components/SiteLayout.tsx
+++ b/src/app/_components/SiteLayout.tsx
@@ -12,11 +12,14 @@ const archivo = Archivo({
   display: 'swap',
 })
 
-export function SiteLayout({ children }: LayoutProps) {
+export function SiteLayout({
+  children,
+  includeNetlifyManager = true,
+}: LayoutProps) {
   return (
     <html lang="en" className={archivo.className}>
       <body className="m-auto flex max-w-[1032px] flex-col justify-between bg-brand-800 px-6 pb-6 pt-8 tracking-wide text-brand-100">
-        <NetlifyIdentityManager />
+        {includeNetlifyManager && <NetlifyIdentityManager />}
 
         <Navigation />
 

--- a/src/app/global-error.tsx
+++ b/src/app/global-error.tsx
@@ -16,7 +16,7 @@ export default function GlobalError({ error }: { error: Error }) {
   }, [error])
 
   return (
-    <SiteLayout>
+    <SiteLayout includeNetlifyManager={false}>
       <ErrorMessage
         kicker="500"
         title="Internal Server Error"

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -17,6 +17,7 @@ export const metadata: Metadata = {
 
 export type LayoutProps = {
   children: React.ReactNode
+  includeNetlifyManager?: boolean
 }
 
 export default function RootLayout({ children }: LayoutProps) {


### PR DESCRIPTION
## Note
- [Sentry issue](https://filecoin-foundation-qk.sentry.io/issues/5465697738/?environment=production&project=4507390577999872&query=is%3Aunresolved+issue.priority%3A%5Bhigh%2C+medium%5D&referrer=issue-stream&statsPeriod=14d&stream_index=4)
- My guess is that this error is caused by using `SiteLayout` in the `global-error` which includes `NetlifyManager`, hence `There are multiple, different versions of MobX active.`
- [Issue on decap-cms](https://github.com/decaporg/decap-cms/issues/1594)