### PR TITLE
Frontmatter Validation - Remove temporary location check - UXIT-1136

### DIFF
--- a/src/app/_utils/validateFrontMatter.ts
+++ b/src/app/_utils/validateFrontMatter.ts
@@ -29,7 +29,7 @@ export function validateFrontMatter(
   fields: CMSFieldConfig[],
 ): boolean {
   const extraFieldsToSkipCheck: string[] = []
-  const temporaryMissingFieldsToSkipCheck: string[] = ['location']
+  const temporaryMissingFieldsToSkipCheck: string[] = []
   const dynamicMissingFieldsToSkipCheck: string[] = fields
     .filter((field) => field.required === false)
     .map((field) => field.name)


### PR DESCRIPTION
Now that the Events team has updated all Event entries to include the `location` field, we can remove this skip check.