### PR TITLE
Add and fix redirects - UXIT-1153

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -28,87 +28,6 @@ const nextConfig = {
   },
   async redirects() {
     return [
-      // BLOG POST REDIRECTS
-      {
-        source:
-          '/blog/ecosystem-spotlight-ghostdrive%E2%80%99s-secure-decentralized-storage-now-on-mobile',
-        destination:
-          '/blog/ecosystem-spotlight-ghostdrives-secure-decentralized-storage-now-on-mobile',
-        permanent: true,
-      },
-      {
-        source:
-          '/blog/guest-post-if-the-library-of-alexandra-were-built-better/',
-        destination:
-          '/blog/guest-post-if-the-library-of-alexandria-were-built-better',
-        permanent: true,
-      },
-      {
-        source:
-          '/blog/democracy%E2%80%99s-library-announces-more-than-a-petabyte-of-government-data-uploaded-to-the-filecoin-network',
-        destination:
-          '/blog/democracys-library-announces-more-than-a-petabyte-of-government-data-uploaded-to-the-filecoin-network',
-        permanent: true,
-      },
-      {
-        source: '/blog/democracy',
-        destination:
-          '/blog/democracys-library-announces-more-than-a-petabyte-of-government-data-uploaded-to-the-filecoin-network',
-        permanent: true,
-      },
-      {
-        source:
-          '/blog/pilecoin-foundation-successfully-deploys-interflanetary-pile-system-IFPS-in-space',
-        destination:
-          '/blog/filecoin-foundation-successfully-deploys-interplanetary-file-system-ipfs-in-space',
-        permanent: true,
-      },
-      {
-        source:
-          '/blog/announcing-%E2%80%98watermelon%E2%80%99-nv21-upgrade-extended-sector-commitments-synthetic-porep-fvm-enhancements-and-more',
-        destination:
-          '/blog/announcing-watermelon-nv21-upgrade-extended-sector-commitments-synthetic-porep-fvm-enhancements-and-more',
-        permanent: true,
-      },
-      {
-        source:
-          '/blog/democracy%E2%80%99s-library-announces-more-than-a-petabyte-of-government-data-uploaded-to-the-filecoin-network',
-        destination:
-          '/blog/democracys-library-announces-more-than-a-petabyte-of-government-data-uploaded-to-the-filecoin-network',
-        permanent: true,
-      },
-      {
-        source:
-          '/blog/what%E2%80%99s-new-with-the-filecoin-plus-notary-election-and-filecoin-day-highlights-from-labweek23',
-        destination:
-          '/blog/whats-new-with-the-filecoin-plus-notary-election-and-filecoin-day-highlights-from-labweek23',
-        permanent: true,
-      },
-      {
-        source: '/ecosystem/project/bela-supernova',
-        destination:
-          '/blog/bela-supernova-awarded-chainlink-filecoin-joint-grant-to-support-public-health-data-oracle',
-        permanent: true,
-      },
-      {
-        source: '/filplus/%20%22Filecoin%20Plus%22',
-        destination:
-          '/blog/participating-in-the-filecoin-ecosystem-bounties-microgrants-and-fips',
-        permanent: true,
-      },
-      {
-        source: '/filplus',
-        destination:
-          '/blog/the-growth-of-filecoin-plus-and-upcoming-notary-elections',
-        permanent: true,
-      },
-      {
-        source: '/fips',
-        destination:
-          '/blog/participating-in-the-filecoin-ecosystem-bounties-microgrants-and-fips',
-        permanent: true,
-      },
-
       // PAGE REDIRECTS
       {
         source: '/board',
@@ -131,8 +50,49 @@ const nextConfig = {
         permanent: true,
       },
       {
-        source: '/governance/proposing',
-        destination: '/governance',
+        source: '/davos',
+        destination: '/events/the-filecoin-sanctuary-davos-2024',
+        permanent: true,
+      },
+      {
+        source: '/davos-registration',
+        destination: '/events/the-filecoin-sanctuary-davos-2024',
+        permanent: true,
+      },
+      {
+        source: '/ecosystem',
+        destination: '/ecosystem-explorer/',
+        permanent: true,
+      },
+      {
+        source: '/ecosystem/%5C%22',
+        destination: '/ecosystem-explorer',
+        permanent: true,
+      },
+      {
+        source: '/ecosystem-projects/:path*',
+        destination: '/ecosystem-explorer/:path*',
+        permanent: true,
+      },
+      {
+        source: '/filaustin',
+        destination: '/events/fil-austin',
+        permanent: true,
+      },
+      {
+        source: '/filplus/%20%22Filecoin%20Plus%22',
+        destination: '/filecoin-plus',
+        permanent: true,
+      },
+      {
+        source: '/filplus',
+        destination: '/filecoin-plus',
+        permanent: true,
+      },
+      {
+        source: '/fips',
+        destination:
+          '/blog/participating-in-the-filecoin-ecosystem-bounties-microgrants-and-fips',
         permanent: true,
       },
       {
@@ -143,6 +103,16 @@ const nextConfig = {
       {
         source: '/governance/fips/:path*',
         destination: '/governance',
+        permanent: true,
+      },
+      {
+        source: '/governance/proposing',
+        destination: '/governance',
+        permanent: true,
+      },
+      {
+        source: '/philosophy',
+        destination: '/about',
         permanent: true,
       },
       {
@@ -166,7 +136,17 @@ const nextConfig = {
         permanent: true,
       },
       {
-        source: '/philosophy',
+        source: '/research/research-text.htm',
+        destination: '/',
+        permanent: true,
+      },
+      {
+        source: '/security/bug-bounty',
+        destination: 'https://immunefi.com/bug-bounty/filecoin/',
+        permanent: false,
+      },
+      {
+        source: '/team',
         destination: '/about',
         permanent: true,
       },
@@ -175,53 +155,61 @@ const nextConfig = {
         destination: '/terms-of-use',
         permanent: true,
       },
+
+      // BLOG POST REDIRECTS
       {
-        source: '/team',
-        destination: '/about',
+        source:
+          '/blog/announcing-%E2%80%98watermelon%E2%80%99-nv21-upgrade-extended-sector-commitments-synthetic-porep-fvm-enhancements-and-more',
+        destination:
+          '/blog/announcing-watermelon-nv21-upgrade-extended-sector-commitments-synthetic-porep-fvm-enhancements-and-more',
         permanent: true,
       },
       {
-        source: '/research/research-text.htm',
-        destination: '/',
+        source:
+          '/blog/deep-dive-on-messari%E2%80%99s-q1-filecoin-ecosystem-report',
+        destination: '/blog/deep-dive-on-messaris-q1-filecoin-ecosystem-report',
+        permanent: true,
+      },
+      {
+        source:
+          '/blog/democracy%E2%80%99s-library-announces-more-than-a-petabyte-of-government-data-uploaded-to-the-filecoin-network',
+        destination:
+          '/blog/democracys-library-announces-more-than-a-petabyte-of-government-data-uploaded-to-the-filecoin-network',
+        permanent: true,
+      },
+      {
+        source:
+          '/blog/ecosystem-spotlight-ghostdrive%E2%80%99s-secure-decentralized-storage-now-on-mobile',
+        destination:
+          '/blog/ecosystem-spotlight-ghostdrives-secure-decentralized-storage-now-on-mobile',
+        permanent: true,
+      },
+      {
+        source:
+          '/blog/guest-post-if-the-library-of-alexandra-were-built-better',
+        destination:
+          '/blog/guest-post-if-the-library-of-alexandria-were-built-better',
+        permanent: true,
+      },
+      {
+        source:
+          '/blog/pilecoin-foundation-successfully-deploys-interflanetary-pile-system-IFPS-in-space',
+        destination:
+          '/blog/filecoin-foundation-successfully-deploys-interplanetary-file-system-ipfs-in-space',
+        permanent: true,
+      },
+      {
+        source:
+          '/blog/what%E2%80%99s-new-with-the-filecoin-plus-notary-election-and-filecoin-day-highlights-from-labweek23',
+        destination:
+          '/blog/whats-new-with-the-filecoin-plus-notary-election-and-filecoin-day-highlights-from-labweek23',
         permanent: true,
       },
 
-      // EVENT REDIRECTS
-      {
-        source: '/davos',
-        destination: '/events/the-filecoin-sanctuary-davos-2024',
-        permanent: true,
-      },
-      {
-        source: '/davos-registration',
-        destination: '/events/the-filecoin-sanctuary-davos-2024',
-        permanent: true,
-      },
-      {
-        source: '/filaustin',
-        destination: '/events/fil-austin',
-        permanent: true,
-      },
-
-      // ECOSYSTEM REDIRECTS
-      {
-        source: '/ecosystem',
-        destination: '/ecosystem-explorer/',
-        permanent: true,
-      },
-      {
-        source: '/ecosystem-projects/:path*',
-        destination: '/ecosystem-explorer/:path*',
-        permanent: true,
-      },
+      // ECOSYSTEM PROJECTS REDIRECTS
       {
         source: '/ecosystem-explorer/solmedia/%E2%80%A6',
         destination: '/ecosystem-explorer/solmedia',
-        permanent: true,
-      },
-      {
-        source: '/ecosystem/%5C%22',
-        destination: '/ecosystem-explorer',
         permanent: true,
       },
       {
@@ -229,12 +217,11 @@ const nextConfig = {
         destination: '/ecosystem-explorer/bidlo',
         permanent: true,
       },
-
-      // EXTERNAL REDIRECTS
       {
-        source: '/security/bug-bounty',
-        destination: 'https://immunefi.com/bug-bounty/filecoin/',
-        permanent: false,
+        source: '/ecosystem/project/bela-supernova',
+        destination:
+          '/blog/bela-supernova-awarded-chainlink-filecoin-joint-grant-to-support-public-health-data-oracle',
+        permanent: true,
       },
     ]
   },


### PR DESCRIPTION
This PR:

- Includes a missing redirect from `/blog/deep-dive-on-messari%E2%80%99s-q1-filecoin-ecosystem-report` `/blog/deep-dive-on-messaris-q1-filecoin-ecosystem-report`
- Removes a duplicate redirect `/blog/democracy%E2%80%99s-library-announces-more-than-a-petabyte-of-government-data-uploaded-to-the-filecoin-network/`
- Redirects `filplus` sources to `/filecoin-plus`
- Re-orders the redirects under the group comments based on the `source` instead of the `destination` since that's the logical entry point
- Alphabetises the redirects 