### PR TITLE
Include BASE_ORGANIZATION_SCHEMA to pages - UXIT-1310

### DIFF
--- a/src/app/about/utils/generateStructuredData.ts
+++ b/src/app/about/utils/generateStructuredData.ts
@@ -5,11 +5,17 @@ import { SeoMetadata } from '@/types/metadataTypes'
 import { generateWebPageStructuredData } from '@/utils/generateWebPageStructuredData'
 
 import { PATHS } from '@/constants/paths'
+import { BASE_ORGANIZATION_SCHEMA } from '@/constants/structuredDataConstants'
 
 export function generateStructuredData(seo: SeoMetadata): WithContext<WebPage> {
-  return generateWebPageStructuredData({
+  const baseData = generateWebPageStructuredData({
     title: seo.title,
     description: seo.description,
     path: PATHS.ABOUT.path,
   })
+
+  return {
+    ...baseData,
+    about: BASE_ORGANIZATION_SCHEMA,
+  }
 }

--- a/src/app/governance/utils/generateStructuredData.ts
+++ b/src/app/governance/utils/generateStructuredData.ts
@@ -5,11 +5,17 @@ import { SeoMetadata } from '@/types/metadataTypes'
 import { generateWebPageStructuredData } from '@/utils/generateWebPageStructuredData'
 
 import { PATHS } from '@/constants/paths'
+import { BASE_ORGANIZATION_SCHEMA } from '@/constants/structuredDataConstants'
 
 export function generateStructuredData(seo: SeoMetadata): WithContext<WebPage> {
-  return generateWebPageStructuredData({
+  const baseData = generateWebPageStructuredData({
     title: seo.title,
     description: seo.description,
     path: PATHS.GOVERNANCE.path,
   })
+
+  return {
+    ...baseData,
+    about: BASE_ORGANIZATION_SCHEMA,
+  }
 }

--- a/src/app/grants/utils/generateStructuredData.ts
+++ b/src/app/grants/utils/generateStructuredData.ts
@@ -5,11 +5,17 @@ import { SeoMetadata } from '@/types/metadataTypes'
 import { generateWebPageStructuredData } from '@/utils/generateWebPageStructuredData'
 
 import { PATHS } from '@/constants/paths'
+import { BASE_ORGANIZATION_SCHEMA } from '@/constants/structuredDataConstants'
 
 export function generateStructuredData(seo: SeoMetadata): WithContext<WebPage> {
-  return generateWebPageStructuredData({
+  const baseData = generateWebPageStructuredData({
     title: seo.title,
     description: seo.description,
     path: PATHS.GRANTS.path,
   })
+
+  return {
+    ...baseData,
+    about: BASE_ORGANIZATION_SCHEMA,
+  }
 }


### PR DESCRIPTION
## Note
- added `BASE_ORGANIZATION_SCHEMA` to `about`, `governance` and `grants` page
- putting in draft [until David confirms the format](https://filecoinfoundation.slack.com/archives/C03S74YDWMC/p1721995074993589?thread_ts=1721816547.798289&cid=C03S74YDWMC)