### PR TITLE
[UXIT-1366] Exclude .next/** from Output File Tracing in Deployment Config

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -22,6 +22,7 @@ const nextConfig = {
         '.vscode/**',
         'cypress/**',
         '.netlify/**',
+        '.next/**',
         'public/**',
         'scripts/**',
         'src/app/**',


### PR DESCRIPTION
This pull request updates the deployment configuration to exclude the .next directory from output file tracing by adding `.next/**` to the outputFileTracingExcludes list. This change is essential for optimizing the deployment process, especially in serverless environments, by reducing the size of deployment packages and excluding unnecessary build artifacts.

