### PR TITLE
 Remove .next/** from Output File Tracing in Deployment Config

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -21,8 +21,6 @@ const nextConfig = {
         '.next/cache/**',
         '.vscode/**',
         'cypress/**',
-        '.netlify/**',
-        '.next/**',
         'public/**',
         'scripts/**',
         'src/app/**',


### PR DESCRIPTION
This pull request reverts the previous change that excluded the `.next/**` directory from output file tracing in the deployment configuration.

In a previous update, `.next/**` was excluded from the `outputFileTracingExcludes` list to optimize the deployment process by reducing the size of deployment packages and excluding unnecessary build artifacts.

After implementing the exclusion, Next.js was unable to find all the necessary files for building and serving dynamic pages, resulting in application errors. This is crucial because, without these files, the application fails to build and serve dynamic content correctly.
