### PR TITLE
[UXIT-1380] Redirect /admin to /admin/index.html

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -108,6 +108,11 @@ const nextConfig = {
       },
       { source: '/team', destination: '/about', permanent: true },
       { source: '/terms', destination: '/terms-of-use', permanent: true },
+      {
+        source: '/admin',
+        destination: '/admin/index.html',
+        permanent: true,
+      },
 
       // BLOG POST REDIRECTS
       {


### PR DESCRIPTION
Redirect `/admin` to `/admin/index.html` so that the content team can keep using the CMS as usual.