### PR TITLE
[UXIT-1319] CMS - Fix Featured Entries

### DIFF
--- a/cypress/e2e/weekly_schedule/all_blog_posts_spec.cy.ts
+++ b/cypress/e2e/weekly_schedule/all_blog_posts_spec.cy.ts
@@ -3,7 +3,7 @@ import { getCategorySettings } from '@/utils/categoryUtils'
 import { PATHS } from '@/constants/paths'
 import { createCategoryTests } from '@/support/categoryUtils'
 
-const { validCategoryOptions } = getCategorySettings('blog')
+const { validCategoryOptions } = getCategorySettings('blog_posts')
 
 createCategoryTests({
   pathConfig: PATHS.BLOG,

--- a/cypress/e2e/weekly_schedule/all_events_entries_spec.cy.ts
+++ b/cypress/e2e/weekly_schedule/all_events_entries_spec.cy.ts
@@ -3,7 +3,7 @@ import { getCategorySettings } from '@/utils/categoryUtils'
 import { PATHS } from '@/constants/paths'
 import { createCategoryTests } from '@/support/categoryUtils'
 
-const { validCategoryOptions } = getCategorySettings('events')
+const { validCategoryOptions } = getCategorySettings('event_entries')
 
 createCategoryTests({
   pathConfig: PATHS.EVENTS,

--- a/public/admin/config.yml
+++ b/public/admin/config.yml
@@ -369,17 +369,9 @@ collections:
       - name: title
         label: Company Name
         widget: string
-      - name: created-on
-        label: Created On
-        widget: datetime
-      - name: updated-on
-        label: Updated On
-        widget: datetime
-        required: false
-      - name: published-on
-        label: Published On
-        widget: datetime
-        required: false
+      - *created_on
+      - *updated_on
+      - *published_on
       - *image_config
       - name: category
         label: Category

--- a/public/admin/config.yml
+++ b/public/admin/config.yml
@@ -140,8 +140,8 @@ collections:
           - name: "featured_entry"
             label: "Featured Post"
             widget: "relation"
-            collection: "blog"
-            value_field: "slug"
+            collection: "blog_posts"
+            value_field: "src/content/blog/{{slug}}.md"
             search_fields:
               - "slug"
               - "title"
@@ -174,7 +174,7 @@ collections:
           - name: "featured_entry"
             label: "Featured Event"
             widget: "relation"
-            collection: "events"
+            collection: "event-entries"
             value_field: "slug"
             search_fields:
               - "slug"
@@ -256,7 +256,7 @@ collections:
           - *header_config
           - *meta_config
 
-  - name: "blog"
+  - name: "blog_posts"
     label: "Blog Posts"
     label_singular: "Blog Post"
     folder: "src/content/blog/"
@@ -304,7 +304,7 @@ collections:
         label: "Recommended Posts"
         widget: "hidden"
         required: false
-        collection: "blog"
+        collection: "blog_posts"
         value_field: "src/content/blog/{{slug}}.md"
         search_fields:
           - "slug"
@@ -537,7 +537,7 @@ collections:
         required: false
       - *meta_config
 
-  - name: "events"
+  - name: "event-entries"
     label: "Events"
     folder: "src/content/events/"
     preview_path: "events/{{slug}}"

--- a/public/admin/config.yml
+++ b/public/admin/config.yml
@@ -174,7 +174,7 @@ collections:
           - name: "featured_entry"
             label: "Featured Event"
             widget: "relation"
-            collection: "event-entries"
+            collection: "event_entries"
             value_field: "slug"
             search_fields:
               - "slug"
@@ -537,7 +537,7 @@ collections:
         required: false
       - *meta_config
 
-  - name: "event-entries"
+  - name: "event_entries"
     label: "Events"
     folder: "src/content/events/"
     preview_path: "events/{{slug}}"

--- a/public/admin/config.yml
+++ b/public/admin/config.yml
@@ -175,7 +175,7 @@ collections:
             label: "Featured Event"
             widget: "relation"
             collection: "event_entries"
-            value_field: "slug"
+            value_field: "src/content/events/{{slug}}.md"
             search_fields:
               - "slug"
               - "title"
@@ -209,7 +209,7 @@ collections:
             label: "Featured Grant Graduates"
             widget: "relation"
             collection: "ecosystem_projects"
-            value_field: "slug"
+            value_field: "src/content/ecosystem-explorer/projects/{{slug}}.md"
             search_fields:
               - "slug"
               - "title"
@@ -229,7 +229,7 @@ collections:
             label: "Featured Ecosystem Projects"
             widget: "relation"
             collection: "ecosystem_projects"
-            value_field: "slug"
+            value_field: "src/content/ecosystem-explorer/projects/{{slug}}.md"
             search_fields:
               - "slug"
               - "title"

--- a/src/app/_components/BlogPostHeader.tsx
+++ b/src/app/_components/BlogPostHeader.tsx
@@ -25,7 +25,7 @@ export function BlogPostHeader({
     <header className="space-y-6">
       <div className="space-y-4">
         <TagLabel>
-          {getCategoryLabel({ collectionName: 'blog', category })}
+          {getCategoryLabel({ collectionName: 'blog_posts', category })}
         </TagLabel>
         <Heading tag="h1" variant="4xl">
           {title}

--- a/src/app/_components/FeaturedGrantGraduates.tsx
+++ b/src/app/_components/FeaturedGrantGraduates.tsx
@@ -17,7 +17,6 @@ type FeaturedGrantsGraduatesProps = {
 export function FeaturedGrantsGraduates({
   grantGraduates,
 }: FeaturedGrantsGraduatesProps) {
-  console.log('grantGraduates', grantGraduates)
   if (grantGraduates.length === 0) {
     return <p>No featured grants graduates available.</p>
   }

--- a/src/app/_components/FeaturedGrantGraduates.tsx
+++ b/src/app/_components/FeaturedGrantGraduates.tsx
@@ -17,6 +17,7 @@ type FeaturedGrantsGraduatesProps = {
 export function FeaturedGrantsGraduates({
   grantGraduates,
 }: FeaturedGrantsGraduatesProps) {
+  console.log('grantGraduates', grantGraduates)
   if (grantGraduates.length === 0) {
     return <p>No featured grants graduates available.</p>
   }

--- a/src/app/_types/cmsConfig.ts
+++ b/src/app/_types/cmsConfig.ts
@@ -1,4 +1,4 @@
-export type CMSCollectionName = 'blog_posts' | 'ecosystem' | 'events'
+export type CMSCollectionName = 'blog_posts' | 'ecosystem' | 'event_entries'
 
 export type CMSFieldOption = {
   label: string

--- a/src/app/_types/cmsConfig.ts
+++ b/src/app/_types/cmsConfig.ts
@@ -1,4 +1,4 @@
-export type CMSCollectionName = 'blog' | 'ecosystem' | 'events'
+export type CMSCollectionName = 'blog_posts' | 'ecosystem' | 'events'
 
 export type CMSFieldOption = {
   label: string

--- a/src/app/_utils/categoryUtils.ts
+++ b/src/app/_utils/categoryUtils.ts
@@ -52,7 +52,7 @@ export function getCategorySettings(collectionName: CMSCollectionName) {
 }
 
 export function getEventsCategorySettings() {
-  const eventSettings = getCategorySettings('events')
+  const eventSettings = getCategorySettings('event_entries')
   const { categorySettings, validCategoryOptions } = eventSettings
 
   return {

--- a/src/app/_utils/getBlogPostData.ts
+++ b/src/app/_utils/getBlogPostData.ts
@@ -6,7 +6,7 @@ import { transformMarkdownToItemData } from '@/utils/transformMarkdownToItemData
 
 import { PATHS } from '@/constants/paths'
 
-const BLOG_COLLECTION_NAME = 'blog'
+const BLOG_COLLECTION_NAME = 'blog_posts'
 const BLOG_DIRECTORY_PATH = PATHS.BLOG.entriesContentPath as string
 
 export function getBlogPostData(slug: string): BlogPostData {

--- a/src/app/_utils/getEventData.ts
+++ b/src/app/_utils/getEventData.ts
@@ -6,7 +6,7 @@ import { transformMarkdownToItemData } from '@/utils/transformMarkdownToItemData
 
 import { PATHS } from '@/constants/paths'
 
-const EVENTS_COLLECTION_NAME = 'events'
+const EVENTS_COLLECTION_NAME = 'event_entries'
 const EVENTS_DIRECTORY_PATH = PATHS.EVENTS.entriesContentPath as string
 
 export function getEventData(slug: string): EventData {

--- a/src/app/blog/page.tsx
+++ b/src/app/blog/page.tsx
@@ -1,3 +1,5 @@
+import path from 'path'
+
 import dynamic from 'next/dynamic'
 
 import { BookOpen } from '@phosphor-icons/react/dist/ssr'
@@ -46,9 +48,18 @@ type Props = {
 }
 
 const posts = getBlogPostsData()
-const { categorySettings, validCategoryOptions } = getCategorySettings('blog')
-const { featured_entry: featuredPostSlug, seo } = attributes
-const featuredPost = getBlogPostData(featuredPostSlug || '')
+
+const { categorySettings, validCategoryOptions } =
+  getCategorySettings('blog_posts')
+
+const { featured_entry, seo } = attributes
+
+if (!featured_entry) {
+  throw new Error('Featured entry is undefined')
+}
+
+const featuredPostSlug = path.parse(featured_entry).name
+const featuredPost = getBlogPostData(featuredPostSlug)
 
 export const metadata = createMetadata({
   seo,
@@ -181,7 +192,7 @@ export default function Blog({ searchParams }: Props) {
                             }),
                           }}
                           tag={getCategoryLabel({
-                            collectionName: 'blog',
+                            collectionName: 'blog_posts',
                             category,
                           })}
                         />

--- a/src/app/events/[slug]/page.tsx
+++ b/src/app/events/[slug]/page.tsx
@@ -38,7 +38,7 @@ export default function EventEntry({ params }: EventProps) {
     <>
       <StructuredDataScript structuredData={generateStructuredData(data)} />
       <TagLabel borderColor="brand-100">
-        {getCategoryLabel({ collectionName: 'events', category })}
+        {getCategoryLabel({ collectionName: 'event_entries', category })}
       </TagLabel>
       <PageHeader
         title={title}

--- a/src/app/events/page.tsx
+++ b/src/app/events/page.tsx
@@ -1,3 +1,5 @@
+import path from 'path'
+
 import dynamic from 'next/dynamic'
 
 import { MagnifyingGlass } from '@phosphor-icons/react/dist/ssr'
@@ -52,8 +54,14 @@ type Props = {
 
 const events = getEventsData()
 const { categorySettings, validCategoryOptions } = getEventsCategorySettings()
-const { featured_entry: featuredEventSlug, seo } = attributes
-const featuredEvent = getEventData(featuredEventSlug || '')
+const { featured_entry, seo } = attributes
+
+if (!featured_entry) {
+  throw new Error('Featured entry is undefined')
+}
+
+const featuredEventSlug = path.parse(featured_entry).name
+const featuredEvent = getEventData(featuredEventSlug)
 
 export const metadata = createMetadata({
   seo,
@@ -186,7 +194,7 @@ export default function Events({ searchParams }: Props) {
                             }),
                           }}
                           tag={getCategoryLabel({
-                            collectionName: 'events',
+                            collectionName: 'event_entries',
                             category,
                           })}
                         />

--- a/src/app/grants/page.tsx
+++ b/src/app/grants/page.tsx
@@ -1,3 +1,5 @@
+import path from 'path'
+
 import { Badge } from '@/components/Badge'
 import { BadgeCardGrid } from '@/components/BadgeCardGrid'
 import { CardGrid } from '@/components/CardGrid'
@@ -27,11 +29,16 @@ import { submissionCriteriaData } from './data/submissionCriteriaData'
 import { generateStructuredData } from './utils/generateStructuredData'
 
 const ecosystemProjects = getEcosystemProjectsData()
-const {
-  featured_grant_graduates: grantGraduatesSlugs,
-  header,
-  seo,
-} = attributes
+const { featured_grant_graduates, header, seo } = attributes
+
+if (!featured_grant_graduates) {
+  throw new Error('Featured grant graduates are undefined')
+}
+
+const grantGraduatesSlugs = featured_grant_graduates.map(
+  (item) => path.parse(item).name,
+)
+
 const grantGraduates = ecosystemProjects.filter((item) =>
   grantGraduatesSlugs?.includes(item.slug),
 )

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,3 +1,5 @@
+import path from 'path'
+
 import { Button } from '@/components/Button'
 import { CardGrid } from '@/components/CardGrid'
 import { CTASection } from '@/components/CTASection'
@@ -23,11 +25,15 @@ import { filecoinEcosystemData } from '@/data/homepage/filecoinEcosystemData'
 
 const ecosystemProjects = getEcosystemProjectsData()
 
-const {
-  featured_ecosystem_projects: featuredEcosystemProjectsSlugs,
-  header,
-  seo,
-} = attributes
+const { featured_ecosystem_projects, header, seo } = attributes
+
+if (!featured_ecosystem_projects) {
+  throw new Error('Featured ecosystem projects are undefined')
+}
+
+const featuredEcosystemProjectsSlugs = featured_ecosystem_projects.map(
+  (item) => path.parse(item).name,
+)
 
 const featuredEcosystemProjects = ecosystemProjects.filter((item) =>
   featuredEcosystemProjectsSlugs?.includes(item.slug),

--- a/src/content/pages/blog.md
+++ b/src/content/pages/blog.md
@@ -3,7 +3,10 @@ header:
   title: Blog
   description: Filecoin Foundation Blog
   featured_entry: src/content/blog/driving-widespread-filecoin-adoption-key-initiatives-and-community-involvement-in-2024.md
+featured_entry: src/content/blog/driving-widespread-filecoin-adoption-key-initiatives-and-community-involvement-in-2024.md
 seo:
   title: Filecoin Foundation Blog | Ecosystem Updates & Announcements
-  description: Read the latest updates, insights, and announcements from the Filecoin ecosystem and Filecoin Foundation. Stay informed about the future of decentralized storage technologies.
+  description: Read the latest updates, insights, and announcements from the
+    Filecoin ecosystem and Filecoin Foundation. Stay informed about the future
+    of decentralized storage technologies.
 ---

--- a/src/content/pages/blog.md
+++ b/src/content/pages/blog.md
@@ -2,7 +2,7 @@
 header:
   title: Blog
   description: Filecoin Foundation Blog
-featured_entry: driving-widespread-filecoin-adoption-key-initiatives-and-community-involvement-in-2024
+  featured_entry: src/content/blog/driving-widespread-filecoin-adoption-key-initiatives-and-community-involvement-in-2024.md
 seo:
   title: Filecoin Foundation Blog | Ecosystem Updates & Announcements
   description: Read the latest updates, insights, and announcements from the Filecoin ecosystem and Filecoin Foundation. Stay informed about the future of decentralized storage technologies.

--- a/src/content/pages/ecosystem-explorer.md
+++ b/src/content/pages/ecosystem-explorer.md
@@ -2,7 +2,6 @@
 header:
   title: "Filecoin Ecosystem Explorer"
   description: "Explore the interactive showcase of diverse projects that make up the Filecoin ecosystem. Given the network’s dynamic growth, this is not an exhaustive list but serves as a launching pad for exploring the ecosystem. If you’re a part of the Filecoin ecosystem and don’t see your project listed, share your details."
-featured_entry: "democracys-library"
 seo:
   title: "Filecoin Foundation Ecosystem – Explore our Projects"
   description: "Discover the diverse landscape of projects that make up the Filecoin ecosystem. Filter Filecoin projects by finance, storage, network, and other categories."

--- a/src/content/pages/events.md
+++ b/src/content/pages/events.md
@@ -2,7 +2,7 @@
 header:
   title: "Events"
   description: "Filecoin Foundation Events"
-featured_entry: "fil-bangkok"
+featured_entry: "src/content/events/fil-bangkok"
 seo:
   title: "Filecoin Foundation Events – Connect & Collaborate"
   description: "Explore upcoming Filecoin Foundation, Web3, and community events. Connect with community members worldwide to collaborate and innovate."

--- a/src/content/pages/events.md
+++ b/src/content/pages/events.md
@@ -2,7 +2,7 @@
 header:
   title: "Events"
   description: "Filecoin Foundation Events"
-featured_entry: "src/content/events/fil-bangkok"
+featured_entry: "src/content/events/fil-bangkok.md"
 seo:
   title: "Filecoin Foundation Events – Connect & Collaborate"
   description: "Explore upcoming Filecoin Foundation, Web3, and community events. Connect with community members worldwide to collaborate and innovate."

--- a/src/content/pages/grants.md
+++ b/src/content/pages/grants.md
@@ -7,7 +7,14 @@ header:
       "Grants support a wide range of projects — from developer and data tooling and integrations to applications and research — that benefit ecosystem participants like developers and storage providers.",
     ]
 featured_grant_graduates:
-  [cavalry, filedrive, fileverse, museum-of-crypto-art-m-c, opsci, portrait]
+  [
+    src/content/ecosystem-explorer/projects/cavalry,
+    src/content/ecosystem-explorer/projects/filedrive,
+    src/content/ecosystem-explorer/projects/fileverse,
+    src/content/ecosystem-explorer/projects/museum-of-crypto-art-m-c,
+    src/content/ecosystem-explorer/projects/opsci,
+    src/content/ecosystem-explorer/projects/portrait,
+  ]
 seo:
   title: "Filecoin Foundation Grants & Funding Opportunities"
   description: "Filecoin Foundation awards grant funding for a wide range of projects –– from developer and data tooling and integrations to applications and research."

--- a/src/content/pages/grants.md
+++ b/src/content/pages/grants.md
@@ -8,12 +8,12 @@ header:
     ]
 featured_grant_graduates:
   [
-    src/content/ecosystem-explorer/projects/cavalry,
-    src/content/ecosystem-explorer/projects/filedrive,
-    src/content/ecosystem-explorer/projects/fileverse,
-    src/content/ecosystem-explorer/projects/museum-of-crypto-art-m-c,
-    src/content/ecosystem-explorer/projects/opsci,
-    src/content/ecosystem-explorer/projects/portrait,
+    src/content/ecosystem-explorer/projects/cavalry.md,
+    src/content/ecosystem-explorer/projects/filedrive.md,
+    src/content/ecosystem-explorer/projects/fileverse.md,
+    src/content/ecosystem-explorer/projects/museum-of-crypto-art-m-c.md,
+    src/content/ecosystem-explorer/projects/opsci.md,
+    src/content/ecosystem-explorer/projects/portrait.md,
   ]
 seo:
   title: "Filecoin Foundation Grants & Funding Opportunities"

--- a/src/content/pages/home.md
+++ b/src/content/pages/home.md
@@ -4,12 +4,12 @@ header:
   description: "Filecoin is the world’s largest decentralized storage network. Filecoin Foundation's mission is to preserve humanity's most important information, as well as to facilitate the open source governance of the Filecoin network, fund research and development projects for decentralized technologies, and support the growth of the Filecoin ecosystem and community."
 featured_ecosystem_projects:
   [
-    "src/content/ecosystem-explorer/projects/nuklai",
-    "src/content/ecosystem-explorer/projects/fleek",
-    "src/content/ecosystem-explorer/projects/tableland",
-    "src/content/ecosystem-explorer/projects/lighthouse",
-    "src/content/ecosystem-explorer/projects/genrait",
-    "src/content/ecosystem-explorer/projects/starling-lab",
+    "src/content/ecosystem-explorer/projects/nuklai.md",
+    "src/content/ecosystem-explorer/projects/fleek.md",
+    "src/content/ecosystem-explorer/projects/tableland.md",
+    "src/content/ecosystem-explorer/projects/lighthouse.md",
+    "src/content/ecosystem-explorer/projects/genrait.md",
+    "src/content/ecosystem-explorer/projects/starling-lab.md",
   ]
 seo:
   title: "Filecoin Foundation | Decentralized Storage Solutions"

--- a/src/content/pages/home.md
+++ b/src/content/pages/home.md
@@ -3,7 +3,14 @@ header:
   title: "Our mission is to preserve humanity’s most important information"
   description: "Filecoin is the world’s largest decentralized storage network. Filecoin Foundation's mission is to preserve humanity's most important information, as well as to facilitate the open source governance of the Filecoin network, fund research and development projects for decentralized technologies, and support the growth of the Filecoin ecosystem and community."
 featured_ecosystem_projects:
-  ["nuklai", "fleek", "tableland", "lighthouse", "genrait", "starling-lab"]
+  [
+    "src/content/ecosystem-explorer/projects/nuklai",
+    "src/content/ecosystem-explorer/projects/fleek",
+    "src/content/ecosystem-explorer/projects/tableland",
+    "src/content/ecosystem-explorer/projects/lighthouse",
+    "src/content/ecosystem-explorer/projects/genrait",
+    "src/content/ecosystem-explorer/projects/starling-lab",
+  ]
 seo:
   title: "Filecoin Foundation | Decentralized Storage Solutions"
   description: "Explore Filecoin Foundation's mission to preserve humanity’s most important information."


### PR DESCRIPTION
This PR addresses the handling of featured entries by ensuring that we correctly extract the slug from the provided file path. The featured entries field now uses the full file path, allowing us to dynamically parse and obtain the slug for further operations, ensuring compatibility with file-based CMS structures.

<img width="822" alt="Screenshot 2024-08-07 at 10 48 27" src="https://github.com/user-attachments/assets/11dd40ca-a231-4364-9ce1-fa4f0a29795e">

<img width="824" alt="Screenshot 2024-08-07 at 10 48 52" src="https://github.com/user-attachments/assets/5d1fc720-d949-4730-8ab9-4559c803f3d5">

<img width="838" alt="Screenshot 2024-08-07 at 10 48 11" src="https://github.com/user-attachments/assets/fc9ec3a3-94ac-4112-bb42-bfebd1dc1703">

<img width="817" alt="Screenshot 2024-08-07 at 10 49 15" src="https://github.com/user-attachments/assets/654d9983-7b78-4409-92a2-f06476efc79c">
