### PR TITLE
Include updated and published on

### DIFF
--- a/src/content/blog/fresh-from-ff-mid-august.md
+++ b/src/content/blog/fresh-from-ff-mid-august.md
@@ -1,6 +1,8 @@
 ---
 title: "Fresh From FF: Mid-August"
 created-on: 2024-08-15T09:00:00.000Z
+updated-on: 2024-08-15T09:00:00.000Z
+published-on: 2024-08-15T09:00:00.000Z
 category: news
 description: "Check out the latest updates about what the Filecoin Foundation team has been up to."
 image:
@@ -14,43 +16,44 @@ seo:
     insights from Messari’s Q2 2024 report, join FIL Singapore, and stay updated
     with the latest FIPs, governance proposals, and community events.
 ---
-[NV23 upgrade](https://www.fil.org/blog/announcing-the-filecoin-nv23-waffle-upgrade-enhancing-filecoins-efficiency-and-security?utm_source=upload.fil.org&utm_medium=referral&utm_campaign=network-insights-from-messari-s-q2-2024-filecoin-report), codenamed "Waffle," went live on Mainnet on August 6. This upgrade brings significant enhancements focused on simplified processes, optimized proof mechanisms, streamlined sector commitments, enhanced cryptographic support, and strengthened security. Several Filecoin Improvement Proposals (FIPs), such as [FIP0065](https://github.com/filecoin-project/FIPs/blob/master/FIPS/fip-0065.md?utm_source=upload.fil.org&utm_medium=referral&utm_campaign=network-insights-from-messari-s-q2-2024-filecoin-report), help the network operate more efficiently and lay the groundwork for more flexible data commitment methods. 
 
-Messari’s [State of Filecoin Q2 2024 report is out](https://messari.io/report/state-of-filecoin-q2-2024). Read it for a detailed overview of the network, including increased network utilization rates, more data client onboarding, continued network maturation as the DePIN backbone for AI advancements, and more. 
+[NV23 upgrade](https://www.fil.org/blog/announcing-the-filecoin-nv23-waffle-upgrade-enhancing-filecoins-efficiency-and-security?utm_source=upload.fil.org&utm_medium=referral&utm_campaign=network-insights-from-messari-s-q2-2024-filecoin-report), codenamed "Waffle," went live on Mainnet on August 6. This upgrade brings significant enhancements focused on simplified processes, optimized proof mechanisms, streamlined sector commitments, enhanced cryptographic support, and strengthened security. Several Filecoin Improvement Proposals (FIPs), such as [FIP0065](https://github.com/filecoin-project/FIPs/blob/master/FIPS/fip-0065.md?utm_source=upload.fil.org&utm_medium=referral&utm_campaign=network-insights-from-messari-s-q2-2024-filecoin-report), help the network operate more efficiently and lay the groundwork for more flexible data commitment methods.
 
-Join Metapals for [FIL Singapore](https://www.fil.org/events/fil-singapore-alongside-token2049-2024), hosted by MetaPals and supported by Filecoin Foundation. FILSG: Web3 Wonderland is the marquee event alongside TOKEN2049 bringing together some of the sharpest minds and most innovative projects across Web3 and AI. [Reserve your spot](https://lu.ma/escdw9dx?tk=LRE4fg). 
+Messari’s [State of Filecoin Q2 2024 report is out](https://messari.io/report/state-of-filecoin-q2-2024). Read it for a detailed overview of the network, including increased network utilization rates, more data client onboarding, continued network maturation as the DePIN backbone for AI advancements, and more.
+
+Join Metapals for [FIL Singapore](https://www.fil.org/events/fil-singapore-alongside-token2049-2024), hosted by MetaPals and supported by Filecoin Foundation. FILSG: Web3 Wonderland is the marquee event alongside TOKEN2049 bringing together some of the sharpest minds and most innovative projects across Web3 and AI. [Reserve your spot](https://lu.ma/escdw9dx?tk=LRE4fg).
 
 ## Ecosystem
 
 ### Builders Funnel
 
-* Join the next [Developer Working Group (DevWG) meeting, August 29](https://lu.ma/n1qa6gj6). This monthly call connects Filecoin developers and community members to discuss key areas of interest across the developer community. Have questions? Check out our [repo](https://github.com/filecoin-project/DeveloperWG) or connect in the [Builders Discussions](https://discord.com/channels/1210612276357500978/1234888399647801426) channel in Discord.
+- Join the next [Developer Working Group (DevWG) meeting, August 29](https://lu.ma/n1qa6gj6). This monthly call connects Filecoin developers and community members to discuss key areas of interest across the developer community. Have questions? Check out our [repo](https://github.com/filecoin-project/DeveloperWG) or connect in the [Builders Discussions](https://discord.com/channels/1210612276357500978/1234888399647801426) channel in Discord.
 
 ### Storage Community
 
-* Several FIPs in the nv23 Waffle upgrade were added to address critical aspects of the network's functionality including [FIP0065](https://github.com/filecoin-project/FIPs/blob/master/FIPS/fip-0065.md) simplifies the network's circulating supply calculation by excluding the locked balances of the built-in market actor, preparing for direct data commitments without requiring market deals.
-* [Filecoin Fast Finality (F3) was accepted](https://x.com/FilFoundation/status/1821594124581048654). This change reduces finalization time from approximately 7.5 hours to ~15 minutes using existing information, without protocol changes, addressing a key barrier for apps, exchanges, and interoperability. [Read more](https://github.com/filecoin-project/FIPs/blob/master/FIPS/fip-0086.md).
+- Several FIPs in the nv23 Waffle upgrade were added to address critical aspects of the network's functionality including [FIP0065](https://github.com/filecoin-project/FIPs/blob/master/FIPS/fip-0065.md) simplifies the network's circulating supply calculation by excluding the locked balances of the built-in market actor, preparing for direct data commitments without requiring market deals.
+- [Filecoin Fast Finality (F3) was accepted](https://x.com/FilFoundation/status/1821594124581048654). This change reduces finalization time from approximately 7.5 hours to ~15 minutes using existing information, without protocol changes, addressing a key barrier for apps, exchanges, and interoperability. [Read more](https://github.com/filecoin-project/FIPs/blob/master/FIPS/fip-0086.md).
 
 ## Network Operations
 
 ### Governance
 
-* Check out the latest FIP one-pager, [FIP0093](https://x.com/fil_gov/status/1821976035644338597). This proposal aims to set the balance of the mining reserve (address f090) to zero, effectively removing 282.9 million FIL tokens from potential future use. This action would reduce the total supply of FIL to approximately 1.717 billion. [Join the full discussion on GitHub](https://github.com/filecoin-project/FIPs/discussions/1030). 
-* [Watch the Filecoin Core Developers call](https://youtu.be/ibkfXroadU8?feature=shared), diving into new proposals, the nv23 Waffle Upgrade, and the timeline discussion for nv24. 
+- Check out the latest FIP one-pager, [FIP0093](https://x.com/fil_gov/status/1821976035644338597). This proposal aims to set the balance of the mining reserve (address f090) to zero, effectively removing 282.9 million FIL tokens from potential future use. This action would reduce the total supply of FIL to approximately 1.717 billion. [Join the full discussion on GitHub](https://github.com/filecoin-project/FIPs/discussions/1030).
+- [Watch the Filecoin Core Developers call](https://youtu.be/ibkfXroadU8?feature=shared), diving into new proposals, the nv23 Waffle Upgrade, and the timeline discussion for nv24.
 
 ### Fil Plus
 
-* Rolling allocator applications are open for submissions. Allocators are a core part of the Fil+ program and help incentivize the storage of useful data on the Filecoin network. Allocators designing new pathways, such as those listed in the [Request for Allocators (RFA)](https://blog.allocator.tech/2024/05/rolling-applications-are-open-for.html?utm_source=upload.fil.org&utm_medium=referral&utm_campaign=network-insights-from-messari-s-q2-2024-filecoin-report), are receiving priority review.
-* [The August 6 Allocator Call is available on YouTube](https://youtu.be/wvsaEgabhc8). If you would like to attend these meetings live add the [Fil+ Allocator Governance calendar](https://calendar.google.com/calendar/embed?src=c_k1gkfoom17g0j8c6bam6uf43j0%40group.calendar.google.com&ctz=America%2FLos_Angeles).
+- Rolling allocator applications are open for submissions. Allocators are a core part of the Fil+ program and help incentivize the storage of useful data on the Filecoin network. Allocators designing new pathways, such as those listed in the [Request for Allocators (RFA)](https://blog.allocator.tech/2024/05/rolling-applications-are-open-for.html?utm_source=upload.fil.org&utm_medium=referral&utm_campaign=network-insights-from-messari-s-q2-2024-filecoin-report), are receiving priority review.
+- [The August 6 Allocator Call is available on YouTube](https://youtu.be/wvsaEgabhc8). If you would like to attend these meetings live add the [Fil+ Allocator Governance calendar](https://calendar.google.com/calendar/embed?src=c_k1gkfoom17g0j8c6bam6uf43j0%40group.calendar.google.com&ctz=America%2FLos_Angeles).
 
 ### Comms, Marketing, & Events
 
-* Filecoin Foundation President and Chair Marta Belcher joined Chainalysis CMO Ian Andrews on the [Public Key Podcast](https://www.chainalysis.com/blog/ipfs-filecoin-and-crypto-policy-developments-ep-121/) to talk about the evolving landscape of crypto policy
-* Filecoin Foundation [joined the NFT.Storage community](https://nft.storage/blog/filecoin-foundation-joins-the-nft-storage-community) as a gold member to help preserve digital assets and ensure that NFTs remain accessible and verifiable for future generations.
-* Join the Filecoin Community in Bangkok to explore decentralized AI infrastructure, DePIN, and the evolving data economy at FIL Bangkok.[Reserve your spot](https://fil.org/events/fil-bangkok) now and keep an eye out for programming announcements!
-* Check out the global Orbit events happening near you at [fil.org/orbit](http://fil.org/orbit)! Network with members of your local Filecoin community at these always welcoming, free-to-attend Orbit events. 
+- Filecoin Foundation President and Chair Marta Belcher joined Chainalysis CMO Ian Andrews on the [Public Key Podcast](https://www.chainalysis.com/blog/ipfs-filecoin-and-crypto-policy-developments-ep-121/) to talk about the evolving landscape of crypto policy
+- Filecoin Foundation [joined the NFT.Storage community](https://nft.storage/blog/filecoin-foundation-joins-the-nft-storage-community) as a gold member to help preserve digital assets and ensure that NFTs remain accessible and verifiable for future generations.
+- Join the Filecoin Community in Bangkok to explore decentralized AI infrastructure, DePIN, and the evolving data economy at FIL Bangkok.[Reserve your spot](https://fil.org/events/fil-bangkok) now and keep an eye out for programming announcements!
+- Check out the global Orbit events happening near you at [fil.org/orbit](http://fil.org/orbit)! Network with members of your local Filecoin community at these always welcoming, free-to-attend Orbit events.
 
 ### Featured Datasets on Filecoin
 
-* [Ushahidi is leveraging](https://x.com/FilFoundation/status/1821581405714784429) Filecoin to understand past elections and identify trends that can inform future democratic advancements.
-* Baseline, by Guardian Project, is [utilizing Filecoin to verify and preserve](https://x.com/FilFoundation/status/1819057414856958141) documentation and played an important role in disaster relief efforts during Hurricane Otis.
+- [Ushahidi is leveraging](https://x.com/FilFoundation/status/1821581405714784429) Filecoin to understand past elections and identify trends that can inform future democratic advancements.
+- Baseline, by Guardian Project, is [utilizing Filecoin to verify and preserve](https://x.com/FilFoundation/status/1819057414856958141) documentation and played an important role in disaster relief efforts during Hurricane Otis.


### PR DESCRIPTION
## 📝 Description

Blog post wasn't showing up on `/blog` because `created-on` and `published-on` dates weren't present.

- **Type:** Bug fix

## 🛠️ Key Changes

- Include `created-on` and `published-on`
