### PR TITLE
Include date default

### DIFF
--- a/public/admin/config.yml
+++ b/public/admin/config.yml
@@ -20,17 +20,22 @@ created_on: &created_on
   name: "created-on"
   label: "Created On"
   widget: "datetime"
+  default: "{{now}}"
 
 updated_on: &updated_on
   name: "updated-on"
   label: "Updated On"
   widget: "datetime"
+  default: "{{now}}"
+
   required: false
 
 published_on: &published_on
   name: "published-on"
   label: "Published On"
   widget: "datetime"
+  default: "{{now}}"
+
   required: false
 
 header_config: &header_config


### PR DESCRIPTION
## 📝 Description

We had an issue where we wouldn't get the `updated-on` and `published-on` fields populated in the frontmatter since these fields are optional. We have now set default dates to the current day. This way, whenever a new entry is created it will populate all three publishing dates to today.

- **Type:** Bug fix

## 🛠️ Key Changes

- Set `created-on`, `updated-on`, `published-on` date default to today.

## 🔖 Resources

Feel free to share any references to documentation, libraries, blog posts, or other resources that you consulted or used during the implementation of the changes.

- https://decapcms.org/docs/widgets/datetime/
