### PR TITLE
[UXIT-1441] Include time based revalidation

### DIFF
--- a/src/app/_constants/revalidateConfig.ts
+++ b/src/app/_constants/revalidateConfig.ts
@@ -1,0 +1,1 @@
+export const REVALIDATE_TIME = 24 * 60 * 60

--- a/src/app/blog/layout.tsx
+++ b/src/app/blog/layout.tsx
@@ -1,3 +1,7 @@
 import { BreadCrumbsLayout } from '@/components/BreadCrumbsLayout'
 
+import { REVALIDATE_TIME } from '@/constants/revalidateConfig'
+
+export const revalidate = REVALIDATE_TIME
+
 export default BreadCrumbsLayout

--- a/src/app/ecosystem-explorer/layout.tsx
+++ b/src/app/ecosystem-explorer/layout.tsx
@@ -1,3 +1,7 @@
 import { BreadCrumbsLayout } from '@/components/BreadCrumbsLayout'
 
+import { REVALIDATE_TIME } from '@/constants/revalidateConfig'
+
+export const revalidate = REVALIDATE_TIME
+
 export default BreadCrumbsLayout

--- a/src/app/events/layout.tsx
+++ b/src/app/events/layout.tsx
@@ -1,3 +1,7 @@
 import { BreadCrumbsLayout } from '@/components/BreadCrumbsLayout'
 
+import { REVALIDATE_TIME } from '@/constants/revalidateConfig'
+
+export const revalidate = REVALIDATE_TIME
+
 export default BreadCrumbsLayout


### PR DESCRIPTION
## 📝 Description

This feature introduces time-based revalidation for data fetching to ensure that cached data is refreshed at regular intervals. By using the next.revalidate option in the fetch function, we can control the cache lifetime of a resource and set it to revalidate at most every 24 hours.

## 🛠️ Key Changes

- Implement the `revalidate` options in `layout.tsx` of Blog Posts, Events, and Ecosystem Explorer projects to set a revalidation interval of 24 hours.

## 🧪 How to Test

- Expected Results: Data should be revalidated and refreshed every 24 hours without unnecessary requests.

## 🔖 Resources
- [Next.js Documentation on Fetch Revalidation](https://nextjs.org/docs/pages/building-your-application/data-fetching/revalidation).