### PR TITLE
UXIT-1465 - Enable Vercel Speed Insights

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,7 @@
         "@sentry/nextjs": "^8.24.0",
         "@tailwindcss/forms": "^0.5.7",
         "@tailwindcss/typography": "^0.5.14",
+        "@vercel/speed-insights": "^1.0.12",
         "airtable": "^0.12.2",
         "autoprefixer": "^10.4.20",
         "clsx": "^2.1.1",
@@ -5536,6 +5537,41 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.2.0.tgz",
       "integrity": "sha512-zuVdFrMJiuCDQUMCzQaD6KL28MjnqqN8XnAqiEq9PNm/hCPTSGfrXCOfwj1ow4LFb/tNymJPwsNbVePc1xFqrQ=="
+    },
+    "node_modules/@vercel/speed-insights": {
+      "version": "1.0.12",
+      "resolved": "https://registry.npmjs.org/@vercel/speed-insights/-/speed-insights-1.0.12.tgz",
+      "integrity": "sha512-ZGQ+a7bcfWJD2VYEp2R1LHvRAMyyaFBYytZXsfnbOMkeOvzGNVxUL7aVUvisIrTZjXTSsxG45DKX7yiw6nq2Jw==",
+      "hasInstallScript": true,
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "@sveltejs/kit": "^1 || ^2",
+        "next": ">= 13",
+        "react": "^18 || ^19",
+        "svelte": "^4",
+        "vue": "^3",
+        "vue-router": "^4"
+      },
+      "peerDependenciesMeta": {
+        "@sveltejs/kit": {
+          "optional": true
+        },
+        "next": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "svelte": {
+          "optional": true
+        },
+        "vue": {
+          "optional": true
+        },
+        "vue-router": {
+          "optional": true
+        }
+      }
     },
     "node_modules/@webassemblyjs/ast": {
       "version": "1.12.1",

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "@sentry/nextjs": "^8.24.0",
     "@tailwindcss/forms": "^0.5.7",
     "@tailwindcss/typography": "^0.5.14",
+    "@vercel/speed-insights": "^1.0.12",
     "airtable": "^0.12.2",
     "autoprefixer": "^10.4.20",
     "clsx": "^2.1.1",

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,3 +1,4 @@
+import { SpeedInsights } from '@vercel/speed-insights/next'
 import type { Metadata } from 'next'
 import PlausibleProvider from 'next-plausible'
 
@@ -23,6 +24,7 @@ export default function RootLayout({ children }: LayoutProps) {
   return (
     <PlausibleProvider domain="fil.org">
       <SiteLayout>{children}</SiteLayout>
+      <SpeedInsights />
     </PlausibleProvider>
   )
 }


### PR DESCRIPTION
## 📝 Description

Enabled Vercel Speed Insights to monitor and improve the performance of the application. This change helps identify bottlenecks and load times for a better user experience.

- **Type:** New feature

## 🛠️ Key Changes

- Integrated Speed Insights following the official documentation.
- Updated project dependencies to support Speed Insights.

## 🧪 How to Test

After the PR has been merged, review Speed Insights reports to ensure metrics are captured (in Vercel project Dashboard under the Usage tab).
- **Expected Results:** Speed Insights should display performance data for the application.

## 📸 Screenshots

<img width="1147" alt="CleanShot 2024-08-26 at 20 01 32@2x" src="https://github.com/user-attachments/assets/614f3169-e293-497d-802d-fd27bbe0c7ca">

## 🔖 Resources

- [Google Speed Insights Documentation](https://developers.google.com/speed/docs/insights)