### PR TITLE
Move SpeedInsights component into body element

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -23,8 +23,10 @@ export type LayoutProps = {
 export default function RootLayout({ children }: LayoutProps) {
   return (
     <PlausibleProvider domain="fil.org">
-      <SiteLayout>{children}</SiteLayout>
-      <SpeedInsights />
+      <SiteLayout>
+        {children}
+        <SpeedInsights />
+      </SiteLayout>
     </PlausibleProvider>
   )
 }


### PR DESCRIPTION
## 📝 Description

- **Type:** Bug fix - Fixes #517 

This PR moves the `<SpeedInsights />` component inside the `<SiteLayout />` component to ensure it is rendered within the `<body>` tag as intended. Previously, the `<SpeedInsights />` component was placed outside of `<SiteLayout />`, which affected integration.

## 📸 Screenshots

![CleanShot 2024-08-27 at 09 29 00@2x](https://github.com/user-attachments/assets/b2c0bf1d-77b0-411d-924b-054a927ca126)
