### PR TITLE
[UXIT-1473] Bug Bounty Page Header

### DIFF
--- a/cypress/e2e/critical/about_page_spec.cy.ts
+++ b/cypress/e2e/critical/about_page_spec.cy.ts
@@ -4,8 +4,7 @@ import { verifyLinks } from '@/support/verifyLinksUtil'
 
 describe('About Page', () => {
   it('should check metadata', () => {
-    testPageMetadata({
-      path: PATHS.ABOUT,
+    testPageMetadata(PATHS.ABOUT, {
       overrideDefaultTitle: true,
     })
   })

--- a/cypress/e2e/critical/blog_page_spec.cy.ts
+++ b/cypress/e2e/critical/blog_page_spec.cy.ts
@@ -4,8 +4,7 @@ import { verifyLinks } from '@/support/verifyLinksUtil'
 
 describe('Blog Page', () => {
   it('should check metadata', () => {
-    testPageMetadata({
-      path: PATHS.BLOG,
+    testPageMetadata(PATHS.BLOG, {
       overrideDefaultTitle: true,
     })
   })

--- a/cypress/e2e/critical/ecosystem_explorer_page_spec.cy.ts
+++ b/cypress/e2e/critical/ecosystem_explorer_page_spec.cy.ts
@@ -4,8 +4,7 @@ import { verifyLinks } from '@/support/verifyLinksUtil'
 
 describe('Ecosystem Explorer Page', () => {
   it('should check metadata', () => {
-    testPageMetadata({
-      path: PATHS.ECOSYSTEM_EXPLORER,
+    testPageMetadata(PATHS.ECOSYSTEM_EXPLORER, {
       overrideDefaultTitle: true,
     })
   })

--- a/cypress/e2e/critical/employee_privacy_policy.cy.ts
+++ b/cypress/e2e/critical/employee_privacy_policy.cy.ts
@@ -4,8 +4,7 @@ import { verifyLinks } from '@/support/verifyLinksUtil'
 
 describe('Employee Privacy Policy Page', () => {
   it('should check metadata', () => {
-    testPageMetadata({
-      path: PATHS.EMPLOYEE_PRIVACY_POLICY,
+    testPageMetadata(PATHS.EMPLOYEE_PRIVACY_POLICY, {
       hasPageHeaderDescription: false,
     })
   })

--- a/cypress/e2e/critical/events_page_spec.cy.ts
+++ b/cypress/e2e/critical/events_page_spec.cy.ts
@@ -4,8 +4,7 @@ import { verifyLinks } from '@/support/verifyLinksUtil'
 
 describe('Events Page', () => {
   it('should check metadata', () => {
-    testPageMetadata({
-      path: PATHS.EVENTS,
+    testPageMetadata(PATHS.EVENTS, {
       overrideDefaultTitle: true,
     })
   })

--- a/cypress/e2e/critical/fil_plus_page_spec.cy.ts
+++ b/cypress/e2e/critical/fil_plus_page_spec.cy.ts
@@ -4,9 +4,7 @@ import { verifyLinks } from '@/support/verifyLinksUtil'
 
 describe('Filecoin Plus Page', () => {
   it('should check metadata', () => {
-    testPageMetadata({
-      path: PATHS.FIL_PLUS,
-    })
+    testPageMetadata(PATHS.FIL_PLUS)
   })
 
   it('should check links', () => {

--- a/cypress/e2e/critical/governance_page_spec.cy.ts
+++ b/cypress/e2e/critical/governance_page_spec.cy.ts
@@ -4,8 +4,7 @@ import { verifyLinks } from '@/support/verifyLinksUtil'
 
 describe('Governance Page', () => {
   it('should check metadata', () => {
-    testPageMetadata({
-      path: PATHS.GOVERNANCE,
+    testPageMetadata(PATHS.GOVERNANCE, {
       overrideDefaultTitle: true,
     })
   })

--- a/cypress/e2e/critical/grants_page_spec.cy.ts
+++ b/cypress/e2e/critical/grants_page_spec.cy.ts
@@ -4,8 +4,7 @@ import { verifyLinks } from '@/support/verifyLinksUtil'
 
 describe('Grants Page', () => {
   it('should check metadata', () => {
-    testPageMetadata({
-      path: PATHS.GRANTS,
+    testPageMetadata(PATHS.GRANTS, {
       overrideDefaultTitle: true,
     })
   })

--- a/cypress/e2e/critical/home_page_spec.cy.ts
+++ b/cypress/e2e/critical/home_page_spec.cy.ts
@@ -4,8 +4,7 @@ import { verifyLinks } from '@/support/verifyLinksUtil'
 
 describe('Homepage', () => {
   it('should check metadata', () => {
-    testPageMetadata({
-      path: PATHS.HOME,
+    testPageMetadata(PATHS.HOME, {
       overrideDefaultTitle: true,
     })
   })

--- a/cypress/e2e/critical/orbit_page_spec.cy.ts
+++ b/cypress/e2e/critical/orbit_page_spec.cy.ts
@@ -2,5 +2,7 @@ import { PATHS } from '@/constants/paths'
 import { testPageMetadata } from '@/support/test-utils'
 
 describe('Orbit Page', () => {
-  testPageMetadata({ path: PATHS.ORBIT, overrideDefaultTitle: true })
+  testPageMetadata(PATHS.ORBIT, {
+    overrideDefaultTitle: true,
+  })
 })

--- a/cypress/e2e/critical/privacy_policy_page_spec.cy.ts
+++ b/cypress/e2e/critical/privacy_policy_page_spec.cy.ts
@@ -4,8 +4,7 @@ import { verifyLinks } from '@/support/verifyLinksUtil'
 
 describe('Privacy Policy Page', () => {
   it('should check metadata', () => {
-    testPageMetadata({
-      path: PATHS.PRIVACY_POLICY,
+    testPageMetadata(PATHS.PRIVACY_POLICY, {
       hasPageHeaderDescription: false,
     })
   })

--- a/cypress/e2e/critical/security_pages_spec.cy.ts
+++ b/cypress/e2e/critical/security_pages_spec.cy.ts
@@ -14,7 +14,7 @@ describe('Security - Coordinated Disclosure Policy Page', () => {
 })
 
 describe('Security - Bug Bounty Program Page', () => {
-  testPageMetadata(PATHS.BUG_BOUNTY_PROGRAM, {
+  testPageMetadata(PATHS.BUG_BOUNTY, {
     overrideDefaultTitle: true,
   })
 })

--- a/cypress/e2e/critical/security_pages_spec.cy.ts
+++ b/cypress/e2e/critical/security_pages_spec.cy.ts
@@ -11,3 +11,10 @@ describe('Security - Coordinated Disclosure Policy Page', () => {
     overrideDefaultTitle: true,
   })
 })
+
+describe('Security - Bug Bounty Program Page', () => {
+  testPageMetadata({
+    path: PATHS.BUG_BOUNTY_PROGRAM,
+    overrideDefaultTitle: true,
+  })
+})

--- a/cypress/e2e/critical/security_pages_spec.cy.ts
+++ b/cypress/e2e/critical/security_pages_spec.cy.ts
@@ -2,19 +2,19 @@ import { PATHS } from '@/constants/paths'
 import { testPageMetadata } from '@/support/test-utils'
 
 describe('Security - Main Page', () => {
-  testPageMetadata({ path: PATHS.SECURITY, overrideDefaultTitle: true })
+  testPageMetadata(PATHS.SECURITY, {
+    overrideDefaultTitle: true,
+  })
 })
 
 describe('Security - Coordinated Disclosure Policy Page', () => {
-  testPageMetadata({
-    path: PATHS.COORDINATED_DISCLOSURE_POLICY,
+  testPageMetadata(PATHS.COORDINATED_DISCLOSURE_POLICY, {
     overrideDefaultTitle: true,
   })
 })
 
 describe('Security - Bug Bounty Program Page', () => {
-  testPageMetadata({
-    path: PATHS.BUG_BOUNTY_PROGRAM,
+  testPageMetadata(PATHS.BUG_BOUNTY_PROGRAM, {
     overrideDefaultTitle: true,
   })
 })

--- a/cypress/e2e/critical/terms_of_use_page_spec.cy.ts
+++ b/cypress/e2e/critical/terms_of_use_page_spec.cy.ts
@@ -4,8 +4,7 @@ import { verifyLinks } from '@/support/verifyLinksUtil'
 
 describe('Terms of Use Page', () => {
   it('should check metadata', () => {
-    testPageMetadata({
-      path: PATHS.TERMS_OF_USE,
+    testPageMetadata(PATHS.TERMS_OF_USE, {
       hasPageHeaderDescription: false,
     })
   })

--- a/cypress/support/test-utils.ts
+++ b/cypress/support/test-utils.ts
@@ -10,6 +10,8 @@ type TestMetaDataOptions = {
   overrideDefaultTitle?: boolean
 }
 
+type HeaderContentType = { title: string; description: string | Array<string> }
+
 export function testPageMetadata(
   pathConfig: PathConfig,
   options: TestMetaDataOptions = {},
@@ -30,7 +32,7 @@ export function testPageMetadata(
         seo,
         featured_entry: featuredSlug,
       } = matter(markdownContent).data as {
-        header: { title: string; description: string }
+        header: HeaderContentType
         seo: { title: string; description: string }
         featured_entry?: string
       }
@@ -43,7 +45,7 @@ export function testPageMetadata(
       if (includesFeaturedEntry && featuredSlug) {
         handleFeaturedEntry(entriesContentPath as string, featuredSlug)
       } else {
-        verifyHeaderContent(header, hasPageHeaderDescription)
+        verifyHeaderContent(header, { hasPageHeaderDescription })
       }
 
       verifyCanonicalLink(path)
@@ -64,17 +66,17 @@ function handleFeaturedEntry(entriesContentPath: string, slug: string) {
       title: string
       description: string
     }
-    verifyHeaderContent(entry, true)
+    verifyHeaderContent(entry)
   })
 }
 
 function verifyHeaderContent(
-  {
-    title,
-    description,
-  }: { title: string; description: string | Array<string> },
-  hasPageHeaderDescription: boolean,
+  header: HeaderContentType,
+  options: Pick<TestMetaDataOptions, 'hasPageHeaderDescription'> = {},
 ) {
+  const { title, description } = header
+  const { hasPageHeaderDescription = true } = options
+
   cy.get('header')
     .first()
     .should('exist')

--- a/cypress/support/test-utils.ts
+++ b/cypress/support/test-utils.ts
@@ -4,17 +4,23 @@ import type { PathConfig } from '../../src/app/_constants/paths'
 import { verifyCanonicalLink } from '../support/verifyCanonicalLinkUtil'
 import { verifyPageTitle } from '../support/verifyPageTitleUtil'
 
-export function testPageMetadata({
-  path: { mainContentPath, path, entriesContentPath },
-  hasPageHeaderDescription = true,
-  includesFeaturedEntry = false,
-  overrideDefaultTitle = false,
-}: {
-  path: PathConfig
+type TestMetaDataOptions = {
   hasPageHeaderDescription?: boolean
   includesFeaturedEntry?: boolean
   overrideDefaultTitle?: boolean
-}) {
+}
+
+export function testPageMetadata(
+  pathConfig: PathConfig,
+  options: TestMetaDataOptions = {},
+) {
+  const { mainContentPath, path, entriesContentPath } = pathConfig
+  const {
+    hasPageHeaderDescription = true,
+    includesFeaturedEntry = false,
+    overrideDefaultTitle = false,
+  } = options
+
   it(`should use the correct metadata from the markdown file`, function () {
     const filePath = `${mainContentPath}.md`
 

--- a/next.config.js
+++ b/next.config.js
@@ -101,11 +101,6 @@ const nextConfig = {
         destination: '/',
         permanent: true,
       },
-      {
-        source: '/security/bug-bounty',
-        destination: 'https://immunefi.com/bug-bounty/filecoin/',
-        permanent: false,
-      },
       { source: '/team', destination: '/about', permanent: true },
       { source: '/terms', destination: '/terms-of-use', permanent: true },
       {

--- a/public/admin/config.yml
+++ b/public/admin/config.yml
@@ -253,6 +253,13 @@ collections:
           - *header_config
           - *meta_config
 
+      - name: "security/bug-bounty"
+        label: "Bug Bounty"
+        file: "src/content/pages/security/bug-bounty.md"
+        fields:
+          - *header_config
+          - *meta_config
+
       - name: "terms"
         label: "Terms"
         file: "src/content/pages/terms-of-use.md"

--- a/public/admin/config.yml
+++ b/public/admin/config.yml
@@ -256,6 +256,7 @@ collections:
       - name: "security/bug-bounty"
         label: "Bug Bounty"
         file: "src/content/pages/security/bug-bounty.md"
+        preview_path: "security/bug-bounty"
         fields:
           - *header_config
           - *meta_config

--- a/src/app/_constants/paths.ts
+++ b/src/app/_constants/paths.ts
@@ -17,8 +17,10 @@ export type PathValues =
   | '/orbit'
   | '/privacy-policy'
   | '/security'
+  | '/security/bug-bounty'
   | '/security/coordinated-disclosure-policy'
   | '/terms-of-use'
+
 export interface PathConfig {
   path: PathValues
   label: string
@@ -72,6 +74,10 @@ export const PATHS = {
   COORDINATED_DISCLOSURE_POLICY: createPathObject(
     '/security/coordinated-disclosure-policy',
     'Coordinated Disclosure Policy',
+  ),
+  BUG_BOUNTY_PROGRAM: createPathObject(
+    '/security/bug-bounty',
+    'Bug Bounty Program',
   ),
   ECOSYSTEM_EXPLORER: createPathObject(
     '/ecosystem-explorer',

--- a/src/app/_constants/paths.ts
+++ b/src/app/_constants/paths.ts
@@ -75,10 +75,7 @@ export const PATHS = {
     '/security/coordinated-disclosure-policy',
     'Coordinated Disclosure Policy',
   ),
-  BUG_BOUNTY_PROGRAM: createPathObject(
-    '/security/bug-bounty',
-    'Bug Bounty Program',
-  ),
+  BUG_BOUNTY: createPathObject('/security/bug-bounty', 'Bug Bounty Program'),
   ECOSYSTEM_EXPLORER: createPathObject(
     '/ecosystem-explorer',
     'Ecosystem Explorer',

--- a/src/app/_constants/siteMetadata.ts
+++ b/src/app/_constants/siteMetadata.ts
@@ -110,8 +110,8 @@ const FILECOIN_FOUNDATION_URLS = {
       filecoinCompatibility:
         'https://docs.filecoin.io/smart-contracts/filecoin-evm-runtime/difference-with-ethereum',
       auditReports: 'https://spec.filecoin.io/#section-appendix.audit_reports',
-      bugBountyProgram: 'https://immunefi.com/bug-bounty/filecoin/',
     },
+    bugBountyProgram: 'https://immunefi.com/bug-bounty/filecoin/',
   },
   social: {
     bluesky: {

--- a/src/app/security/bug-bounty/page.tsx
+++ b/src/app/security/bug-bounty/page.tsx
@@ -17,7 +17,7 @@ const { header, seo } = attributes
 
 export const metadata = createMetadata({
   seo,
-  path: PATHS.BUG_BOUNTY_PROGRAM.path,
+  path: PATHS.BUG_BOUNTY.path,
 })
 
 export default function BugBounty() {

--- a/src/app/security/bug-bounty/page.tsx
+++ b/src/app/security/bug-bounty/page.tsx
@@ -18,6 +18,7 @@ const { header, seo } = attributes
 export const metadata = createMetadata({
   seo,
   path: PATHS.BUG_BOUNTY.path,
+  overrideDefaultTitle: true,
 })
 
 export default function BugBounty() {

--- a/src/app/security/bug-bounty/page.tsx
+++ b/src/app/security/bug-bounty/page.tsx
@@ -1,0 +1,38 @@
+import { PageHeader } from '@/components/PageHeader'
+import { PageLayout } from '@/components/PageLayout'
+import { StructuredDataScript } from '@/components/StructuredDataScript'
+
+import { createMetadata } from '@/utils/createMetadata'
+
+import { graphicsData } from '@/data/graphicsData'
+
+import { attributes } from '@/content/pages/security/bug-bounty.md'
+
+import { PATHS } from '@/constants/paths'
+import { FILECOIN_FOUNDATION_URLS } from '@/constants/siteMetadata'
+
+import { generateStructuredData } from './utils/generateStructuredData'
+
+const { header, seo } = attributes
+
+export const metadata = createMetadata({
+  seo,
+  path: PATHS.BUG_BOUNTY_PROGRAM.path,
+})
+
+export default function BugBounty() {
+  return (
+    <PageLayout>
+      <StructuredDataScript structuredData={generateStructuredData(seo)} />
+      <PageHeader
+        title={header.title}
+        description={header.description}
+        image={graphicsData.security4}
+        cta={{
+          text: 'Learn More About the Program',
+          href: FILECOIN_FOUNDATION_URLS.security.bugBountyProgram,
+        }}
+      />
+    </PageLayout>
+  )
+}

--- a/src/app/security/bug-bounty/utils/generateStructuredData.tsx
+++ b/src/app/security/bug-bounty/utils/generateStructuredData.tsx
@@ -1,0 +1,15 @@
+import type { WebPage, WithContext } from 'schema-dts'
+
+import type { SeoMetadata } from '@/types/metadataTypes'
+
+import { generateWebPageStructuredData } from '@/utils/generateWebPageStructuredData'
+
+import { PATHS } from '@/constants/paths'
+
+export function generateStructuredData(seo: SeoMetadata): WithContext<WebPage> {
+  return generateWebPageStructuredData({
+    title: seo.title,
+    description: seo.description,
+    path: PATHS.BUG_BOUNTY_PROGRAM.path,
+  })
+}

--- a/src/app/security/bug-bounty/utils/generateStructuredData.tsx
+++ b/src/app/security/bug-bounty/utils/generateStructuredData.tsx
@@ -10,6 +10,6 @@ export function generateStructuredData(seo: SeoMetadata): WithContext<WebPage> {
   return generateWebPageStructuredData({
     title: seo.title,
     description: seo.description,
-    path: PATHS.BUG_BOUNTY_PROGRAM.path,
+    path: PATHS.BUG_BOUNTY.path,
   })
 }

--- a/src/app/security/page.tsx
+++ b/src/app/security/page.tsx
@@ -112,7 +112,7 @@ export default function Security() {
         description="Filecoin Foundation offers bug bounties for reported security vulnerabilities on the Filecoin protocol. Earn up to 150,000 USD, paid in USD/USDC, for reporting critical vulnerabilities. Since launching our Bug Bounty program, we’ve paid out more than $400,000 in rewards."
         cta={{
           text: 'Filecoin Foundation Bug Bounty',
-          href: PATHS.BUG_BOUNTY_PROGRAM.path,
+          href: PATHS.BUG_BOUNTY.path,
         }}
       />
 

--- a/src/app/security/page.tsx
+++ b/src/app/security/page.tsx
@@ -112,7 +112,7 @@ export default function Security() {
         description="Filecoin Foundation offers bug bounties for reported security vulnerabilities on the Filecoin protocol. Earn up to 150,000 USD, paid in USD/USDC, for reporting critical vulnerabilities. Since launching our Bug Bounty program, we’ve paid out more than $400,000 in rewards."
         cta={{
           text: 'Filecoin Foundation Bug Bounty',
-          href: FILECOIN_FOUNDATION_URLS.security.documents.bugBountyProgram,
+          href: PATHS.BUG_BOUNTY_PROGRAM.path,
         }}
       />
 

--- a/src/content/pages/security/bug-bounty.md
+++ b/src/content/pages/security/bug-bounty.md
@@ -3,7 +3,7 @@ header:
   title: "Bug Bounty Program"
   description:
     [
-      "Filecoin Foundation is deeply committed to the integrity and security of the Filecoin network. With that in mind, we launched a bug bounty program for reported security vulnerabilities on the Filecoin protocol. Earn up to 150,000 USD, paid in USD/USDC, for reporting critical vulnerabilities",
+      "Filecoin Foundation is deeply committed to the integrity and security of the Filecoin network. With that in mind, we launched a bug bounty program for reported security vulnerabilities on the Filecoin protocol. Earn up to 150,000 USD, paid in USD/USDC, for reporting critical vulnerabilities.",
       "Since launching our bug bounty program, we have worked with over 100 researchers and paid out more than $400,000 in rewards –– recognizing external efforts in strengthening our network’s security.",
     ]
 seo:

--- a/src/content/pages/security/bug-bounty.md
+++ b/src/content/pages/security/bug-bounty.md
@@ -1,0 +1,12 @@
+---
+header:
+  title: "Bug Bounty Program"
+  description:
+    [
+      "Filecoin Foundation is deeply committed to the integrity and security of the Filecoin network. With that in mind, we launched a bug bounty program for reported security vulnerabilities on the Filecoin protocol. Earn up to 150,000 USD, paid in USD/USDC, for reporting critical vulnerabilities",
+      "Since launching our bug bounty program, we have worked with over 100 researchers and paid out more than $400,000 in rewards –– recognizing external efforts in strengthening our network’s security.",
+    ]
+seo:
+  title: "Bug Bounty Program"
+  description: Filecoin Foundation is deeply committed to the integrity and security of the Filecoin network. Earn up to 150,000 USD, paid in USD/USDC, for reporting critical vulnerabilities.
+---

--- a/templates/test_spec.cy.ts
+++ b/templates/test_spec.cy.ts
@@ -4,9 +4,7 @@ import { verifyLinks } from '@/support/verifyLinksUtil'
 
 describe('__PAGE_NAME_START_CASE__ Page', () => {
   it('should check metadata', () => {
-    testPageMetadata({
-      path: PATHS.__PATH_NAME__
-    })
+    testPageMetadata(PATHS.__PATH_NAME__)
   })
 
   it('should check links', () => {


### PR DESCRIPTION
## 📝 Description

This PR adds the Bug Bounty page with a page header. The leaderboard will be added in the following PR.

## 🛠️ Key Changes
- Adds `security/bug-bounty/page.tsx` and removes the redirect to the Immunefi page
- Refactors `testPageMetadata` to accept one mandatory parameter and an optional config object.

## 🧪 How to Test

Go to `/security/bug-bounty` and make sure the page works

## 📸 Screenshots

![CleanShot 2024-08-28 at 10 10 29@2x](https://github.com/user-attachments/assets/4e7888fa-eacb-44b1-824c-543bd76c0f93)
