### PR TITLE
[UXIT-1421] Fix import order

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -52,6 +52,36 @@
             "position": "before"
           },
           {
+            "pattern": "@/types/**",
+            "group": "internal",
+            "position": "before"
+          },
+          {
+            "pattern": "@/constants/**",
+            "group": "internal",
+            "position": "before"
+          },
+          {
+            "pattern": "@/content/**",
+            "group": "internal",
+            "position": "before"
+          },
+          {
+            "pattern": "@/data/**",
+            "group": "internal",
+            "position": "before"
+          },
+          {
+            "pattern": "@/utils/**",
+            "group": "internal",
+            "position": "before"
+          },
+          {
+            "pattern": "@/schemas/**",
+            "group": "internal",
+            "position": "before"
+          },
+          {
             "pattern": "@/hooks/**",
             "group": "internal",
             "position": "before"
@@ -63,31 +93,6 @@
           },
           {
             "pattern": "@/styles/**",
-            "group": "internal",
-            "position": "before"
-          },
-          {
-            "pattern": "@/types/**",
-            "group": "internal",
-            "position": "before"
-          },
-          {
-            "pattern": "@/schemas/**",
-            "group": "internal",
-            "position": "before"
-          },
-          {
-            "pattern": "@/utils/**",
-            "group": "internal",
-            "position": "before"
-          },
-          {
-            "pattern": "@/data/**",
-            "group": "internal",
-            "position": "before"
-          },
-          {
-            "pattern": "@/content/**",
             "group": "internal",
             "position": "before"
           },

--- a/src/app/_components/ArticleHeader.tsx
+++ b/src/app/_components/ArticleHeader.tsx
@@ -1,11 +1,11 @@
-import { DynamicImage } from '@/components/DynamicImage'
-import { type HeadingProps, Heading } from '@/components/Heading'
-
 import type { ImageProps } from '@/types/sharedProps/imageType'
+
+import { graphicsData } from '@/data/graphicsData'
 
 import { buildImageSizeProp } from '@/utils/buildImageSizeProp'
 
-import { graphicsData } from '@/data/graphicsData'
+import { DynamicImage } from '@/components/DynamicImage'
+import { type HeadingProps, Heading } from '@/components/Heading'
 
 type ArticleHeaderProps = {
   image?: ImageProps

--- a/src/app/_components/BreadCrumbs.tsx
+++ b/src/app/_components/BreadCrumbs.tsx
@@ -7,11 +7,11 @@ import { CaretRight } from '@phosphor-icons/react/dist/ssr'
 import { clsx } from 'clsx'
 import type { Route } from 'next'
 
-import { Icon } from '@/components/Icon'
+import { PATHS } from '@/constants/paths'
 
 import { capitalize } from '@/utils/capitalize'
 
-import { PATHS } from '@/constants/paths'
+import { Icon } from '@/components/Icon'
 
 export function BreadCrumbs() {
   const pathname = usePathname()

--- a/src/app/_components/Button.tsx
+++ b/src/app/_components/Button.tsx
@@ -1,10 +1,10 @@
 import { ArrowUpRight } from '@phosphor-icons/react/dist/ssr'
 import { clsx } from 'clsx'
 
+import { isExternalLink } from '@/utils/linkUtils'
+
 import { CustomLink, type CustomLinkProps } from '@/components/CustomLink'
 import { Icon as IconComponent, type IconProps } from '@/components/Icon'
-
-import { isExternalLink } from '@/utils/linkUtils'
 
 const variantStyles = {
   primary:

--- a/src/app/_components/CTAButtonGroup.tsx
+++ b/src/app/_components/CTAButtonGroup.tsx
@@ -1,8 +1,8 @@
 import { clsx } from 'clsx'
 
-import { Button } from '@/components/Button'
-
 import type { CTAProps } from '@/types/sharedProps/ctaType'
+
+import { Button } from '@/components/Button'
 
 export type CTAButtonGroupProps = {
   cta: CTAProps | [CTAProps, CTAProps]

--- a/src/app/_components/Card.tsx
+++ b/src/app/_components/Card.tsx
@@ -2,6 +2,10 @@ import { ArrowUpRight } from '@phosphor-icons/react/dist/ssr'
 import { clsx } from 'clsx'
 import theme from 'tailwindcss/defaultTheme'
 
+import { type CTAProps } from '@/types/sharedProps/ctaType'
+
+import { isExternalLink } from '@/utils/linkUtils'
+
 import { CustomLink } from '@/components/CustomLink'
 import { DynamicImage, type DynamicImageProps } from '@/components/DynamicImage'
 import { Heading } from '@/components/Heading'
@@ -9,10 +13,6 @@ import { Icon } from '@/components/Icon'
 import { Meta, type MetaDataType } from '@/components/Meta'
 import { StaticImage, type StaticImageProps } from '@/components/StaticImage'
 import { type TagGroupProps, TagGroup } from '@/components/TagGroup'
-
-import { type CTAProps } from '@/types/sharedProps/ctaType'
-
-import { isExternalLink } from '@/utils/linkUtils'
 
 type CardProps = {
   title: string | React.ReactNode

--- a/src/app/_components/Category.tsx
+++ b/src/app/_components/Category.tsx
@@ -2,16 +2,16 @@
 
 import { useEffect, useState } from 'react'
 
+import type { CategoryOption, CategoryId } from '@/types/categoryTypes'
+
+import { DEFAULT_CATEGORY } from '@/constants/categoryConstants'
+import { CATEGORY_KEY } from '@/constants/searchParams'
+
 import { useCategory } from '@/hooks/useCategory'
 import { useUpdateSearchParams } from '@/hooks/useUpdateSearchParams'
 
 import { CategoryListbox } from '@/components/CategoryListbox'
 import { CategorySidebar } from '@/components/CategorySidebar'
-
-import type { CategoryOption, CategoryId } from '@/types/categoryTypes'
-
-import { DEFAULT_CATEGORY } from '@/constants/categoryConstants'
-import { CATEGORY_KEY } from '@/constants/searchParams'
 
 type CategoryProps = {
   query: ReturnType<typeof useCategory>['categoryQuery']

--- a/src/app/_components/CategoryListbox.tsx
+++ b/src/app/_components/CategoryListbox.tsx
@@ -3,20 +3,20 @@
 import { Listbox } from '@headlessui/react'
 import { CaretDown } from '@phosphor-icons/react/dist/ssr'
 
-import { Icon } from '@/components/Icon'
-import { ListboxButton } from '@/components/ListboxButton'
-import { ListboxOption } from '@/components/ListboxOption'
-import { ListboxOptions } from '@/components/ListboxOptions'
-
 import {
   type CategoryCounts,
   type CategoryId,
   type CategoryOption,
 } from '@/types/categoryTypes'
 
+import { DEFAULT_CATEGORY } from '@/constants/categoryConstants'
+
 import { getTotalCategoryCount } from '@/utils/getTotalCategoryCount'
 
-import { DEFAULT_CATEGORY } from '@/constants/categoryConstants'
+import { Icon } from '@/components/Icon'
+import { ListboxButton } from '@/components/ListboxButton'
+import { ListboxOption } from '@/components/ListboxOption'
+import { ListboxOptions } from '@/components/ListboxOptions'
 
 type CategoryListboxProps = {
   selected: CategoryId | undefined

--- a/src/app/_components/CategoryResetButton.tsx
+++ b/src/app/_components/CategoryResetButton.tsx
@@ -1,13 +1,13 @@
 'use client'
 
+import { DEFAULT_CATEGORY } from '@/constants/categoryConstants'
+
+import { getTotalCategoryCount } from '@/utils/getTotalCategoryCount'
+
 import { useCategory } from '@/hooks/useCategory'
 import { useUpdateSearchParams } from '@/hooks/useUpdateSearchParams'
 
 import { CategorySidebar } from '@/components/CategorySidebar'
-
-import { getTotalCategoryCount } from '@/utils/getTotalCategoryCount'
-
-import { DEFAULT_CATEGORY } from '@/constants/categoryConstants'
 
 type CategoryResetButtonProps = {
   counts: ReturnType<typeof useCategory>['categoryCounts']

--- a/src/app/_components/DesktopNavigation.tsx
+++ b/src/app/_components/DesktopNavigation.tsx
@@ -7,14 +7,14 @@ import { ArrowUpRight } from '@phosphor-icons/react'
 import { clsx } from 'clsx'
 import type { Route } from 'next'
 
+import { PATHS } from '@/constants/paths'
+
+import { desktopNavigationItems } from '@/data/components/navigationData'
+
 import { useNavigationItems } from '@/hooks/useNavigationItems'
 
 import { Icon } from '@/components/Icon'
 import { NavigationPopover } from '@/components/NavigationPopover'
-
-import { desktopNavigationItems } from '@/data/components/navigationData'
-
-import { PATHS } from '@/constants/paths'
 
 type MainNavItemProps = {
   href: Route

--- a/src/app/_components/DynamicImage.tsx
+++ b/src/app/_components/DynamicImage.tsx
@@ -2,9 +2,9 @@ import Image, { type ImageProps } from 'next/image'
 
 import { clsx } from 'clsx'
 
-import { StaticImage, type StaticImageProps } from '@/components/StaticImage'
-
 import type { ImageObjectFit } from '@/types/sharedProps/imageType'
+
+import { StaticImage, type StaticImageProps } from '@/components/StaticImage'
 
 export type DynamicImageProps = {
   src: string

--- a/src/app/_components/ErrorMessage.tsx
+++ b/src/app/_components/ErrorMessage.tsx
@@ -1,10 +1,10 @@
-import { Button } from '@/components/Button'
-import { DescriptionText } from '@/components/DescriptionText'
-import { Heading } from '@/components/Heading'
-
 import { type CTAProps } from '@/types/sharedProps/ctaType'
 
 import { PATHS } from '@/constants/paths'
+
+import { Button } from '@/components/Button'
+import { DescriptionText } from '@/components/DescriptionText'
+import { Heading } from '@/components/Heading'
 
 type ErrorMessageProps = {
   kicker: string

--- a/src/app/_components/FeaturedBlogPosts.tsx
+++ b/src/app/_components/FeaturedBlogPosts.tsx
@@ -1,5 +1,6 @@
-import { Card } from '@/components/Card'
-import { CardGrid } from '@/components/CardGrid'
+import { PATHS } from '@/constants/paths'
+
+import { graphicsData } from '@/data/graphicsData'
 
 import { buildImageSizeProp } from '@/utils/buildImageSizeProp'
 import { getCategoryLabel } from '@/utils/categoryUtils'
@@ -7,9 +8,8 @@ import { getBlogPostsData } from '@/utils/getBlogPostData'
 import { getBlogPostMetaData } from '@/utils/getMetaData'
 import { sortEntriesByDate } from '@/utils/sortEntriesByDate'
 
-import { graphicsData } from '@/data/graphicsData'
-
-import { PATHS } from '@/constants/paths'
+import { Card } from '@/components/Card'
+import { CardGrid } from '@/components/CardGrid'
 
 const blogPosts = getBlogPostsData()
 const MAX_POSTS = 4

--- a/src/app/_components/FeaturedEcosystemProjects.tsx
+++ b/src/app/_components/FeaturedEcosystemProjects.tsx
@@ -1,15 +1,15 @@
 import { MagnifyingGlass } from '@phosphor-icons/react/dist/ssr'
 
-import { Card } from '@/components/Card'
-import { CardGrid } from '@/components/CardGrid'
-
 import type { EcosystemProject } from '@/types/ecosystemProjectType'
 
-import { buildImageSizeProp } from '@/utils/buildImageSizeProp'
+import { PATHS } from '@/constants/paths'
 
 import { graphicsData } from '@/data/graphicsData'
 
-import { PATHS } from '@/constants/paths'
+import { buildImageSizeProp } from '@/utils/buildImageSizeProp'
+
+import { Card } from '@/components/Card'
+import { CardGrid } from '@/components/CardGrid'
 
 type FeaturedEcosystemProjectsProps = {
   ecosystemProjects: Array<EcosystemProject>

--- a/src/app/_components/FeaturedGrantGraduates.tsx
+++ b/src/app/_components/FeaturedGrantGraduates.tsx
@@ -1,15 +1,15 @@
 import { BookOpen } from '@phosphor-icons/react/dist/ssr'
 
-import { Card } from '@/components/Card'
-import { CardGrid } from '@/components/CardGrid'
-
 import type { EcosystemProject } from '@/types/ecosystemProjectType'
 
-import { buildImageSizeProp } from '@/utils/buildImageSizeProp'
+import { PATHS } from '@/constants/paths'
 
 import { graphicsData } from '@/data/graphicsData'
 
-import { PATHS } from '@/constants/paths'
+import { buildImageSizeProp } from '@/utils/buildImageSizeProp'
+
+import { Card } from '@/components/Card'
+import { CardGrid } from '@/components/CardGrid'
 
 type FeaturedGrantsGraduatesProps = {
   grantGraduates: Array<EcosystemProject>

--- a/src/app/_components/FocusAreaCard.tsx
+++ b/src/app/_components/FocusAreaCard.tsx
@@ -1,7 +1,7 @@
+import { buildImageSizeProp } from '@/utils/buildImageSizeProp'
+
 import { Heading } from '@/components/Heading'
 import { StaticImage, type StaticImageProps } from '@/components/StaticImage'
-
-import { buildImageSizeProp } from '@/utils/buildImageSizeProp'
 
 export type FocusAreaCardProps = {
   title: string

--- a/src/app/_components/Footer.tsx
+++ b/src/app/_components/Footer.tsx
@@ -1,9 +1,9 @@
+import { footerNavigationItems } from '@/constants/navigationItems'
+
 import { Logo } from '@/components/Logo'
 import { NewsletterForm } from '@/components/NewsletterForm'
 import { Social } from '@/components/Social'
 import { TextLink } from '@/components/TextLink'
-
-import { footerNavigationItems } from '@/constants/navigationItems'
 
 export function Footer() {
   return (

--- a/src/app/_components/GovernanceCalendarCards.tsx
+++ b/src/app/_components/GovernanceCalendarCards.tsx
@@ -6,14 +6,14 @@ import { Clock, CalendarPlus } from '@phosphor-icons/react/dist/ssr'
 import useSWR from 'swr'
 import { z } from 'zod'
 
+import { GOOGLE_CALENDAR_API_URL } from '@/constants/apiUrls'
+
+import { formatDateComponentsFromISO } from '@/utils/dateUtils'
+
 import { Card } from '@/components/Card'
 import { CardGrid } from '@/components/CardGrid'
 import { Heading } from '@/components/Heading'
 import { TagLabel } from '@/components/TagLabel'
-
-import { formatDateComponentsFromISO } from '@/utils/dateUtils'
-
-import { GOOGLE_CALENDAR_API_URL } from '@/constants/apiUrls'
 
 type CalendarProps = {
   startDate: string

--- a/src/app/_components/HomeExploreSectionCard.tsx
+++ b/src/app/_components/HomeExploreSectionCard.tsx
@@ -1,9 +1,9 @@
 import { clsx } from 'clsx'
 
+import { type CTAProps } from '@/types/sharedProps/ctaType'
+
 import { Card } from '@/components/Card'
 import { type HeadingProps, Heading } from '@/components/Heading'
-
-import { type CTAProps } from '@/types/sharedProps/ctaType'
 
 type HomeExploreSectionCardProps = {
   heading: HeadingProps

--- a/src/app/_components/KeyMemberCard.tsx
+++ b/src/app/_components/KeyMemberCard.tsx
@@ -1,10 +1,10 @@
 import { LinkedinLogo } from '@phosphor-icons/react/dist/ssr'
 
+import type { MemberData } from '@/types/memberType'
+
 import { Card } from '@/components/Card'
 import { Heading } from '@/components/Heading'
 import { StaticImage } from '@/components/StaticImage'
-
-import type { MemberData } from '@/types/memberType'
 
 type KeyMemberCardProps = MemberData
 

--- a/src/app/_components/ListboxOption.tsx
+++ b/src/app/_components/ListboxOption.tsx
@@ -4,9 +4,9 @@ import { Listbox } from '@headlessui/react'
 import { Check } from '@phosphor-icons/react'
 import { clsx } from 'clsx'
 
-import { Icon } from '@/components/Icon'
-
 import { type CategoryCounts } from '@/types/categoryTypes'
+
+import { Icon } from '@/components/Icon'
 
 type Option = {
   id: string

--- a/src/app/_components/MarkdownContent.tsx
+++ b/src/app/_components/MarkdownContent.tsx
@@ -1,11 +1,11 @@
 import ReactMarkdown from 'react-markdown'
 import rehypeRaw from 'rehype-raw'
 
-import { DynamicImage } from '@/components/DynamicImage'
+import { graphicsData } from '@/data/graphicsData'
 
 import { buildImageSizeProp } from '@/utils/buildImageSizeProp'
 
-import { graphicsData } from '@/data/graphicsData'
+import { DynamicImage } from '@/components/DynamicImage'
 
 type MarkdownContentProps = {
   children: string

--- a/src/app/_components/MobileNavigation.tsx
+++ b/src/app/_components/MobileNavigation.tsx
@@ -8,16 +8,16 @@ import { ArrowUpRight, List, X } from '@phosphor-icons/react'
 import { clsx } from 'clsx'
 import type { Route } from 'next'
 
+import { mobileNavigationItems } from '@/constants/navigationItems'
+import { PATHS } from '@/constants/paths'
+
+import { isExternalLink } from '@/utils/linkUtils'
+
 import { Icon, type IconProps } from '@/components/Icon'
 import { Logo } from '@/components/Logo'
 import { SlideOver } from '@/components/SlideOver'
 import { Social } from '@/components/Social'
 import { linkBaseStyles } from '@/components/TextLink'
-
-import { isExternalLink } from '@/utils/linkUtils'
-
-import { mobileNavigationItems } from '@/constants/navigationItems'
-import { PATHS } from '@/constants/paths'
 
 type IconButtonProps = {
   icon: IconProps['component']

--- a/src/app/_components/Navigation.tsx
+++ b/src/app/_components/Navigation.tsx
@@ -1,10 +1,10 @@
 import Link from 'next/link'
 
+import { PATHS } from '@/constants/paths'
+
 import { DesktopNavigation } from '@/components/DesktopNavigation'
 import { Logo } from '@/components/Logo'
 import { MobileNavigation } from '@/components/MobileNavigation'
-
-import { PATHS } from '@/constants/paths'
 
 export function Navigation() {
   return (

--- a/src/app/_components/OrbitAmbassadorCard.tsx
+++ b/src/app/_components/OrbitAmbassadorCard.tsx
@@ -1,9 +1,9 @@
 import { clsx } from 'clsx'
 
+import { buildImageSizeProp } from '@/utils/buildImageSizeProp'
+
 import { BasicCard } from '@/components/BasicCard'
 import { StaticImage } from '@/components/StaticImage'
-
-import { buildImageSizeProp } from '@/utils/buildImageSizeProp'
 
 import type { AmbassadorData } from '@/orbit/data/ambassadorsData'
 

--- a/src/app/_components/PageHeader.tsx
+++ b/src/app/_components/PageHeader.tsx
@@ -1,5 +1,7 @@
 import { clsx } from 'clsx'
 
+import { buildImageSizeProp } from '@/utils/buildImageSizeProp'
+
 import {
   type CTAButtonGroupProps,
   CTAButtonGroup,
@@ -13,8 +15,6 @@ import { Heading } from '@/components/Heading'
 import { Meta, type MetaDataType } from '@/components/Meta'
 import { SectionDivider } from '@/components/SectionDivider'
 import { StaticImage, type StaticImageProps } from '@/components/StaticImage'
-
-import { buildImageSizeProp } from '@/utils/buildImageSizeProp'
 
 type TitleProps = {
   children: string

--- a/src/app/_components/PageSection.tsx
+++ b/src/app/_components/PageSection.tsx
@@ -1,5 +1,7 @@
 import { clsx } from 'clsx'
 
+import { buildImageSizeProp } from '@/utils/buildImageSizeProp'
+
 import {
   type CTAButtonGroupProps,
   CTAButtonGroup,
@@ -14,8 +16,6 @@ import {
   type SectionDividerProps,
 } from '@/components/SectionDivider'
 import { StaticImage, type StaticImageProps } from '@/components/StaticImage'
-
-import { buildImageSizeProp } from '@/utils/buildImageSizeProp'
 
 type PageSectionProps = {
   kicker: SectionDividerProps['title']

--- a/src/app/_components/Pagination.tsx
+++ b/src/app/_components/Pagination.tsx
@@ -6,15 +6,15 @@ import { CaretLeft, CaretRight, LineVertical } from '@phosphor-icons/react'
 import { clsx } from 'clsx'
 import { useDebounceCallback } from 'usehooks-ts'
 
+import { DEFAULT_PAGE_NUMBER } from '@/constants/paginationConstants'
+import { PAGE_KEY } from '@/constants/searchParams'
+
 import { usePagination } from '@/hooks/usePagination'
 import { useResponsiveRange } from '@/hooks/useResponsiveRange'
 import { useUpdateSearchParams } from '@/hooks/useUpdateSearchParams'
 import { useVisiblePages } from '@/hooks/useVisiblePages'
 
 import { Icon } from '@/components/Icon'
-
-import { DEFAULT_PAGE_NUMBER } from '@/constants/paginationConstants'
-import { PAGE_KEY } from '@/constants/searchParams'
 
 type PaginationProps = {
   pageCount: ReturnType<typeof usePagination>['pageCount']

--- a/src/app/_components/Search.tsx
+++ b/src/app/_components/Search.tsx
@@ -6,13 +6,13 @@ import { useSearchParams } from 'next/navigation'
 
 import { useDebounceCallback } from 'usehooks-ts'
 
+import { DEFAULT_PAGE_NUMBER } from '@/constants/paginationConstants'
+import { PAGE_KEY, SEARCH_KEY } from '@/constants/searchParams'
+
 import { useSearch } from '@/hooks/useSearch'
 import { useUpdateSearchParams } from '@/hooks/useUpdateSearchParams'
 
 import { SearchInput } from '@/components/SearchInput'
-
-import { DEFAULT_PAGE_NUMBER } from '@/constants/paginationConstants'
-import { PAGE_KEY, SEARCH_KEY } from '@/constants/searchParams'
 
 export type SearchProps = {
   query: ReturnType<typeof useSearch>['searchQuery']

--- a/src/app/_components/Social.tsx
+++ b/src/app/_components/Social.tsx
@@ -1,8 +1,8 @@
 import { clsx } from 'clsx'
 
-import { Icon } from '@/components/Icon'
-
 import { socialLinksWithIcons } from '@/utils/socialConfig'
+
+import { Icon } from '@/components/Icon'
 
 const touchTarget = {
   class: 'p-2',

--- a/src/app/_components/Sort.tsx
+++ b/src/app/_components/Sort.tsx
@@ -2,11 +2,6 @@
 
 import { useState, useEffect } from 'react'
 
-import { useSort } from '@/hooks/useSort'
-import { useUpdateSearchParams } from '@/hooks/useUpdateSearchParams'
-
-import { SortListbox } from '@/components/SortListbox'
-
 import {
   type DefaultSortType,
   type SortId,
@@ -14,6 +9,11 @@ import {
 } from '@/types/sortTypes'
 
 import { SORT_KEY } from '@/constants/searchParams'
+
+import { useSort } from '@/hooks/useSort'
+import { useUpdateSearchParams } from '@/hooks/useUpdateSearchParams'
+
+import { SortListbox } from '@/components/SortListbox'
 
 type SortProps = {
   query: ReturnType<typeof useSort>['sortQuery']

--- a/src/app/_components/SortListbox.tsx
+++ b/src/app/_components/SortListbox.tsx
@@ -3,12 +3,12 @@
 import { Listbox } from '@headlessui/react'
 import { ArrowsDownUp, CaretDown } from '@phosphor-icons/react/dist/ssr'
 
+import { type SortOption, type SortId } from '@/types/sortTypes'
+
 import { Icon } from '@/components/Icon'
 import { ListboxButton } from '@/components/ListboxButton'
 import { ListboxOption } from '@/components/ListboxOption'
 import { ListboxOptions } from '@/components/ListboxOptions'
-
-import { type SortOption, type SortId } from '@/types/sortTypes'
 
 type SortListboxProps = {
   sortId: SortId

--- a/src/app/_components/TextLink.tsx
+++ b/src/app/_components/TextLink.tsx
@@ -3,10 +3,10 @@
 import { ArrowUpRight } from '@phosphor-icons/react'
 import { clsx } from 'clsx'
 
+import { isExternalLink } from '@/utils/linkUtils'
+
 import { CustomLink } from '@/components/CustomLink'
 import { Icon } from '@/components/Icon'
-
-import { isExternalLink } from '@/utils/linkUtils'
 
 type TextLinkProps = {
   href: string

--- a/src/app/_constants/structuredDataConstants.ts
+++ b/src/app/_constants/structuredDataConstants.ts
@@ -1,12 +1,12 @@
 import type { Organization, WithContext } from 'schema-dts'
 
-import { attributes } from '@/content/pages/about.md'
-
 import {
   BASE_URL,
   FILECOIN_FOUNDATION_URLS,
   ORGANIZATION_NAME,
 } from '@/constants/siteMetadata'
+
+import { attributes } from '@/content/pages/about.md'
 
 const { header } = attributes
 const { social, email } = FILECOIN_FOUNDATION_URLS

--- a/src/app/_data/homepage/filecoinEcosystemData.ts
+++ b/src/app/_data/homepage/filecoinEcosystemData.ts
@@ -1,9 +1,10 @@
 import { Code, HardDrives, Money, Person } from '@phosphor-icons/react/dist/ssr'
 
-import type { IconProps } from '@/components/Icon'
 
 import { PATHS } from '@/constants/paths'
 import { FILECOIN_DOCS_URLS } from '@/constants/siteMetadata'
+
+import type { IconProps } from '@/components/Icon'
 
 interface FilecoinEcosystemData {
   heading: {

--- a/src/app/_hooks/useCategory.ts
+++ b/src/app/_hooks/useCategory.ts
@@ -4,9 +4,9 @@ import { type CategoryCounts, type CategoryId } from '@/types/categoryTypes'
 import { type NextServerSearchParams } from '@/types/searchParams'
 import { type Object } from '@/types/utils'
 
-import { normalizeQueryParam } from '@/utils/queryUtils'
-
 import { CATEGORY_KEY } from '@/constants/searchParams'
+
+import { normalizeQueryParam } from '@/utils/queryUtils'
 
 export type UseCategoryProps<Entry extends Object> = {
   searchParams: NextServerSearchParams

--- a/src/app/_hooks/useEventsCategory.ts
+++ b/src/app/_hooks/useEventsCategory.ts
@@ -2,13 +2,13 @@ import { useMemo } from 'react'
 
 import { isBefore } from 'date-fns'
 
-import { type UseCategoryProps, useCategory } from '@/hooks/useCategory'
-
 import type { Event } from '@/types/eventType'
+
+import { pastEventsOption } from '@/constants/categoryConstants'
 
 import { getUTCMidnightToday } from '@/utils/dateUtils'
 
-import { pastEventsOption } from '@/constants/categoryConstants'
+import { type UseCategoryProps, useCategory } from '@/hooks/useCategory'
 
 export function useEventsCategory(props: UseCategoryProps<Event>) {
   const { entries, searchParams, validCategoryIds } = props

--- a/src/app/_hooks/useNavigationItems.ts
+++ b/src/app/_hooks/useNavigationItems.ts
@@ -1,8 +1,8 @@
 import { usePathname } from 'next/navigation'
 
-import { type SubNavItemProps } from '@/components/DesktopNavigation'
-
 import { isInternalLink, isExternalLink } from '@/utils/linkUtils'
+
+import { type SubNavItemProps } from '@/components/DesktopNavigation'
 
 export function useNavigationItems(items: Array<SubNavItemProps>) {
   const pathname = usePathname()

--- a/src/app/_hooks/usePagination.ts
+++ b/src/app/_hooks/usePagination.ts
@@ -3,13 +3,13 @@ import { useMemo } from 'react'
 import { type NextServerSearchParams } from '@/types/searchParams'
 import { type Object } from '@/types/utils'
 
-import { normalizeQueryParam } from '@/utils/queryUtils'
-
 import {
   DEFAULT_ENTRIES_PER_PAGE,
   DEFAULT_PAGE_NUMBER,
 } from '@/constants/paginationConstants'
 import { PAGE_KEY } from '@/constants/searchParams'
+
+import { normalizeQueryParam } from '@/utils/queryUtils'
 
 type UsePaginationProps<Entry extends Object> = {
   searchParams: NextServerSearchParams

--- a/src/app/_hooks/useSearch.ts
+++ b/src/app/_hooks/useSearch.ts
@@ -5,9 +5,9 @@ import slugify from 'slugify'
 import { type NextServerSearchParams } from '@/types/searchParams'
 import { type Object } from '@/types/utils'
 
-import { normalizeQueryParam } from '@/utils/queryUtils'
-
 import { SEARCH_KEY } from '@/constants/searchParams'
+
+import { normalizeQueryParam } from '@/utils/queryUtils'
 
 type UseSearchProps<Entry extends Object> = {
   searchParams: NextServerSearchParams

--- a/src/app/_hooks/useSort.ts
+++ b/src/app/_hooks/useSort.ts
@@ -9,16 +9,16 @@ import type {
 } from '@/types/sortTypes'
 import { type Object } from '@/types/utils'
 
-import { normalizeQueryParam } from '@/utils/queryUtils'
-import { sortEntriesAlphabetically } from '@/utils/sortEntriesAlphabetically'
-import { sortEntriesByDate } from '@/utils/sortEntriesByDate'
-
 import { SORT_KEY } from '@/constants/searchParams'
 import {
   ALPHABETICAL_SORT_IDS,
   CHRONOLOGICAL_SORT_IDS,
   VALID_SORT_IDS,
 } from '@/constants/sortConstants'
+
+import { normalizeQueryParam } from '@/utils/queryUtils'
+import { sortEntriesAlphabetically } from '@/utils/sortEntriesAlphabetically'
+import { sortEntriesByDate } from '@/utils/sortEntriesByDate'
 
 type UseSortProps<Entry extends Object> = {
   searchParams: NextServerSearchParams

--- a/src/app/_schemas/blogPostFrontMatterSchema.ts
+++ b/src/app/_schemas/blogPostFrontMatterSchema.ts
@@ -1,11 +1,11 @@
 import { z } from 'zod'
 
-import { DynamicBaseDataSchema } from '@/schemas/dynamicDataBaseSchema'
-
 import {
   getCategorySettings,
   createCategorySchema,
 } from '@/utils/categoryUtils'
+
+import { DynamicBaseDataSchema } from '@/schemas/dynamicDataBaseSchema'
 
 const { validCategoryIds } = getCategorySettings('blog_posts')
 

--- a/src/app/_schemas/ecosystemProject/CategorySchemas.ts
+++ b/src/app/_schemas/ecosystemProject/CategorySchemas.ts
@@ -1,13 +1,13 @@
 import {
+  ECOSYSTEM_CATEGORIES_DIRECTORY_PATH,
+  ECOSYSTEM_SUBCATEGORIES_DIRECTORY_PATH,
+} from '@/constants/paths'
+
+import {
   createCategorySchema,
   getCategoryDataFromDirectory,
   getCategorySettingsFromMap,
 } from '@/utils/categoryUtils'
-
-import {
-  ECOSYSTEM_CATEGORIES_DIRECTORY_PATH,
-  ECOSYSTEM_SUBCATEGORIES_DIRECTORY_PATH,
-} from '@/constants/paths'
 
 function createSchemaForDirectory(directoryPath: string) {
   const categoryData = getCategoryDataFromDirectory(directoryPath)

--- a/src/app/_schemas/eventFrontMatterSchema.ts
+++ b/src/app/_schemas/eventFrontMatterSchema.ts
@@ -1,11 +1,11 @@
 import { z } from 'zod'
 
-import { DynamicBaseDataSchema } from '@/schemas/dynamicDataBaseSchema'
-
 import {
   getEventsCategorySettings,
   createCategorySchema,
 } from '@/utils/categoryUtils'
+
+import { DynamicBaseDataSchema } from '@/schemas/dynamicDataBaseSchema'
 
 const { validCategoryIds } = getEventsCategorySettings()
 

--- a/src/app/_types/sortTypes.ts
+++ b/src/app/_types/sortTypes.ts
@@ -1,8 +1,8 @@
 import type { Event } from '@/types/eventType'
 
-import type { DynamicBaseData } from '@/schemas/dynamicDataBaseSchema'
-
 import { DEFAULT_SORT_OPTION, SORT_TYPES } from '@/constants/sortConstants'
+
+import type { DynamicBaseData } from '@/schemas/dynamicDataBaseSchema'
 
 type BaseSortType = typeof SORT_TYPES
 

--- a/src/app/_utils/categoryUtils.ts
+++ b/src/app/_utils/categoryUtils.ts
@@ -3,10 +3,10 @@ import { z } from 'zod'
 import { type CategoryMap, type CategoryYAMLData } from '@/types/categoryTypes'
 import { type CMSCollectionName, type CMSFieldOption } from '@/types/cmsConfig'
 
+import { pastEventsOption } from '@/constants/categoryConstants'
+
 import { getCMSFieldOptions, getCollectionConfig } from '@/utils/cmsConfigUtils'
 import { readAndValidateYamlFiles } from '@/utils/yamlUtils'
-
-import { pastEventsOption } from '@/constants/categoryConstants'
 
 type GetCategoryLabelParams = {
   collectionName: CMSCollectionName

--- a/src/app/_utils/getBlogPostData.ts
+++ b/src/app/_utils/getBlogPostData.ts
@@ -1,7 +1,7 @@
+import { PATHS } from '@/constants/paths'
+
 import { convertMarkdownToBlogPostData } from '@/utils/covertMarkdowntoBlogPostData'
 import { getData, getAllData } from '@/utils/getData'
-
-import { PATHS } from '@/constants/paths'
 
 const BLOG_DIRECTORY_PATH = PATHS.BLOG.entriesContentPath as string
 

--- a/src/app/_utils/getDigestArticleData.ts
+++ b/src/app/_utils/getDigestArticleData.ts
@@ -1,7 +1,7 @@
+import { PATHS } from '@/constants/paths'
+
 import { convertMarkdownToDigestArticleData } from '@/utils/convertMarkdownToDigestArticleData'
 import { getData, getAllData } from '@/utils/getData'
-
-import { PATHS } from '@/constants/paths'
 
 const DIGEST_DIRECTORY_PATH = PATHS.DIGEST.entriesContentPath as string
 

--- a/src/app/_utils/getEcosystemProjectData.ts
+++ b/src/app/_utils/getEcosystemProjectData.ts
@@ -1,7 +1,7 @@
+import { ECOSYSTEM_PROJECTS_DIRECTORY_PATH } from '@/constants/paths'
+
 import { convertMarkdownToEcosystemProjectData } from '@/utils/convertMarkdownToEcosystemProjectData'
 import { getData, getAllData } from '@/utils/getData'
-
-import { ECOSYSTEM_PROJECTS_DIRECTORY_PATH } from '@/constants/paths'
 
 export function getEcosystemProjectData(slug: string) {
   return getData(

--- a/src/app/_utils/getEventData.ts
+++ b/src/app/_utils/getEventData.ts
@@ -1,7 +1,7 @@
+import { PATHS } from '@/constants/paths'
+
 import { convertMarkdownToEventData } from '@/utils/convertMarkdownToEventData'
 import { getData, getAllData } from '@/utils/getData'
-
-import { PATHS } from '@/constants/paths'
 
 const EVENTS_DIRECTORY_PATH = PATHS.EVENTS.entriesContentPath as string
 

--- a/src/app/_utils/socialConfig.ts
+++ b/src/app/_utils/socialConfig.ts
@@ -5,8 +5,9 @@ import {
   YoutubeLogo,
 } from '@phosphor-icons/react/dist/ssr'
 
-import BlueskyLogo from '@/assets/logos/bluesky-logo.svg'
 import { FILECOIN_FOUNDATION_URLS } from '@/constants/siteMetadata'
+
+import BlueskyLogo from '@/assets/logos/bluesky-logo.svg'
 
 const socialIcons = {
   bluesky: BlueskyLogo,

--- a/src/app/about/data/reportsData.ts
+++ b/src/app/about/data/reportsData.ts
@@ -1,7 +1,8 @@
+import { FILECOIN_FOUNDATION_URLS } from '@/constants/siteMetadata'
+
 import type { StaticImageProps } from '@/components/StaticImage'
 
 import annualReport from '@/assets/images/022624-ff-anualreport.png'
-import { FILECOIN_FOUNDATION_URLS } from '@/constants/siteMetadata'
 
 type ReportData = {
   title: string

--- a/src/app/about/page.tsx
+++ b/src/app/about/page.tsx
@@ -1,6 +1,16 @@
 import { Files } from '@phosphor-icons/react/dist/ssr'
 import { clsx } from 'clsx'
 
+import { PATHS } from '@/constants/paths'
+import { FILECOIN_FOUNDATION_URLS } from '@/constants/siteMetadata'
+
+import { attributes } from '@/content/pages/about.md'
+
+import { graphicsData } from '@/data/graphicsData'
+
+import { buildImageSizeProp } from '@/utils/buildImageSizeProp'
+import { createMetadata } from '@/utils/createMetadata'
+
 import { Card } from '@/components/Card'
 import { CardGrid } from '@/components/CardGrid'
 import { FocusAreaCard } from '@/components/FocusAreaCard'
@@ -9,16 +19,6 @@ import { PageHeader } from '@/components/PageHeader'
 import { PageLayout } from '@/components/PageLayout'
 import { PageSection } from '@/components/PageSection'
 import { StructuredDataScript } from '@/components/StructuredDataScript'
-
-import { buildImageSizeProp } from '@/utils/buildImageSizeProp'
-import { createMetadata } from '@/utils/createMetadata'
-
-import { graphicsData } from '@/data/graphicsData'
-
-import { attributes } from '@/content/pages/about.md'
-
-import { PATHS } from '@/constants/paths'
-import { FILECOIN_FOUNDATION_URLS } from '@/constants/siteMetadata'
 
 import { advisorsData } from './data/advisorsData'
 import { boardMembersData } from './data/boardMembersData'

--- a/src/app/about/utils/generateStructuredData.ts
+++ b/src/app/about/utils/generateStructuredData.ts
@@ -2,10 +2,10 @@ import type { WebPage, WithContext } from 'schema-dts'
 
 import type { SeoMetadata } from '@/types/metadataTypes'
 
-import { generateWebPageStructuredData } from '@/utils/generateWebPageStructuredData'
-
 import { PATHS } from '@/constants/paths'
 import { ORGANIZATION_SCHEMA_BASE } from '@/constants/structuredDataConstants'
+
+import { generateWebPageStructuredData } from '@/utils/generateWebPageStructuredData'
 
 export function generateStructuredData(seo: SeoMetadata): WithContext<WebPage> {
   const baseData = generateWebPageStructuredData({

--- a/src/app/blog/[slug]/components/BlogPostHeader.tsx
+++ b/src/app/blog/[slug]/components/BlogPostHeader.tsx
@@ -1,10 +1,10 @@
-import { ArticleHeader } from '@/components/ArticleHeader'
-import { TagLabel } from '@/components/TagLabel'
-
 import type { BlogPost } from '@/types/blogPostType'
 
 import { getCategoryLabel } from '@/utils/categoryUtils'
 import { formatDate } from '@/utils/dateUtils'
+
+import { ArticleHeader } from '@/components/ArticleHeader'
+import { TagLabel } from '@/components/TagLabel'
 
 type BlogPostHeaderProps = Pick<
   BlogPost,

--- a/src/app/blog/[slug]/page.tsx
+++ b/src/app/blog/[slug]/page.tsx
@@ -1,11 +1,11 @@
-import { MarkdownContent } from '@/components/MarkdownContent'
-import { PageLayout } from '@/components/PageLayout'
-import { StructuredDataScript } from '@/components/StructuredDataScript'
+import { type DynamicPathValues, PATHS } from '@/constants/paths'
 
 import { createMetadata } from '@/utils/createMetadata'
 import { getBlogPostData } from '@/utils/getBlogPostData'
 
-import { type DynamicPathValues, PATHS } from '@/constants/paths'
+import { MarkdownContent } from '@/components/MarkdownContent'
+import { PageLayout } from '@/components/PageLayout'
+import { StructuredDataScript } from '@/components/StructuredDataScript'
 
 import { BlogPostHeader } from './components/BlogPostHeader'
 import { generateStructuredData } from './utils/generateStructuredData'

--- a/src/app/blog/page.tsx
+++ b/src/app/blog/page.tsx
@@ -4,6 +4,23 @@ import dynamic from 'next/dynamic'
 
 import { BookOpen } from '@phosphor-icons/react/dist/ssr'
 
+import { type NextServerSearchParams } from '@/types/searchParams'
+
+import { PATHS } from '@/constants/paths'
+import { DEFAULT_SORT_OPTION } from '@/constants/sortConstants'
+
+import { attributes } from '@/content/pages/blog.md'
+
+import { graphicsData } from '@/data/graphicsData'
+
+import { buildImageSizeProp } from '@/utils/buildImageSizeProp'
+import { getCategorySettings, getCategoryLabel } from '@/utils/categoryUtils'
+import { createMetadata } from '@/utils/createMetadata'
+import { getBlogPostData, getBlogPostsData } from '@/utils/getBlogPostData'
+import { getBlogPostMetaData } from '@/utils/getMetaData'
+import { getSortOptions } from '@/utils/getSortOptions'
+import { hasNoFiltersApplied } from '@/utils/searchParamsUtils'
+
 import { useCategory } from '@/hooks/useCategory'
 import { usePagination } from '@/hooks/usePagination'
 import { useSearch } from '@/hooks/useSearch'
@@ -21,23 +38,6 @@ import { PageSection } from '@/components/PageSection'
 import { Search } from '@/components/Search'
 import { Sort } from '@/components/Sort'
 import { StructuredDataScript } from '@/components/StructuredDataScript'
-
-import { type NextServerSearchParams } from '@/types/searchParams'
-
-import { buildImageSizeProp } from '@/utils/buildImageSizeProp'
-import { getCategorySettings, getCategoryLabel } from '@/utils/categoryUtils'
-import { createMetadata } from '@/utils/createMetadata'
-import { getBlogPostData, getBlogPostsData } from '@/utils/getBlogPostData'
-import { getBlogPostMetaData } from '@/utils/getMetaData'
-import { getSortOptions } from '@/utils/getSortOptions'
-import { hasNoFiltersApplied } from '@/utils/searchParamsUtils'
-
-import { graphicsData } from '@/data/graphicsData'
-
-import { attributes } from '@/content/pages/blog.md'
-
-import { PATHS } from '@/constants/paths'
-import { DEFAULT_SORT_OPTION } from '@/constants/sortConstants'
 
 import { generateStructuredData } from './utils/generateStructuredData'
 

--- a/src/app/blog/utils/generateStructuredData.ts
+++ b/src/app/blog/utils/generateStructuredData.ts
@@ -3,11 +3,11 @@ import type { WebPage, WithContext } from 'schema-dts'
 import type { BlogPost } from '@/types/blogPostType'
 import type { SeoMetadata } from '@/types/metadataTypes'
 
-import { generateWebPageStructuredData } from '@/utils/generateWebPageStructuredData'
-
 import { PATHS } from '@/constants/paths'
 import { BASE_URL, ORGANIZATION_NAME } from '@/constants/siteMetadata'
 import { ORGANIZATION_SCHEMA_BASE } from '@/constants/structuredDataConstants'
+
+import { generateWebPageStructuredData } from '@/utils/generateWebPageStructuredData'
 
 export function generateStructuredData(
   posts: Array<BlogPost>,

--- a/src/app/digest/[slug]/components/DigestArticleHeader.tsx
+++ b/src/app/digest/[slug]/components/DigestArticleHeader.tsx
@@ -1,7 +1,7 @@
+import { type DigestArticleData } from '@/types/digestTypes'
+
 import { ArticleHeader } from '@/components/ArticleHeader'
 import { TagGroup } from '@/components/TagGroup'
-
-import { type DigestArticleData } from '@/types/digestTypes'
 
 type DigestArticleHeaderProps = Pick<
   DigestArticleData,

--- a/src/app/digest/[slug]/page.tsx
+++ b/src/app/digest/[slug]/page.tsx
@@ -1,11 +1,13 @@
-import { MarkdownContent } from '@/components/MarkdownContent'
-import { PageLayout } from '@/components/PageLayout'
-import { StructuredDataScript } from '@/components/StructuredDataScript'
+import { type DynamicPathValues, PATHS } from '@/constants/paths'
 
 import { createMetadata } from '@/utils/createMetadata'
 import { getDigestArticleData } from '@/utils/getDigestArticleData'
 
-import { type DynamicPathValues, PATHS } from '@/constants/paths'
+import { MarkdownContent } from '@/components/MarkdownContent'
+import { PageLayout } from '@/components/PageLayout'
+import { StructuredDataScript } from '@/components/StructuredDataScript'
+
+
 
 import { DigestArticleHeader } from './components/DigestArticleHeader'
 import { generateStructuredData } from './utils/generateStructuredData'

--- a/src/app/digest/[slug]/utils/generateStructuredData.ts
+++ b/src/app/digest/[slug]/utils/generateStructuredData.ts
@@ -2,9 +2,10 @@ import type { WebPage, WithContext } from 'schema-dts'
 
 import type { DigestArticleData } from '@/types/digestTypes'
 
+import { type DynamicPathValues, PATHS } from '@/constants/paths'
+
 import { generateWebPageStructuredData } from '@/utils/generateWebPageStructuredData'
 
-import { type DynamicPathValues, PATHS } from '@/constants/paths'
 
 export function generateStructuredData(
   data: DigestArticleData,

--- a/src/app/digest/page.tsx
+++ b/src/app/digest/page.tsx
@@ -1,5 +1,18 @@
 import { BookOpen } from '@phosphor-icons/react/dist/ssr'
 
+import { PATHS } from '@/constants/paths'
+import { FILECOIN_FOUNDATION_URLS } from '@/constants/siteMetadata'
+
+import { attributes } from '@/content/pages/digest.md'
+
+import { graphicsData } from '@/data/graphicsData'
+
+import { buildImageSizeProp } from '@/utils/buildImageSizeProp'
+import { createMetadata } from '@/utils/createMetadata'
+import { getDigestArticlesData } from '@/utils/getDigestArticleData'
+
+
+
 import { Card } from '@/components/Card'
 import { CardGrid } from '@/components/CardGrid'
 import { CTASection } from '@/components/CTASection'
@@ -8,16 +21,9 @@ import { PageLayout } from '@/components/PageLayout'
 import { PageSection } from '@/components/PageSection'
 import { StructuredDataScript } from '@/components/StructuredDataScript'
 
-import { buildImageSizeProp } from '@/utils/buildImageSizeProp'
-import { createMetadata } from '@/utils/createMetadata'
-import { getDigestArticlesData } from '@/utils/getDigestArticleData'
 
-import { graphicsData } from '@/data/graphicsData'
 
-import { attributes } from '@/content/pages/digest.md'
 
-import { PATHS } from '@/constants/paths'
-import { FILECOIN_FOUNDATION_URLS } from '@/constants/siteMetadata'
 
 import { generateStructuredData } from './utils/generateStructuredData'
 import { sortArticlesByNumber } from './utils/sortArticlesByNumber'

--- a/src/app/digest/utils/generateStructuredData.tsx
+++ b/src/app/digest/utils/generateStructuredData.tsx
@@ -2,9 +2,9 @@ import type { WebPage, WithContext } from 'schema-dts'
 
 import type { SeoMetadata } from '@/types/metadataTypes'
 
-import { generateWebPageStructuredData } from '@/utils/generateWebPageStructuredData'
-
 import { PATHS } from '@/constants/paths'
+
+import { generateWebPageStructuredData } from '@/utils/generateWebPageStructuredData'
 
 export function generateStructuredData(seo: SeoMetadata): WithContext<WebPage> {
   return generateWebPageStructuredData({

--- a/src/app/ecosystem-explorer/[slug]/page.tsx
+++ b/src/app/ecosystem-explorer/[slug]/page.tsx
@@ -1,5 +1,20 @@
 import { BookOpen, GitFork, Globe, XLogo } from '@phosphor-icons/react/dist/ssr'
 
+import {
+  type DynamicPathValues,
+  PATHS,
+  ECOSYSTEM_CATEGORIES_DIRECTORY_PATH,
+  ECOSYSTEM_SUBCATEGORIES_DIRECTORY_PATH,
+} from '@/constants/paths'
+
+import { graphicsData } from '@/data/graphicsData'
+
+import { buildImageSizeProp } from '@/utils/buildImageSizeProp'
+import { getCategoryDataFromDirectory } from '@/utils/categoryUtils'
+import { createMetadata } from '@/utils/createMetadata'
+import { formatDate } from '@/utils/dateUtils'
+import { getEcosystemProjectData } from '@/utils/getEcosystemProjectData'
+
 import { DescriptionText } from '@/components/DescriptionText'
 import { DynamicImage } from '@/components/DynamicImage'
 import { Heading } from '@/components/Heading'
@@ -8,21 +23,6 @@ import { MarkdownContent } from '@/components/MarkdownContent'
 import { StructuredDataScript } from '@/components/StructuredDataScript'
 import { TagLabel } from '@/components/TagLabel'
 import { TextLink } from '@/components/TextLink'
-
-import { buildImageSizeProp } from '@/utils/buildImageSizeProp'
-import { getCategoryDataFromDirectory } from '@/utils/categoryUtils'
-import { createMetadata } from '@/utils/createMetadata'
-import { formatDate } from '@/utils/dateUtils'
-import { getEcosystemProjectData } from '@/utils/getEcosystemProjectData'
-
-import { graphicsData } from '@/data/graphicsData'
-
-import {
-  type DynamicPathValues,
-  PATHS,
-  ECOSYSTEM_CATEGORIES_DIRECTORY_PATH,
-  ECOSYSTEM_SUBCATEGORIES_DIRECTORY_PATH,
-} from '@/constants/paths'
 
 import { VideoSection } from './components/VideoSection'
 import { generateStructuredData } from './utils/generateStructuredData'

--- a/src/app/ecosystem-explorer/[slug]/utils/generateStructuredData.ts
+++ b/src/app/ecosystem-explorer/[slug]/utils/generateStructuredData.ts
@@ -1,8 +1,8 @@
 import type { EcosystemProject } from '@/types/ecosystemProjectType'
 
-import { generateWebPageStructuredData } from '@/utils/generateWebPageStructuredData'
-
 import { type DynamicPathValues, PATHS } from '@/constants/paths'
+
+import { generateWebPageStructuredData } from '@/utils/generateWebPageStructuredData'
 
 export function generateStructuredData(data: EcosystemProject) {
   const { seo } = data

--- a/src/app/ecosystem-explorer/page.tsx
+++ b/src/app/ecosystem-explorer/page.tsx
@@ -2,6 +2,25 @@ import dynamic from 'next/dynamic'
 
 import { BookOpen } from '@phosphor-icons/react/dist/ssr'
 
+import type { NextServerSearchParams } from '@/types/searchParams'
+
+import { PATHS, ECOSYSTEM_CATEGORIES_DIRECTORY_PATH } from '@/constants/paths'
+import { FILECOIN_FOUNDATION_URLS } from '@/constants/siteMetadata'
+import { DEFAULT_SORT_OPTION } from '@/constants/sortConstants'
+
+import { attributes } from '@/content/pages/ecosystem-explorer.md'
+
+import { graphicsData } from '@/data/graphicsData'
+
+import { buildImageSizeProp } from '@/utils/buildImageSizeProp'
+import {
+  getCategoryDataFromDirectory,
+  getCategorySettingsFromMap,
+} from '@/utils/categoryUtils'
+import { createMetadata } from '@/utils/createMetadata'
+import { getEcosystemProjectsData } from '@/utils/getEcosystemProjectData'
+import { getSortOptions } from '@/utils/getSortOptions'
+
 import { useCategory } from '@/hooks/useCategory'
 import { usePagination } from '@/hooks/usePagination'
 import { useSearch } from '@/hooks/useSearch'
@@ -21,24 +40,10 @@ import { Search } from '@/components/Search'
 import { Sort } from '@/components/Sort'
 import { StructuredDataScript } from '@/components/StructuredDataScript'
 
-import type { NextServerSearchParams } from '@/types/searchParams'
 
-import { buildImageSizeProp } from '@/utils/buildImageSizeProp'
-import {
-  getCategoryDataFromDirectory,
-  getCategorySettingsFromMap,
-} from '@/utils/categoryUtils'
-import { createMetadata } from '@/utils/createMetadata'
-import { getEcosystemProjectsData } from '@/utils/getEcosystemProjectData'
-import { getSortOptions } from '@/utils/getSortOptions'
 
-import { graphicsData } from '@/data/graphicsData'
 
-import { attributes } from '@/content/pages/ecosystem-explorer.md'
 
-import { PATHS, ECOSYSTEM_CATEGORIES_DIRECTORY_PATH } from '@/constants/paths'
-import { FILECOIN_FOUNDATION_URLS } from '@/constants/siteMetadata'
-import { DEFAULT_SORT_OPTION } from '@/constants/sortConstants'
 
 import { generateStructuredData } from './utils/generateStructuredData'
 

--- a/src/app/ecosystem-explorer/project-form/services/github/utils/pathUtils.ts
+++ b/src/app/ecosystem-explorer/project-form/services/github/utils/pathUtils.ts
@@ -1,8 +1,8 @@
 import { z } from 'zod'
 
-import configJson from '@/data/cmsConfigSchema.json'
-
 import { ECOSYSTEM_PROJECTS_DIRECTORY_PATH } from '@/constants/paths'
+
+import configJson from '@/data/cmsConfigSchema.json'
 
 const pathConfigSchema = z.object({
   media_folder: z.string(),

--- a/src/app/ecosystem-explorer/utils/generateStructuredData.ts
+++ b/src/app/ecosystem-explorer/utils/generateStructuredData.ts
@@ -2,9 +2,9 @@ import type { WebPage, WithContext } from 'schema-dts'
 
 import type { SeoMetadata } from '@/types/metadataTypes'
 
-import { generateWebPageStructuredData } from '@/utils/generateWebPageStructuredData'
-
 import { PATHS } from '@/constants/paths'
+
+import { generateWebPageStructuredData } from '@/utils/generateWebPageStructuredData'
 
 export function generateStructuredData(seo: SeoMetadata): WithContext<WebPage> {
   return generateWebPageStructuredData({

--- a/src/app/employee-privacy-policy/page.tsx
+++ b/src/app/employee-privacy-policy/page.tsx
@@ -1,20 +1,23 @@
-import { PageHeader } from '@/components/PageHeader'
-import { StructuredDataScript } from '@/components/StructuredDataScript'
-
-import { createMetadata } from '@/utils/createMetadata'
+import { PATHS } from '@/constants/paths'
 
 import {
   attributes,
   react as Content,
 } from '@/content/pages/employee-privacy-policy.md'
 
-import { PATHS } from '@/constants/paths'
+import { createMetadata } from '@/utils/createMetadata'
+
+import { PageHeader } from '@/components/PageHeader'
+import { StructuredDataScript } from '@/components/StructuredDataScript'
 
 import { generateStructuredData } from './utils/generateStructuredData'
 
 const { header, seo } = attributes
 
-export const metadata = createMetadata({ seo, path: PATHS.EMPLOYEE_PRIVACY_POLICY.path })
+export const metadata = createMetadata({
+  seo,
+  path: PATHS.EMPLOYEE_PRIVACY_POLICY.path,
+})
 
 export default function EmployeePrivacyPolicy() {
   const { title } = header

--- a/src/app/employee-privacy-policy/utils/generateStructuredData.ts
+++ b/src/app/employee-privacy-policy/utils/generateStructuredData.ts
@@ -2,9 +2,9 @@ import type { WebPage, WithContext } from 'schema-dts'
 
 import type { SeoMetadata } from '@/types/metadataTypes'
 
-import { generateWebPageStructuredData } from '@/utils/generateWebPageStructuredData'
-
 import { PATHS } from '@/constants/paths'
+
+import { generateWebPageStructuredData } from '@/utils/generateWebPageStructuredData'
 
 export function generateStructuredData(seo: SeoMetadata): WithContext<WebPage> {
   return generateWebPageStructuredData({

--- a/src/app/events/[slug]/page.tsx
+++ b/src/app/events/[slug]/page.tsx
@@ -1,15 +1,15 @@
-import { PageHeader } from '@/components/PageHeader'
-import { StructuredDataScript } from '@/components/StructuredDataScript'
-import { TagLabel } from '@/components/TagLabel'
+import { type DynamicPathValues, PATHS } from '@/constants/paths'
+
+import { graphicsData } from '@/data/graphicsData'
 
 import { getCategoryLabel } from '@/utils/categoryUtils'
 import { createMetadata } from '@/utils/createMetadata'
 import { getEventData } from '@/utils/getEventData'
 import { getEventMetaData } from '@/utils/getMetaData'
 
-import { graphicsData } from '@/data/graphicsData'
-
-import { type DynamicPathValues, PATHS } from '@/constants/paths'
+import { PageHeader } from '@/components/PageHeader'
+import { StructuredDataScript } from '@/components/StructuredDataScript'
+import { TagLabel } from '@/components/TagLabel'
 
 import { generateStructuredData } from './utils/generateStructuredData'
 

--- a/src/app/events/data/getInvolvedData.ts
+++ b/src/app/events/data/getInvolvedData.ts
@@ -1,8 +1,8 @@
 import { Clipboard, Envelope, HandWaving } from '@phosphor-icons/react/dist/ssr'
 
-import { extractEmailAddress } from '@/utils/extractEmailAddress'
-
 import { FILECOIN_FOUNDATION_URLS } from '@/constants/siteMetadata'
+
+import { extractEmailAddress } from '@/utils/extractEmailAddress'
 
 export const getInvolvedData = [
   {

--- a/src/app/events/page.tsx
+++ b/src/app/events/page.tsx
@@ -4,6 +4,26 @@ import dynamic from 'next/dynamic'
 
 import { MagnifyingGlass } from '@phosphor-icons/react/dist/ssr'
 
+import type { NextServerSearchParams } from '@/types/searchParams'
+
+import { PATHS } from '@/constants/paths'
+import { DEFAULT_SORT_OPTION } from '@/constants/sortConstants'
+
+import { attributes } from '@/content/pages/events.md'
+
+import { graphicsData } from '@/data/graphicsData'
+
+import { buildImageSizeProp } from '@/utils/buildImageSizeProp'
+import {
+  getEventsCategorySettings,
+  getCategoryLabel,
+} from '@/utils/categoryUtils'
+import { createMetadata } from '@/utils/createMetadata'
+import { getEventData, getEventsData } from '@/utils/getEventData'
+import { getEventMetaData } from '@/utils/getMetaData'
+import { getSortOptions } from '@/utils/getSortOptions'
+import { hasNoFiltersApplied } from '@/utils/searchParamsUtils'
+
 import { useEventsCategory } from '@/hooks/useEventsCategory'
 import { usePagination } from '@/hooks/usePagination'
 import { useSearch } from '@/hooks/useSearch'
@@ -22,26 +42,6 @@ import { Search } from '@/components/Search'
 import { Sort } from '@/components/Sort'
 import { StaticImage } from '@/components/StaticImage'
 import { StructuredDataScript } from '@/components/StructuredDataScript'
-
-import type { NextServerSearchParams } from '@/types/searchParams'
-
-import { buildImageSizeProp } from '@/utils/buildImageSizeProp'
-import {
-  getEventsCategorySettings,
-  getCategoryLabel,
-} from '@/utils/categoryUtils'
-import { createMetadata } from '@/utils/createMetadata'
-import { getEventData, getEventsData } from '@/utils/getEventData'
-import { getEventMetaData } from '@/utils/getMetaData'
-import { getSortOptions } from '@/utils/getSortOptions'
-import { hasNoFiltersApplied } from '@/utils/searchParamsUtils'
-
-import { graphicsData } from '@/data/graphicsData'
-
-import { attributes } from '@/content/pages/events.md'
-
-import { PATHS } from '@/constants/paths'
-import { DEFAULT_SORT_OPTION } from '@/constants/sortConstants'
 
 import { getInvolvedData } from './data/getInvolvedData'
 import { generateStructuredData } from './utils/generateStructuredData'

--- a/src/app/events/utils/generateStructuredData.ts
+++ b/src/app/events/utils/generateStructuredData.ts
@@ -2,9 +2,10 @@ import type { WebPage, WithContext } from 'schema-dts'
 
 import type { SeoMetadata } from '@/types/metadataTypes'
 
+import { PATHS } from '@/constants/paths'
+
 import { generateWebPageStructuredData } from '@/utils/generateWebPageStructuredData'
 
-import { PATHS } from '@/constants/paths'
 
 export function generateStructuredData(seo: SeoMetadata): WithContext<WebPage> {
   return generateWebPageStructuredData({

--- a/src/app/filecoin-plus/data/aboutData.ts
+++ b/src/app/filecoin-plus/data/aboutData.ts
@@ -1,6 +1,6 @@
-import type { StaticImageProps } from '@/components/StaticImage'
-
 import { graphicsData } from '@/data/graphicsData'
+
+import type { StaticImageProps } from '@/components/StaticImage'
 
 export type AboutData = {
   title: string

--- a/src/app/filecoin-plus/data/applicationData.tsx
+++ b/src/app/filecoin-plus/data/applicationData.tsx
@@ -1,6 +1,6 @@
-import { TextLink } from '@/components/TextLink'
-
 import { FIL_PLUS_URLS } from '@/constants/siteMetadata'
+
+import { TextLink } from '@/components/TextLink'
 
 export const applicationData = [
   {

--- a/src/app/filecoin-plus/page.tsx
+++ b/src/app/filecoin-plus/page.tsx
@@ -1,3 +1,12 @@
+import { PATHS } from '@/constants/paths'
+import { FIL_PLUS_URLS } from '@/constants/siteMetadata'
+
+import { attributes } from '@/content/pages/filecoin-plus.md'
+
+import { graphicsData } from '@/data/graphicsData'
+
+import { createMetadata } from '@/utils/createMetadata'
+
 import { Badge } from '@/components/Badge'
 import { BadgeCardGrid } from '@/components/BadgeCardGrid'
 import { Button } from '@/components/Button'
@@ -10,15 +19,6 @@ import { PageLayout } from '@/components/PageLayout'
 import { PageSection } from '@/components/PageSection'
 import { StructuredDataScript } from '@/components/StructuredDataScript'
 import { TextLink } from '@/components/TextLink'
-
-import { createMetadata } from '@/utils/createMetadata'
-
-import { graphicsData } from '@/data/graphicsData'
-
-import { attributes } from '@/content/pages/filecoin-plus.md'
-
-import { PATHS } from '@/constants/paths'
-import { FIL_PLUS_URLS } from '@/constants/siteMetadata'
 
 import { aboutData } from './data/aboutData'
 import { applicationData } from './data/applicationData'

--- a/src/app/filecoin-plus/utils/generateStructuredData.tsx
+++ b/src/app/filecoin-plus/utils/generateStructuredData.tsx
@@ -2,9 +2,9 @@ import type { WebPage, WithContext } from 'schema-dts'
 
 import type { SeoMetadata } from '@/types/metadataTypes'
 
-import { generateWebPageStructuredData } from '@/utils/generateWebPageStructuredData'
-
 import { PATHS } from '@/constants/paths'
+
+import { generateWebPageStructuredData } from '@/utils/generateWebPageStructuredData'
 
 export function generateStructuredData(seo: SeoMetadata): WithContext<WebPage> {
   return generateWebPageStructuredData({

--- a/src/app/global-error.tsx
+++ b/src/app/global-error.tsx
@@ -6,10 +6,10 @@ import Error from 'next/error'
 
 import * as Sentry from '@sentry/nextjs'
 
+import { FILECOIN_FOUNDATION_URLS } from '@/constants/siteMetadata'
+
 import ErrorMessage from '@/components/ErrorMessage'
 import { SiteLayout } from '@/components/SiteLayout'
-
-import { FILECOIN_FOUNDATION_URLS } from '@/constants/siteMetadata'
 
 export default function GlobalError({ error }: { error: Error }) {
   useEffect(() => {

--- a/src/app/governance/page.tsx
+++ b/src/app/governance/page.tsx
@@ -1,3 +1,12 @@
+import { PATHS } from '@/constants/paths'
+import { FILECOIN_FOUNDATION_URLS } from '@/constants/siteMetadata'
+
+import { attributes } from '@/content/pages/governance.md'
+
+import { graphicsData } from '@/data/graphicsData'
+
+import { createMetadata } from '@/utils/createMetadata'
+
 import { CardGrid } from '@/components/CardGrid'
 import { CTASection } from '@/components/CTASection'
 import { GovernanceCalendarCards } from '@/components/GovernanceCalendarCards'
@@ -7,15 +16,6 @@ import { PageLayout } from '@/components/PageLayout'
 import { PageSection } from '@/components/PageSection'
 import { StructuredDataScript } from '@/components/StructuredDataScript'
 import { TextLink } from '@/components/TextLink'
-
-import { createMetadata } from '@/utils/createMetadata'
-
-import { graphicsData } from '@/data/graphicsData'
-
-import { attributes } from '@/content/pages/governance.md'
-
-import { PATHS } from '@/constants/paths'
-import { FILECOIN_FOUNDATION_URLS } from '@/constants/siteMetadata'
 
 import { governanceDocsData } from './data/governanceDocsData'
 import { generateStructuredData } from './utils/generateStructuredData'

--- a/src/app/governance/utils/generateStructuredData.ts
+++ b/src/app/governance/utils/generateStructuredData.ts
@@ -2,10 +2,10 @@ import type { WebPage, WithContext } from 'schema-dts'
 
 import type { SeoMetadata } from '@/types/metadataTypes'
 
-import { generateWebPageStructuredData } from '@/utils/generateWebPageStructuredData'
-
 import { PATHS } from '@/constants/paths'
 import { ORGANIZATION_SCHEMA_BASE } from '@/constants/structuredDataConstants'
+
+import { generateWebPageStructuredData } from '@/utils/generateWebPageStructuredData'
 
 export function generateStructuredData(seo: SeoMetadata): WithContext<WebPage> {
   const baseData = generateWebPageStructuredData({

--- a/src/app/grants/page.tsx
+++ b/src/app/grants/page.tsx
@@ -1,5 +1,16 @@
 import path from 'path'
 
+import { PATHS } from '@/constants/paths'
+import { FILECOIN_FOUNDATION_URLS } from '@/constants/siteMetadata'
+
+import { attributes } from '@/content/pages/grants.md'
+
+import { graphicsData } from '@/data/graphicsData'
+
+import { createMetadata } from '@/utils/createMetadata'
+import { extractEmailAddress } from '@/utils/extractEmailAddress'
+import { getEcosystemProjectsData } from '@/utils/getEcosystemProjectData'
+
 import { Badge } from '@/components/Badge'
 import { BadgeCardGrid } from '@/components/BadgeCardGrid'
 import { CardGrid } from '@/components/CardGrid'
@@ -12,17 +23,6 @@ import { PageLayout } from '@/components/PageLayout'
 import { PageSection } from '@/components/PageSection'
 import { StructuredDataScript } from '@/components/StructuredDataScript'
 import { TextLink } from '@/components/TextLink'
-
-import { createMetadata } from '@/utils/createMetadata'
-import { extractEmailAddress } from '@/utils/extractEmailAddress'
-import { getEcosystemProjectsData } from '@/utils/getEcosystemProjectData'
-
-import { graphicsData } from '@/data/graphicsData'
-
-import { attributes } from '@/content/pages/grants.md'
-
-import { PATHS } from '@/constants/paths'
-import { FILECOIN_FOUNDATION_URLS } from '@/constants/siteMetadata'
 
 import { applicationProcessData } from './data/applicationProcessData'
 import { opportunitiesData } from './data/opportunitiesData'

--- a/src/app/grants/utils/generateStructuredData.ts
+++ b/src/app/grants/utils/generateStructuredData.ts
@@ -2,10 +2,10 @@ import type { WebPage, WithContext } from 'schema-dts'
 
 import type { SeoMetadata } from '@/types/metadataTypes'
 
-import { generateWebPageStructuredData } from '@/utils/generateWebPageStructuredData'
-
 import { PATHS } from '@/constants/paths'
 import { ORGANIZATION_SCHEMA_BASE } from '@/constants/structuredDataConstants'
+
+import { generateWebPageStructuredData } from '@/utils/generateWebPageStructuredData'
 
 export function generateStructuredData(seo: SeoMetadata): WithContext<WebPage> {
   const baseData = generateWebPageStructuredData({

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -4,9 +4,9 @@ import PlausibleProvider from 'next-plausible'
 
 import '@/styles/globals.scss'
 
-import { SiteLayout } from '@/components/SiteLayout'
-
 import { BASE_URL, ORGANIZATION_NAME } from '@/constants/siteMetadata'
+
+import { SiteLayout } from '@/components/SiteLayout'
 
 export const metadata: Metadata = {
   title: {

--- a/src/app/orbit/components/EventsSection.tsx
+++ b/src/app/orbit/components/EventsSection.tsx
@@ -1,6 +1,13 @@
 import * as Sentry from '@sentry/nextjs'
 import { ZodError } from 'zod'
 
+import type { NextServerSearchParams } from '@/types/searchParams'
+
+import { FILECOIN_FOUNDATION_URLS } from '@/constants/siteMetadata'
+
+import { formatDate } from '@/utils/dateUtils'
+import { logZodError } from '@/utils/zodUtils'
+
 import { usePagination } from '@/hooks/usePagination'
 import { useSearch } from '@/hooks/useSearch'
 
@@ -11,13 +18,6 @@ import { FilterContainer } from '@/components/FilterContainer'
 import { NoResultsMessage } from '@/components/NoResultsMessage'
 import { Pagination } from '@/components/Pagination'
 import { Search } from '@/components/Search'
-
-import type { NextServerSearchParams } from '@/types/searchParams'
-
-import { formatDate } from '@/utils/dateUtils'
-import { logZodError } from '@/utils/zodUtils'
-
-import { FILECOIN_FOUNDATION_URLS } from '@/constants/siteMetadata'
 
 import { fetchAndParseAirtableEvents } from '../services/airtable'
 

--- a/src/app/orbit/data/exploreOrbitData.ts
+++ b/src/app/orbit/data/exploreOrbitData.ts
@@ -4,9 +4,10 @@ import {
   Envelope,
 } from '@phosphor-icons/react/dist/ssr'
 
+import { FILECOIN_FOUNDATION_URLS } from '@/constants/siteMetadata'
+
 import type { IconProps } from '@/components/Icon'
 
-import { FILECOIN_FOUNDATION_URLS } from '@/constants/siteMetadata'
 
 type ExploreOrbitData = {
   heading: {

--- a/src/app/orbit/page.tsx
+++ b/src/app/orbit/page.tsx
@@ -1,3 +1,14 @@
+import type { NextServerSearchParams } from '@/types/searchParams'
+
+import { PATHS } from '@/constants/paths'
+import { FILECOIN_FOUNDATION_URLS } from '@/constants/siteMetadata'
+
+import { attributes } from '@/content/pages/orbit.md'
+
+import { graphicsData } from '@/data/graphicsData'
+
+import { createMetadata } from '@/utils/createMetadata'
+
 import { Badge } from '@/components/Badge'
 import { BadgeCardGrid } from '@/components/BadgeCardGrid'
 import { CardGrid } from '@/components/CardGrid'
@@ -12,17 +23,6 @@ import { PageSection } from '@/components/PageSection'
 import { StatisticCard } from '@/components/StatisticCard'
 import { StructuredDataScript } from '@/components/StructuredDataScript'
 import { TextLink } from '@/components/TextLink'
-
-import type { NextServerSearchParams } from '@/types/searchParams'
-
-import { createMetadata } from '@/utils/createMetadata'
-
-import { graphicsData } from '@/data/graphicsData'
-
-import { attributes } from '@/content/pages/orbit.md'
-
-import { PATHS } from '@/constants/paths'
-import { FILECOIN_FOUNDATION_URLS } from '@/constants/siteMetadata'
 
 import { OrbitEventsSection } from './components/EventsSection'
 import { ambassadorsData } from './data/ambassadorsData'

--- a/src/app/orbit/utils/generateStructuredData.ts
+++ b/src/app/orbit/utils/generateStructuredData.ts
@@ -2,9 +2,9 @@ import type { WebPage, WithContext } from 'schema-dts'
 
 import type { SeoMetadata } from '@/types/metadataTypes'
 
-import { generateWebPageStructuredData } from '@/utils/generateWebPageStructuredData'
-
 import { PATHS } from '@/constants/paths'
+
+import { generateWebPageStructuredData } from '@/utils/generateWebPageStructuredData'
 
 export function generateStructuredData(seo: SeoMetadata): WithContext<WebPage> {
   return generateWebPageStructuredData({

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,5 +1,17 @@
 import path from 'path'
 
+import { PATHS } from '@/constants/paths'
+import { FILECOIN_URLS } from '@/constants/siteMetadata'
+import { ORGANIZATION_SCHEMA_BASE } from '@/constants/structuredDataConstants'
+
+import { attributes } from '@/content/pages/home.md'
+
+import { graphicsData } from '@/data/graphicsData'
+import { filecoinEcosystemData } from '@/data/homepage/filecoinEcosystemData'
+
+import { createMetadata } from '@/utils/createMetadata'
+import { getEcosystemProjectsData } from '@/utils/getEcosystemProjectData'
+
 import { Button } from '@/components/Button'
 import { CardGrid } from '@/components/CardGrid'
 import { CTASection } from '@/components/CTASection'
@@ -11,18 +23,6 @@ import { PageHeader } from '@/components/PageHeader'
 import { PageLayout } from '@/components/PageLayout'
 import { PageSection } from '@/components/PageSection'
 import { StructuredDataScript } from '@/components/StructuredDataScript'
-
-import { createMetadata } from '@/utils/createMetadata'
-import { getEcosystemProjectsData } from '@/utils/getEcosystemProjectData'
-
-import { graphicsData } from '@/data/graphicsData'
-import { filecoinEcosystemData } from '@/data/homepage/filecoinEcosystemData'
-
-import { attributes } from '@/content/pages/home.md'
-
-import { PATHS } from '@/constants/paths'
-import { FILECOIN_URLS } from '@/constants/siteMetadata'
-import { ORGANIZATION_SCHEMA_BASE } from '@/constants/structuredDataConstants'
 
 const ecosystemProjects = getEcosystemProjectsData()
 

--- a/src/app/privacy-policy/page.tsx
+++ b/src/app/privacy-policy/page.tsx
@@ -1,11 +1,15 @@
-import { PageHeader } from '@/components/PageHeader'
-import { StructuredDataScript } from '@/components/StructuredDataScript'
-
-import { createMetadata } from '@/utils/createMetadata'
+import { PATHS } from '@/constants/paths'
 
 import { attributes, react as Content } from '@/content/pages/privacy-policy.md'
 
-import { PATHS } from '@/constants/paths'
+import { createMetadata } from '@/utils/createMetadata'
+
+
+import { PageHeader } from '@/components/PageHeader'
+import { StructuredDataScript } from '@/components/StructuredDataScript'
+
+
+
 
 import { generateStructuredData } from './utils/generateStructuredData'
 

--- a/src/app/privacy-policy/utils/generateStructuredData.ts
+++ b/src/app/privacy-policy/utils/generateStructuredData.ts
@@ -2,9 +2,10 @@ import type { WebPage, WithContext } from 'schema-dts'
 
 import type { SeoMetadata } from '@/types/metadataTypes'
 
+import { PATHS } from '@/constants/paths'
+
 import { generateWebPageStructuredData } from '@/utils/generateWebPageStructuredData'
 
-import { PATHS } from '@/constants/paths'
 
 export function generateStructuredData(seo: SeoMetadata): WithContext<WebPage> {
   return generateWebPageStructuredData({

--- a/src/app/security/bug-bounty/page.tsx
+++ b/src/app/security/bug-bounty/page.tsx
@@ -1,16 +1,16 @@
+import { PATHS } from '@/constants/paths'
+import { FILECOIN_FOUNDATION_URLS } from '@/constants/siteMetadata'
+
+import { attributes } from '@/content/pages/security/bug-bounty.md'
+
+import { graphicsData } from '@/data/graphicsData'
+
+import { createMetadata } from '@/utils/createMetadata'
+
 import { PageHeader } from '@/components/PageHeader'
 import { PageLayout } from '@/components/PageLayout'
 import { PageSection } from '@/components/PageSection'
 import { StructuredDataScript } from '@/components/StructuredDataScript'
-
-import { createMetadata } from '@/utils/createMetadata'
-
-import { graphicsData } from '@/data/graphicsData'
-
-import { attributes } from '@/content/pages/security/bug-bounty.md'
-
-import { PATHS } from '@/constants/paths'
-import { FILECOIN_FOUNDATION_URLS } from '@/constants/siteMetadata'
 
 import { Leaderboard } from './components/Leaderboard'
 import { generateStructuredData } from './utils/generateStructuredData'

--- a/src/app/security/bug-bounty/utils/generateStructuredData.tsx
+++ b/src/app/security/bug-bounty/utils/generateStructuredData.tsx
@@ -2,9 +2,10 @@ import type { WebPage, WithContext } from 'schema-dts'
 
 import type { SeoMetadata } from '@/types/metadataTypes'
 
+import { PATHS } from '@/constants/paths'
+
 import { generateWebPageStructuredData } from '@/utils/generateWebPageStructuredData'
 
-import { PATHS } from '@/constants/paths'
 
 export function generateStructuredData(seo: SeoMetadata): WithContext<WebPage> {
   return generateWebPageStructuredData({

--- a/src/app/security/coordinated-disclosure-policy/page.tsx
+++ b/src/app/security/coordinated-disclosure-policy/page.tsx
@@ -1,14 +1,14 @@
-import { PageHeader } from '@/components/PageHeader'
-import { StructuredDataScript } from '@/components/StructuredDataScript'
-
-import { createMetadata } from '@/utils/createMetadata'
+import { PATHS } from '@/constants/paths'
 
 import {
   attributes,
   react as Content,
 } from '@/content/pages/security/coordinated-disclosure-policy.md'
 
-import { PATHS } from '@/constants/paths'
+import { createMetadata } from '@/utils/createMetadata'
+
+import { PageHeader } from '@/components/PageHeader'
+import { StructuredDataScript } from '@/components/StructuredDataScript'
 
 import { generateStructuredData } from './utils/generateStructuredData'
 

--- a/src/app/security/coordinated-disclosure-policy/utils/generateStructuredData.ts
+++ b/src/app/security/coordinated-disclosure-policy/utils/generateStructuredData.ts
@@ -2,9 +2,9 @@ import type { WebPage, WithContext } from 'schema-dts'
 
 import type { SeoMetadata } from '@/types/metadataTypes'
 
-import { generateWebPageStructuredData } from '@/utils/generateWebPageStructuredData'
-
 import { PATHS } from '@/constants/paths'
+
+import { generateWebPageStructuredData } from '@/utils/generateWebPageStructuredData'
 
 export function generateStructuredData(seo: SeoMetadata): WithContext<WebPage> {
   return generateWebPageStructuredData({

--- a/src/app/security/data/developerSupportData.tsx
+++ b/src/app/security/data/developerSupportData.tsx
@@ -1,11 +1,13 @@
 import { FileText, UserCircle } from '@phosphor-icons/react/dist/ssr'
 
-import type { IconProps } from '@/components/Icon'
-import { TextLink } from '@/components/TextLink'
+import { FILECOIN_FOUNDATION_URLS } from '@/constants/siteMetadata'
 
 import { extractEmailAddress } from '@/utils/extractEmailAddress'
 
-import { FILECOIN_FOUNDATION_URLS } from '@/constants/siteMetadata'
+import type { IconProps } from '@/components/Icon'
+import { TextLink } from '@/components/TextLink'
+
+
 
 type DeveloperSupportData = {
   heading: {

--- a/src/app/security/maturity-model/page.tsx
+++ b/src/app/security/maturity-model/page.tsx
@@ -1,3 +1,11 @@
+import { PATHS } from '@/constants/paths'
+
+import { attributes } from '@/content/pages/maturity-model.md'
+
+import { graphicsData } from '@/data/graphicsData'
+
+import { createMetadata } from '@/utils/createMetadata'
+
 import { Badge } from '@/components/Badge'
 import { BadgeCardGrid } from '@/components/BadgeCardGrid'
 import { CardWithBadge } from '@/components/CardWithBadge'
@@ -5,14 +13,6 @@ import { PageHeader } from '@/components/PageHeader'
 import { PageLayout } from '@/components/PageLayout'
 import { PageSection } from '@/components/PageSection'
 import { StructuredDataScript } from '@/components/StructuredDataScript'
-
-import { createMetadata } from '@/utils/createMetadata'
-
-import { graphicsData } from '@/data/graphicsData'
-
-import { attributes } from '@/content/pages/maturity-model.md'
-
-import { PATHS } from '@/constants/paths'
 
 import { CoreFunctions } from './components/CoreFunctions'
 import { applicationAndUseData } from './data/applicationAndUseData'

--- a/src/app/security/maturity-model/utils/generateStructuredData.tsx
+++ b/src/app/security/maturity-model/utils/generateStructuredData.tsx
@@ -2,9 +2,10 @@
 
 import type { SeoMetadata } from '@/types/metadataTypes'
 
+import { PATHS } from '@/constants/paths'
+
 import { generateWebPageStructuredData } from '@/utils/generateWebPageStructuredData'
 
-import { PATHS } from '@/constants/paths'
 
 export function generateStructuredData(seo: SeoMetadata): WithContext<WebPage> {
   return generateWebPageStructuredData({

--- a/src/app/security/page.tsx
+++ b/src/app/security/page.tsx
@@ -1,3 +1,12 @@
+import { PATHS } from '@/constants/paths'
+import { FILECOIN_FOUNDATION_URLS } from '@/constants/siteMetadata'
+
+import { attributes } from '@/content/pages/security/security.md'
+
+import { graphicsData } from '@/data/graphicsData'
+
+import { createMetadata } from '@/utils/createMetadata'
+
 import { CardGrid } from '@/components/CardGrid'
 import { CTASection } from '@/components/CTASection'
 import { HomeExploreSectionCard } from '@/components/HomeExploreSectionCard'
@@ -5,15 +14,6 @@ import { PageHeader } from '@/components/PageHeader'
 import { PageLayout } from '@/components/PageLayout'
 import { PageSection } from '@/components/PageSection'
 import { StructuredDataScript } from '@/components/StructuredDataScript'
-
-import { createMetadata } from '@/utils/createMetadata'
-
-import { graphicsData } from '@/data/graphicsData'
-
-import { attributes } from '@/content/pages/security/security.md'
-
-import { PATHS } from '@/constants/paths'
-import { FILECOIN_FOUNDATION_URLS } from '@/constants/siteMetadata'
 
 import { developerSupportData } from './data/developerSupportData'
 import { generateStructuredData } from './utils/generateStructuredData'

--- a/src/app/security/utils/generateStructuredData.ts
+++ b/src/app/security/utils/generateStructuredData.ts
@@ -2,9 +2,10 @@ import type { WebPage, WithContext } from 'schema-dts'
 
 import type { SeoMetadata } from '@/types/metadataTypes'
 
+import { PATHS } from '@/constants/paths'
+
 import { generateWebPageStructuredData } from '@/utils/generateWebPageStructuredData'
 
-import { PATHS } from '@/constants/paths'
 
 export function generateStructuredData(seo: SeoMetadata): WithContext<WebPage> {
   return generateWebPageStructuredData({

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -1,14 +1,14 @@
 import { formatISO } from 'date-fns'
 
-import type { DynamicBaseData } from '@/schemas/dynamicDataBaseSchema'
+import { PATHS } from '@/constants/paths'
+import { BASE_URL } from '@/constants/siteMetadata'
 
 import { getBlogPostsData } from '@/utils/getBlogPostData'
 import { getDigestArticlesData } from '@/utils/getDigestArticleData'
 import { getEcosystemProjectsData } from '@/utils/getEcosystemProjectData'
 import { getEventsData } from '@/utils/getEventData'
 
-import { PATHS } from '@/constants/paths'
-import { BASE_URL } from '@/constants/siteMetadata'
+import type { DynamicBaseData } from '@/schemas/dynamicDataBaseSchema'
 
 type GenericEntryData = Pick<DynamicBaseData, 'updatedOn'> & { slug: string }
 

--- a/src/app/terms-of-use/page.tsx
+++ b/src/app/terms-of-use/page.tsx
@@ -1,11 +1,15 @@
-import { PageHeader } from '@/components/PageHeader'
-import { StructuredDataScript } from '@/components/StructuredDataScript'
-
-import { createMetadata } from '@/utils/createMetadata'
+import { PATHS } from '@/constants/paths'
 
 import { attributes, react as Content } from '@/content/pages/terms-of-use.md'
 
-import { PATHS } from '@/constants/paths'
+import { createMetadata } from '@/utils/createMetadata'
+
+
+import { PageHeader } from '@/components/PageHeader'
+import { StructuredDataScript } from '@/components/StructuredDataScript'
+
+
+
 
 import { generateStructuredData } from './utils/generateStructuredData'
 

--- a/src/app/terms-of-use/utils/generateStructuredData.ts
+++ b/src/app/terms-of-use/utils/generateStructuredData.ts
@@ -2,9 +2,9 @@ import type { WebPage, WithContext } from 'schema-dts'
 
 import type { SeoMetadata } from '@/types/metadataTypes'
 
-import { generateWebPageStructuredData } from '@/utils/generateWebPageStructuredData'
-
 import { PATHS } from '@/constants/paths'
+
+import { generateWebPageStructuredData } from '@/utils/generateWebPageStructuredData'
 
 export function generateStructuredData(seo: SeoMetadata): WithContext<WebPage> {
   return generateWebPageStructuredData({


### PR DESCRIPTION
## 📝 Description

This PR updates the ESLint configuration to refine the import order rules, ensuring a more logical and consistent structure throughout the codebase. The adjustments aim to better align the import order with project dependencies, improving both readability and maintainability.

- **Type:** Refactor

## 🛠️ Key Changes

- **Adjusted Import Order:**
  - Introduced `constants` into the import order, which was previously missing, and positioned it earlier in the internal import group, reflecting its foundational role.
  - Moved `types` to be imported earlier in the internal import group.
  - Rearranged the order of `schemas`, `hooks`, and `components` to ensure a logical flow where foundational elements are imported first.
