### PR TITLE
[UXIT-1510] Digest Page - Remove Markdown from content descriptions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -37,6 +37,7 @@
         "react-lite-youtube-embed": "^2.4.0",
         "react-markdown": "^9.0.1",
         "rehype-raw": "^7.0.0",
+        "remove-markdown": "^0.5.5",
         "schema-dts": "^1.1.2",
         "sharp": "^0.33.4",
         "slugify": "^1.6.6",
@@ -18234,6 +18235,12 @@
         "is-alphanumerical": "^1.0.0",
         "is-hexadecimal": "^1.0.0"
       }
+    },
+    "node_modules/remove-markdown": {
+      "version": "0.5.5",
+      "resolved": "https://registry.npmjs.org/remove-markdown/-/remove-markdown-0.5.5.tgz",
+      "integrity": "sha512-lMR8tOtDqazFT6W2bZidoXwkptMdF3pCxpri0AEokHg0sZlC2GdoLqnoaxsEj1o7/BtXV1MKtT3YviA1t7rW7g==",
+      "license": "MIT"
     },
     "node_modules/repeat-string": {
       "version": "1.6.1",

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "react-lite-youtube-embed": "^2.4.0",
     "react-markdown": "^9.0.1",
     "rehype-raw": "^7.0.0",
+    "remove-markdown": "^0.5.5",
     "schema-dts": "^1.1.2",
     "sharp": "^0.33.4",
     "slugify": "^1.6.6",

--- a/src/app/digest/[slug]/page.tsx
+++ b/src/app/digest/[slug]/page.tsx
@@ -7,8 +7,6 @@ import { MarkdownContent } from '@/components/MarkdownContent'
 import { PageLayout } from '@/components/PageLayout'
 import { StructuredDataScript } from '@/components/StructuredDataScript'
 
-
-
 import { DigestArticleHeader } from './components/DigestArticleHeader'
 import { generateStructuredData } from './utils/generateStructuredData'
 

--- a/src/app/digest/page.tsx
+++ b/src/app/digest/page.tsx
@@ -1,4 +1,5 @@
 import { BookOpen } from '@phosphor-icons/react/dist/ssr'
+import removeMarkdown from 'remove-markdown'
 
 import { PATHS } from '@/constants/paths'
 import { FILECOIN_FOUNDATION_URLS } from '@/constants/siteMetadata'
@@ -57,7 +58,7 @@ export default function Digest() {
               <Card
                 key={title}
                 title={title}
-                description={content}
+                description={removeMarkdown(content)}
                 textIsClamped={true}
                 tagLabel={[`Issue ${issueNumber}`, `Article ${articleNumber}`]}
                 cta={{


### PR DESCRIPTION
## 📝 Description

The descriptions of the Digest cards are the main content truncated. The main content comes in Markdown so we've installed the `remove-markdown` library to remove the Markdown from showing on the description cards.

- **Type:** Bug fix

## 🛠️ Key Changes

- Install `remove-markdown`
- Use `removeMarkdown` function on `content` 

## 📸 Screenshots

Before vs. After
![CleanShot 2024-09-03 at 14 42 24@2x](https://github.com/user-attachments/assets/06af9cc7-db5f-406f-843a-1d6ae2c0a803)

![CleanShot 2024-09-03 at 14 42 33@2x](https://github.com/user-attachments/assets/a288487b-801e-41e2-9667-0263ad2e9c28)

## 🔖 Resources

- [remove-markdown](https://github.com/zuchka/remove-markdown)
