### PR TITLE
[UXIT-1538] Event Page · Add Luma Events section

### DIFF
--- a/public/admin/config.yml
+++ b/public/admin/config.yml
@@ -681,8 +681,10 @@ collections:
           - name: "title"
             label: "Section Title"
             widget: "string"
+            required: false
           - name: "embed-link"
             label: "Luma Embed URL"
             widget: "string"
+            required: false
       - *image_config
       - *meta_config

--- a/public/admin/config.yml
+++ b/public/admin/config.yml
@@ -677,14 +677,17 @@ collections:
         label: "Luma Events Section"
         widget: "object"
         required: false
+        hint: Both the section title and the embed URL must be filled out for this section to appear on the page.
         fields:
           - name: "title"
             label: "Section Title"
             widget: "string"
             required: false
+            hint: This is the title for the section header. For example, "FIL Bangkok 2024 Events."
           - name: "embed-link"
             label: "Luma Embed URL"
             widget: "string"
             required: false
+            hint: Paste the embed URL for your Luma event here to display the events directly on the page. Include relevant tags when appropriate, e.g., https://lu.ma/embed/calendar/cal-nlDvL4B7Ko1swF0/events?lt=light&tag=FIL%20Bangkok%202024.
       - *image_config
       - *meta_config

--- a/public/admin/config.yml
+++ b/public/admin/config.yml
@@ -673,5 +673,16 @@ collections:
         widget: "string"
         required: false
         hint: "Luma Calendar URL for the event. Include relevant tags when appropriate, e.g., https://lu.ma/filecoin-events?tag=fil%20bangkok%202024"
+      - name: luma-events-section
+        label: "Luma Events Section"
+        widget: "object"
+        required: false
+        fields:
+          - name: "title"
+            label: "Section Title"
+            widget: "string"
+          - name: "embed-link"
+            label: "Luma Embed URL"
+            widget: "string"
       - *image_config
       - *meta_config

--- a/src/app/_schemas/eventFrontMatterSchema.ts
+++ b/src/app/_schemas/eventFrontMatterSchema.ts
@@ -18,6 +18,12 @@ export const EventFrontMatterSchema = DynamicBaseDataSchema.extend({
   location: z.string(),
   externalLink: z.string().url().optional(),
   lumaCalendarLink: z.string().url().optional(),
+  lumaEventsSection: z
+    .object({
+      title: z.string(),
+      embedLink: z.string().url(),
+    })
+    .optional(),
   startDate: z.coerce.date(),
   endDate: z.coerce.date().optional(),
 })

--- a/src/app/_utils/convertMarkdownToEventData.ts
+++ b/src/app/_utils/convertMarkdownToEventData.ts
@@ -11,6 +11,14 @@ export function convertMarkdownToEventData(data: Record<string, any>) {
     location: data.location,
     externalLink: data['external-link'],
     lumaCalendarLink: data['luma-calendar-link'],
+    lumaEventsSection:
+      data['luma-events-section']?.title &&
+      data['luma-events-section']['embed-link']
+        ? {
+            title: data['luma-events-section'].title,
+            embedLink: data['luma-events-section']['embed-link'],
+          }
+        : undefined,
     startDate: data['start-date'],
     endDate: data['end-date'],
     image: data.image,

--- a/src/app/events/[slug]/page.tsx
+++ b/src/app/events/[slug]/page.tsx
@@ -8,6 +8,7 @@ import { getEventData } from '@/utils/getEventData'
 import { getEventMetaData } from '@/utils/getMetaData'
 
 import { PageHeader } from '@/components/PageHeader'
+import { PageSection } from '@/components/PageSection'
 import { StructuredDataScript } from '@/components/StructuredDataScript'
 import { TagLabel } from '@/components/TagLabel'
 
@@ -42,6 +43,7 @@ export default function EventEntry({ params }: EventProps) {
     category,
     externalLink,
     lumaCalendarLink,
+    lumaEventsSection,
   } = data
 
   return (
@@ -61,6 +63,17 @@ export default function EventEntry({ params }: EventProps) {
           fallback: graphicsData.imageFallback,
         }}
       />
+
+      {lumaEventsSection && (
+        <PageSection kicker="Explore" title={lumaEventsSection.title}>
+          <iframe
+            src={lumaEventsSection.embedLink}
+            width="100%"
+            height="720"
+            className="rounded-lg"
+          ></iframe>
+        </PageSection>
+      )}
     </>
   )
 }

--- a/src/content/events/fil-bangkok-2024.md
+++ b/src/content/events/fil-bangkok-2024.md
@@ -10,6 +10,9 @@ end-date: 2024-11-12T11:18:00.000Z
 description: "Join the Filecoin Community in Bangkok! Dive into decentralized AI infrastructure, DePIN, and the data economy with the Filecoin community in Bangkok, ahead of Devcon. Set in the heart of Thailand, Filecoin Foundation will have dynamic programming, major announcements, and networking opportunities. Seize this opportunity to help shape the future of Filecoin and contribute to the next chapter of a better internet."
 external-link: https://lu.ma/aqyqwupe
 luma-calendar-link: https://lu.ma/filecoin-events?tag=fil%20bangkok%202024
+luma-events-section:
+  title: "FIL Bangkok 2024 Events"
+  embed-link: https://lu.ma/embed/calendar/cal-nlDvL4B7Ko1swF0/events?lt=light&tag=FIL%20Bangkok%202024
 image:
   src: /assets/images/fil-bangkok-2024.webp
 seo:


### PR DESCRIPTION
## 📝 Description

This PR extends the event data structure to include a `Luma Events Section` field. The `Luma Events Section` allows events to display an embedded link and title for integration with Luma Calendar events. The PR also includes rendering updates for displaying this section in the event pages.

- **Type:** New Feature / Content Update

## 🛠️ Key Changes

- Added `lumaEventsSection` to the `EventFrontMatterSchema`, allowing events to have a section for Luma calendar integration.
- Refactored the logic to ensure optional fields like `lumaEventsSection` are handled gracefully.
- Updated event entries to include `Luma Events Section` for FIL Bangkok event.
- Rendered `Luma Events Section` on the event detail page when data is available.

## 📌 To-Do Before Merging

- [x] Ensure all relevant events have been updated with the `Luma Events Section` where applicable.
- [x] Confirm that the embedded link and title are correctly rendered for each event.

## 🧪 How to Test

- **Setup:** Ensure the latest event content data is loaded.
- **Steps to Test:**
  1. Open the FIL Bangkok event in the application.
  2. Verify that the `Luma Events Section` is displayed with the correct title and embedded link.
  3. Test other events to ensure that the section is not rendered when the `Luma Events Section` is absent.
- **Expected Results:** 
  - Events with `lumaEventsSection` should display a title and an embedded link.
  - Events without this section should render as normal without errors.

## 📸 Screenshots
![CleanShot 2024-09-26 at 10 12 12@2x](https://github.com/user-attachments/assets/65e6d4c8-12c6-497b-a802-9abbc39670bf)
