### PR TITLE
Open Graph Data - Defaults Fix [skip percy]

### DIFF
--- a/public/admin/config.yml
+++ b/public/admin/config.yml
@@ -118,7 +118,7 @@ meta_config: &meta_config
         - "^.{0,220}$"
         - "Must have at most 220 characters."
       hint: "To generate meta title and description, copy and paste the entry content into ChatGPT 4.0, then use the prompt: 'Generate a meta title and a meta description under 220 characters for the following content: [paste your content here].'"
-    - name: "og"
+    - name: "open-graph"
       label: "Open Graph Metadata"
       widget: "object"
       required: false
@@ -130,6 +130,11 @@ meta_config: &meta_config
           widget: "string"
           required: false
           hint: "If left empty, the SEO meta title will be used."
+        - name: "description"
+          label: "Open Graph Description"
+          widget: "string"
+          required: false
+          hint: "If left empty, the SEO meta description will be used."
         - name: "image"
           label: "Open Graph Image"
           widget: "image"

--- a/src/app/_schemas/seoMetadataSchema.ts
+++ b/src/app/_schemas/seoMetadataSchema.ts
@@ -31,4 +31,3 @@ export const SeoMetadataSchema = z
   .strict()
 
 export type SeoMetadata = z.infer<typeof SeoMetadataSchema>
-export type SeoMetadataInput = z.input<typeof SeoMetadataSchema>

--- a/src/app/_schemas/seoMetadataSchema.ts
+++ b/src/app/_schemas/seoMetadataSchema.ts
@@ -13,7 +13,7 @@ export const SeoMetadataSchema = z
   .object({
     title: z.string(),
     description: z.string().max(seo_metadata_description_max_characters),
-    image: z.string().default(graphicsData.home.data.src).optional(),
+    image: z.string().optional().default(graphicsData.home.data.src),
     og: z
       .object({
         title: z.string().optional(),
@@ -23,15 +23,15 @@ export const SeoMetadataSchema = z
       .optional(),
     twitter: z
       .object({
-        card: TwitterCardType.default('summary').optional(),
+        card: TwitterCardType.optional().default('summary'),
         site: z
           .string()
-          .default(FILECOIN_FOUNDATION_URLS.social.twitter.handle)
-          .optional(),
+          .optional()
+          .default(FILECOIN_FOUNDATION_URLS.social.twitter.handle),
         creator: z
           .string()
-          .default(FILECOIN_FOUNDATION_URLS.social.twitter.handle)
-          .optional(),
+          .optional()
+          .default(FILECOIN_FOUNDATION_URLS.social.twitter.handle),
       })
       .strict()
       .optional(),

--- a/src/app/_schemas/seoMetadataSchema.ts
+++ b/src/app/_schemas/seoMetadataSchema.ts
@@ -14,9 +14,10 @@ export const SeoMetadataSchema = z
     title: z.string(),
     description: z.string().max(seo_metadata_description_max_characters),
     image: z.string().optional().default(graphicsData.home.data.src),
-    og: z
+    'open-graph': z
       .object({
         title: z.string().optional(),
+        description: z.string().optional(),
         image: z.string().optional(),
       })
       .strict()

--- a/src/app/_schemas/seoMetadataSchema.ts
+++ b/src/app/_schemas/seoMetadataSchema.ts
@@ -40,3 +40,4 @@ export const SeoMetadataSchema = z
   .strict()
 
 export type SeoMetadata = z.infer<typeof SeoMetadataSchema>
+export type SeoMetadataInput = z.input<typeof SeoMetadataSchema>

--- a/src/app/_schemas/seoMetadataSchema.ts
+++ b/src/app/_schemas/seoMetadataSchema.ts
@@ -1,9 +1,6 @@
 import { z } from 'zod'
 
-import { FILECOIN_FOUNDATION_URLS } from '@/constants/siteMetadata'
-
 import configJson from '@/data/cmsConfigSchema.json'
-import { graphicsData } from '@/data/graphicsData'
 
 const { seo_metadata_description_max_characters } = configJson
 
@@ -13,7 +10,7 @@ export const SeoMetadataSchema = z
   .object({
     title: z.string(),
     description: z.string().max(seo_metadata_description_max_characters),
-    image: z.string().optional().default(graphicsData.home.data.src),
+    image: z.string().optional(),
     'open-graph': z
       .object({
         title: z.string().optional(),
@@ -24,15 +21,9 @@ export const SeoMetadataSchema = z
       .optional(),
     twitter: z
       .object({
-        card: TwitterCardType.optional().default('summary'),
-        site: z
-          .string()
-          .optional()
-          .default(FILECOIN_FOUNDATION_URLS.social.twitter.handle),
-        creator: z
-          .string()
-          .optional()
-          .default(FILECOIN_FOUNDATION_URLS.social.twitter.handle),
+        card: TwitterCardType.optional(),
+        site: z.string().optional(),
+        creator: z.string().optional(),
       })
       .strict()
       .optional(),

--- a/src/app/_utils/createMetadata.ts
+++ b/src/app/_utils/createMetadata.ts
@@ -2,7 +2,10 @@ import { type Metadata as NextMetadata } from 'next'
 
 import type { DynamicPathValues, PathValues } from '@/constants/paths'
 
-import type { SeoMetadata } from '@/schemas/seoMetadataSchema'
+import {
+  type SeoMetadata,
+  SeoMetadataSchema,
+} from '@/schemas/seoMetadataSchema'
 
 type CreateMetadataProps = {
   seo: SeoMetadata
@@ -15,23 +18,44 @@ export function createMetadata({
   path,
   overrideDefaultTitle = false,
 }: CreateMetadataProps): NextMetadata {
-  const { title, description, image } = seo
+  const parsedSEO = SeoMetadataSchema.parse(seo)
 
-  return {
-    title: overrideDefaultTitle ? { absolute: title } : title,
-    description,
-    openGraph: {
-      title: seo.og?.title || title,
-      description,
-      images: seo.og?.image || image,
+  const enrichedSEO = {
+    title: parsedSEO.title,
+    description: parsedSEO.description,
+    og: {
+      title: parsedSEO.og?.title || parsedSEO.title,
+      image: parsedSEO.og?.image || parsedSEO.image,
     },
     twitter: {
-      card: seo.twitter?.card,
-      site: seo.twitter?.site,
-      creator: seo.twitter?.creator,
+      card: parsedSEO.twitter?.card,
+      site: parsedSEO.twitter?.site,
+      creator: parsedSEO.twitter?.creator,
+    },
+  }
+
+  const parsedEnrichedSEO = SeoMetadataSchema.parse(enrichedSEO)
+
+  const meta = {
+    title: overrideDefaultTitle
+      ? { absolute: parsedEnrichedSEO.title }
+      : parsedEnrichedSEO.title,
+    description: parsedEnrichedSEO.description,
+    openGraph: {
+      title: parsedEnrichedSEO.og?.title,
+      description: parsedEnrichedSEO.description,
+      images: parsedEnrichedSEO.og?.image,
+    },
+    twitter: {
+      card: parsedEnrichedSEO.twitter?.card,
+      site: parsedEnrichedSEO.twitter?.site,
+      creator: parsedEnrichedSEO.twitter?.creator,
     },
     alternates: {
       canonical: path,
     },
   }
+
+  console.log({ seo, parsedSEO, enrichedSEO, parsedEnrichedSEO, meta })
+  return meta
 }

--- a/src/app/_utils/createMetadata.ts
+++ b/src/app/_utils/createMetadata.ts
@@ -3,12 +3,12 @@ import { type Metadata as NextMetadata } from 'next'
 import type { DynamicPathValues, PathValues } from '@/constants/paths'
 
 import {
-  type SeoMetadata,
+  type SeoMetadataInput,
   SeoMetadataSchema,
 } from '@/schemas/seoMetadataSchema'
 
 type CreateMetadataProps = {
-  seo: SeoMetadata
+  seo: SeoMetadataInput
   path: PathValues | DynamicPathValues
   overrideDefaultTitle?: boolean
 }

--- a/src/app/_utils/createMetadata.ts
+++ b/src/app/_utils/createMetadata.ts
@@ -23,9 +23,11 @@ export function createMetadata({
   const enrichedSEO = {
     title: parsedSEO.title,
     description: parsedSEO.description,
-    og: {
-      title: parsedSEO.og?.title || parsedSEO.title,
-      image: parsedSEO.og?.image || parsedSEO.image,
+    'open-graph': {
+      title: parsedSEO['open-graph']?.title || parsedSEO.title,
+      description:
+        parsedSEO['open-graph']?.description || parsedSEO.description,
+      image: parsedSEO['open-graph']?.image || parsedSEO.image,
     },
     twitter: {
       card: parsedSEO.twitter?.card,
@@ -36,15 +38,15 @@ export function createMetadata({
 
   const parsedEnrichedSEO = SeoMetadataSchema.parse(enrichedSEO)
 
-  const meta = {
+  return {
     title: overrideDefaultTitle
       ? { absolute: parsedEnrichedSEO.title }
       : parsedEnrichedSEO.title,
     description: parsedEnrichedSEO.description,
     openGraph: {
-      title: parsedEnrichedSEO.og?.title,
+      title: parsedEnrichedSEO['open-graph']?.title,
       description: parsedEnrichedSEO.description,
-      images: parsedEnrichedSEO.og?.image,
+      images: parsedEnrichedSEO['open-graph']?.image,
     },
     twitter: {
       card: parsedEnrichedSEO.twitter?.card,
@@ -55,7 +57,4 @@ export function createMetadata({
       canonical: path,
     },
   }
-
-  console.log({ seo, parsedSEO, enrichedSEO, parsedEnrichedSEO, meta })
-  return meta
 }

--- a/src/app/_utils/createMetadata.ts
+++ b/src/app/_utils/createMetadata.ts
@@ -6,12 +6,12 @@ import { FILECOIN_FOUNDATION_URLS } from '@/constants/siteMetadata'
 import { graphicsData } from '@/data/graphicsData'
 
 import {
-  type SeoMetadataInput,
+  type SeoMetadata,
   SeoMetadataSchema,
 } from '@/schemas/seoMetadataSchema'
 
 type CreateMetadataProps = {
-  seo: SeoMetadataInput
+  seo: SeoMetadata
   path: PathValues | DynamicPathValues
   overrideDefaultTitle?: boolean
 }

--- a/src/app/_utils/createMetadata.ts
+++ b/src/app/_utils/createMetadata.ts
@@ -1,6 +1,9 @@
 import { type Metadata as NextMetadata } from 'next'
 
 import type { DynamicPathValues, PathValues } from '@/constants/paths'
+import { FILECOIN_FOUNDATION_URLS } from '@/constants/siteMetadata'
+
+import { graphicsData } from '@/data/graphicsData'
 
 import {
   type SeoMetadataInput,
@@ -18,21 +21,21 @@ export function createMetadata({
   path,
   overrideDefaultTitle = false,
 }: CreateMetadataProps): NextMetadata {
-  const parsedSEO = SeoMetadataSchema.parse(seo)
-
   const enrichedSEO = {
-    title: parsedSEO.title,
-    description: parsedSEO.description,
+    title: seo.title,
+    description: seo.description,
+    image: seo.image || graphicsData.home.data.src,
     'open-graph': {
-      title: parsedSEO['open-graph']?.title || parsedSEO.title,
-      description:
-        parsedSEO['open-graph']?.description || parsedSEO.description,
-      image: parsedSEO['open-graph']?.image || parsedSEO.image,
+      title: seo['open-graph']?.title || seo.title,
+      description: seo['open-graph']?.description || seo.description,
+      image:
+        seo['open-graph']?.image || seo.image || graphicsData.home.data.src,
     },
     twitter: {
-      card: parsedSEO.twitter?.card,
-      site: parsedSEO.twitter?.site,
-      creator: parsedSEO.twitter?.creator,
+      card: seo.twitter?.card || 'summary',
+      site: seo.twitter?.site || FILECOIN_FOUNDATION_URLS.social.twitter.handle,
+      creator:
+        seo.twitter?.creator || FILECOIN_FOUNDATION_URLS.social.twitter.handle,
     },
   }
 


### PR DESCRIPTION
This pull request includes several changes to improve the handling and validation of SEO metadata. The most important changes involve renaming and adding fields in the configuration files, updating the schema for SEO metadata, and enriching the SEO metadata in the utility function.

### Configuration Updates:
* [`public/admin/config.yml`](diffhunk://#diff-c4b7720f4813ef734de91022075db713c78b4d0566dd7a95f868d75a65935486L121-R121): Renamed `og` to `open-graph` and added a `description` field under the Open Graph metadata configuration. [[1]](diffhunk://#diff-c4b7720f4813ef734de91022075db713c78b4d0566dd7a95f868d75a65935486L121-R121) [[2]](diffhunk://#diff-c4b7720f4813ef734de91022075db713c78b4d0566dd7a95f868d75a65935486R133-R137)

### Schema Updates:
* [`src/app/_schemas/seoMetadataSchema.ts`](diffhunk://#diff-4095673b3d519863c66d9d5918e5f276d39669c89f473d164bdc7bb84127d94dL3-L6): Updated the `SeoMetadataSchema` to reflect the changes in the configuration, including renaming `og` to `open-graph` and adding optional fields for Open Graph metadata. Removed default values for Twitter metadata. [[1]](diffhunk://#diff-4095673b3d519863c66d9d5918e5f276d39669c89f473d164bdc7bb84127d94dL3-L6) [[2]](diffhunk://#diff-4095673b3d519863c66d9d5918e5f276d39669c89f473d164bdc7bb84127d94dL16-R26)

### Utility Function Updates:
* [`src/app/_utils/createMetadata.ts`](diffhunk://#diff-4c8c6cd7ea449c16d415861ae76c76fd47aeb3760e45258d389fdce37256ae9fR4-R11): Enriched the SEO metadata by providing default values and ensuring the new schema is used for validation. Updated the Open Graph and Twitter metadata handling to align with the new schema. [[1]](diffhunk://#diff-4c8c6cd7ea449c16d415861ae76c76fd47aeb3760e45258d389fdce37256ae9fR4-R11) [[2]](diffhunk://#diff-4c8c6cd7ea449c16d415861ae76c76fd47aeb3760e45258d389fdce37256ae9fL18-R57)