### PR TITLE
[UXIT-1568] Include textColor prop to TableHead

### DIFF
--- a/src/app/_components/Table/TableHead.tsx
+++ b/src/app/_components/Table/TableHead.tsx
@@ -7,12 +7,12 @@ import { clsx } from 'clsx'
 
 type TableHeadProps<Data extends RowData> = {
   headerGroups: Array<HeaderGroup<Data>>
-  headerColor?: 'text-brand-100' | 'text-brand-300'
+  textColor?: 'text-brand-100' | 'text-brand-300'
 }
 
 export function TableHead<Data extends RowData>({
   headerGroups,
-  headerColor = 'text-brand-100',
+  textColor = 'text-brand-100',
 }: TableHeadProps<Data>) {
   const firstHeaderGroup = headerGroups[0]
   const { headers } = firstHeaderGroup
@@ -26,7 +26,7 @@ export function TableHead<Data extends RowData>({
           return (
             <th
               key={header.id}
-              className={clsx('cell', headerColor, meta?.headerCellStyle)}
+              className={clsx('cell', textColor, meta?.headerCellStyle)}
             >
               {flexRender(header.column.columnDef.header, header.getContext())}
             </th>

--- a/src/app/_components/Table/TableHead.tsx
+++ b/src/app/_components/Table/TableHead.tsx
@@ -7,10 +7,12 @@ import { clsx } from 'clsx'
 
 type TableHeadProps<Data extends RowData> = {
   headerGroups: Array<HeaderGroup<Data>>
+  headerColor?: 'text-brand-100' | 'text-brand-300'
 }
 
 export function TableHead<Data extends RowData>({
   headerGroups,
+  headerColor = 'text-brand-100',
 }: TableHeadProps<Data>) {
   const firstHeaderGroup = headerGroups[0]
   const { headers } = firstHeaderGroup
@@ -22,7 +24,10 @@ export function TableHead<Data extends RowData>({
           const { meta } = header.column.columnDef
 
           return (
-            <th key={header.id} className={clsx('cell', meta?.headerCellStyle)}>
+            <th
+              key={header.id}
+              className={clsx('cell', headerColor, meta?.headerCellStyle)}
+            >
               {flexRender(header.column.columnDef.header, header.getContext())}
             </th>
           )

--- a/src/app/filecoin-plus/allocators/components/AllocatorsTable.tsx
+++ b/src/app/filecoin-plus/allocators/components/AllocatorsTable.tsx
@@ -33,7 +33,7 @@ export function AllocatorsTable({ allocators }: AllocatorsTableProps) {
       <table className="w-full">
         <TableHead
           headerGroups={table.getHeaderGroups()}
-          headerColor="text-brand-300"
+          textColor="text-brand-300"
         />
         <TableBody rowModel={table.getRowModel()} />
       </table>

--- a/src/app/filecoin-plus/allocators/components/AllocatorsTable.tsx
+++ b/src/app/filecoin-plus/allocators/components/AllocatorsTable.tsx
@@ -31,7 +31,10 @@ export function AllocatorsTable({ allocators }: AllocatorsTableProps) {
   return (
     <div className="w-full overflow-x-auto">
       <table className="w-full">
-        <TableHead headerGroups={table.getHeaderGroups()} />
+        <TableHead
+          headerGroups={table.getHeaderGroups()}
+          headerColor="text-brand-300"
+        />
         <TableBody rowModel={table.getRowModel()} />
       </table>
     </div>


### PR DESCRIPTION
This pull request includes changes to the `TableHead` component to add a `textColor` prop, which allows customization of the header text color. Additionally, the `AllocatorsTable` component is updated to use this new prop.

Changes to `TableHead` component:

* [`src/app/_components/Table/TableHead.tsx`](diffhunk://#diff-1bae739cc1fe6b4951801252477ec3493a51f255d098130c9cbf193f17e8cd9eR10-R15): Added `textColor` prop to `TableHeadProps` and set a default value of `'text-brand-100'`. Updated the `TableHead` function to apply `textColor` to the header cells. [[1]](diffhunk://#diff-1bae739cc1fe6b4951801252477ec3493a51f255d098130c9cbf193f17e8cd9eR10-R15) [[2]](diffhunk://#diff-1bae739cc1fe6b4951801252477ec3493a51f255d098130c9cbf193f17e8cd9eL25-R30)

Changes to `AllocatorsTable` component:

* [`src/app/filecoin-plus/allocators/components/AllocatorsTable.tsx`](diffhunk://#diff-b84cbbc79a9a799dbc73004afe7910b49caa54db8976b0684651dd76c1aa7cfcL34-R37): Updated the `TableHead` usage to pass `textColor="text-brand-300"`.