### PR TITLE
Fixed revalidate configuration to resolve static analyzability error

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -8,9 +8,7 @@ import { BASE_URL, ORGANIZATION_NAME } from '@/constants/siteMetadata'
 
 import { SiteLayout } from '@/components/SiteLayout'
 
-const REVALIDATE_TIME_IN_SECONDS = 24 * 60 * 60
-
-export const revalidate = REVALIDATE_TIME_IN_SECONDS
+export const revalidate = 86400
 
 export const metadata: Metadata = {
   title: {


### PR DESCRIPTION
- Updated the revalidate configuration from `const REVALIDATE_TIME_IN_SECONDS = 24 * 60 * 60` to a direct value of `86400` to resolve the error related to static analyzability.
- The previous configuration caused a TypeScript error, as the revalidation time must be statically analyzable and a constant expression was not allowed.

![image](https://github.com/user-attachments/assets/0dd23a0b-1d0d-42ba-a9da-c98df5a54c67)
