### PR TITLE
[UXIT-1596] Fix Card image Fit

### DIFF
--- a/src/app/_components/Card.tsx
+++ b/src/app/_components/Card.tsx
@@ -90,7 +90,9 @@ export function Card({
   )
 }
 
-Card.Image = function ImageComponent({ image }: { image: CardImageProps }) {
+Card.Image = function ImageComponent({
+  image,
+}: Required<Pick<CardProps, 'image'>>) {
   const isStaticImage = 'data' in image
 
   const commonProps = {

--- a/src/app/_components/Card.tsx
+++ b/src/app/_components/Card.tsx
@@ -29,12 +29,12 @@ type CardProps = {
   tagLabel?: TagGroupProps['label']
   metaData?: MetaDataType
   description?: string
-  cta?: CTAProps
+  cta?: CTAPropsWithSpacing
   image?: CardImageProps
   borderColor?: 'brand-300' | 'brand-400' | 'brand-500' | 'brand-600'
   textIsClamped?: boolean
   as?: React.ElementType
-  avatar?: AvatarGroupProps['authors']
+  avatars?: AvatarGroupProps['authors']
 }
 
 type SpacingValue = keyof typeof theme.spacing
@@ -43,7 +43,7 @@ type BreakpointValue = keyof typeof theme.screens
 type LeftProperty = `left-${SpacingValue}`
 type ResponsiveLeftProperty = `${BreakpointValue}:${LeftProperty}`
 
-type LinkProps = {
+type CTAPropsWithSpacing = {
   left?: LeftProperty | [LeftProperty, ResponsiveLeftProperty]
 } & CTAProps
 
@@ -64,7 +64,7 @@ export function Card({
   borderColor = 'brand-500',
   textIsClamped = false,
   as: Tag = 'li',
-  avatar,
+  avatars,
 }: CardProps) {
   return (
     <Tag
@@ -75,14 +75,17 @@ export function Card({
     >
       {image && <Card.Image image={image} />}
       <div className="flex flex-col gap-3 p-4">
-        <Card.MetaAndTags tagLabel={tagLabel} metaData={metaData} />
+        {tagLabel && <TagGroup label={tagLabel} />}
+        {metaData && <Meta metaData={metaData} />}
         <Card.Title title={title} />
         <div className={clsx(cta && 'mb-10')}>
-          <Card.Description
-            description={description}
-            textIsClamped={textIsClamped}
-          />
-          <Card.Avatar avatar={avatar} />
+          {description && (
+            <Card.Description
+              description={description}
+              textIsClamped={textIsClamped}
+            />
+          )}
+          {avatars && <Card.Avatars avatars={avatars} />}
           {cta && <Card.Link {...cta} />}
         </div>
       </div>
@@ -133,21 +136,7 @@ Card.Image = function ImageComponent({
   )
 }
 
-Card.MetaAndTags = function MetaAndTags({
-  tagLabel,
-  metaData,
-}: Pick<CardProps, 'tagLabel' | 'metaData'>) {
-  return (
-    <>
-      {tagLabel && <TagGroup label={tagLabel} />}
-      {metaData && metaData.length > 0 && <Meta metaData={metaData} />}
-    </>
-  )
-}
-
 Card.Title = function Title({ title }: Pick<CardProps, 'title'>) {
-  if (!title) return null
-
   return typeof title === 'string' ? (
     <Heading isClamped tag="h3" variant="lg">
       {title}
@@ -160,9 +149,7 @@ Card.Title = function Title({ title }: Pick<CardProps, 'title'>) {
 Card.Description = function Description({
   description,
   textIsClamped,
-}: Pick<CardProps, 'description' | 'textIsClamped'>) {
-  if (!description) return null
-
+}: Required<Pick<CardProps, 'description' | 'textIsClamped'>>) {
   return (
     <p className={clsx(textIsClamped && 'line-clamp-3 text-ellipsis')}>
       {description}
@@ -170,16 +157,12 @@ Card.Description = function Description({
   )
 }
 
-Card.Avatar = function Avatar({
-  avatar,
-}: {
-  avatar?: AvatarGroupProps['authors']
-}) {
-  if (!avatar) return null
-
+Card.Avatars = function Avatars({
+  avatars,
+}: Required<Pick<CardProps, 'avatars'>>) {
   return (
     <div className="mt-6">
-      <AvatarGroup authors={avatar} />
+      <AvatarGroup authors={avatars} />
     </div>
   )
 }
@@ -190,7 +173,7 @@ Card.Link = function Link({
   icon,
   text,
   left = 'left-4',
-}: LinkProps) {
+}: NonNullable<CardProps['cta']>) {
   const isExternal = isExternalLink(href)
   const textElement = <span>{text}</span>
 

--- a/src/app/_components/PageHeader.tsx
+++ b/src/app/_components/PageHeader.tsx
@@ -73,8 +73,9 @@ PageHeader.Title = function Title({ children }: TitleProps) {
 
 PageHeader.Image = function PageHeaderImage({
   image,
-}: Required<Pick<PageHeaderProps, 'image'>>) {
+}: Pick<PageHeaderProps, 'image'>) {
   const isStaticImage = 'data' in image
+
   const commonProps = {
     alt: image.alt,
     priority: true,

--- a/src/app/_components/PageHeader.tsx
+++ b/src/app/_components/PageHeader.tsx
@@ -2,7 +2,7 @@ import Image, { type ImageProps } from 'next/image'
 
 import { clsx } from 'clsx'
 
-import type { StaticImageProps } from '@/types/imageType'
+import type { ImageObjectFit, StaticImageProps } from '@/types/imageType'
 
 import { buildImageSizeProp } from '@/utils/buildImageSizeProp'
 
@@ -22,9 +22,13 @@ type TitleProps = {
   children: string
 }
 
+type PageHeaderImageProps = (StaticImageProps | ImageProps) & {
+  objectFit?: ImageObjectFit
+}
+
 type PageHeaderProps = {
   title: TitleProps['children']
-  image: StaticImageProps | ImageProps
+  image: PageHeaderImageProps
   isFeatured?: boolean
   metaData?: MetaDataType
   description?: DescriptionTextType
@@ -69,14 +73,18 @@ PageHeader.Title = function Title({ children }: TitleProps) {
 
 PageHeader.Image = function PageHeaderImage({
   image,
-}: Pick<PageHeaderProps, 'image'>) {
+}: Required<Pick<PageHeaderProps, 'image'>>) {
   const isStaticImage = 'data' in image
   const commonProps = {
     alt: image.alt,
     priority: true,
     quality: 100,
     sizes: buildImageSizeProp({ startSize: '100vw', lg: '490px' }),
-    className: 'rounded-lg border border-brand-100',
+    className: clsx(
+      'rounded-lg border border-brand-100',
+      image.objectFit === 'cover' && 'object-cover',
+      image.objectFit === 'contain' && 'object-contain',
+    ),
   }
 
   if (isStaticImage) {

--- a/src/app/blog/page.tsx
+++ b/src/app/blog/page.tsx
@@ -116,6 +116,7 @@ export default function Blog({ searchParams }: Props) {
         image={{
           ...(featuredPost.image || graphicsData.imageFallback.data),
           alt: '',
+          objectFit: 'cover',
         }}
         cta={{
           href: `${PATHS.BLOG.path}/${featuredPostSlug}`,
@@ -213,6 +214,7 @@ export default function Blog({ searchParams }: Props) {
                             ...(image || graphicsData.imageFallback.data),
                             alt: '',
                             priority: isFirstTwoImages,
+                            objectFit: 'cover',
                             sizes: buildImageSizeProp({
                               startSize: '100vw',
                               sm: '350px',

--- a/src/app/digest/page.tsx
+++ b/src/app/digest/page.tsx
@@ -67,7 +67,7 @@ export default function Digest() {
                 key={slug}
                 title={title}
                 tagLabel={[`Issue ${issueNumber}`, `Article ${articleNumber}`]}
-                avatar={authors}
+                avatars={authors}
                 description={description}
                 textIsClamped={true}
                 cta={{

--- a/src/app/events/page.tsx
+++ b/src/app/events/page.tsx
@@ -120,6 +120,7 @@ export default function Events({ searchParams }: Props) {
         image={{
           ...(featuredEvent.image || graphicsData.imageFallback.data),
           alt: '',
+          objectFit: 'cover',
         }}
         cta={{
           href: `${PATHS.EVENTS.path}/${featuredEventSlug}`,
@@ -207,8 +208,8 @@ export default function Events({ searchParams }: Props) {
                           image={{
                             ...(image || graphicsData.imageFallback.data),
                             alt: '',
-
                             priority: isFirstTwoImages,
+                            objectFit: 'cover',
                             sizes: buildImageSizeProp({
                               startSize: '100vw',
                               sm: '350px',


### PR DESCRIPTION
## 📝 Description

This PR improves the fit of dynamic images by adding `objectFit: cover`. The `DynamicImage` component previously handled this automatically, but it was removed during the refactor in [#700.](https://github.com/FilecoinFoundationWeb/filecoin-foundation/pull/700)

## 🛠️ Key Changes
- Adds `objectFit: cover` to `Card` on blog & event pages
- Adds `objectFit: cover` to `PageHeader` on blog & event pages
- Cleans up the prop definitions in the `Card` sub-components by making all props required.

## 📸 Screenshots

Before
![CleanShot 2024-10-11 at 16 08 14@2x](https://github.com/user-attachments/assets/4c0b71db-699d-46f7-a320-5a0e46b7d721)

After
![CleanShot 2024-10-11 at 16 07 55@2x](https://github.com/user-attachments/assets/5ac1917b-4e8f-4a79-9d26-2d3ea65e45e1)
