### PR TITLE
[UXIT-1646] Events Page · Add CTA Section

### DIFF
--- a/src/app/events/[slug]/page.tsx
+++ b/src/app/events/[slug]/page.tsx
@@ -6,12 +6,14 @@ import { getCategoryLabel } from '@/utils/categoryUtils'
 import { createMetadata } from '@/utils/createMetadata'
 import { getEventMetaData } from '@/utils/getMetaData'
 
+import { CTASection } from '@/components/CTASection'
 import { PageHeader } from '@/components/PageHeader'
 import { PageLayout } from '@/components/PageLayout'
 import { PageSection } from '@/components/PageSection'
 import { StructuredDataScript } from '@/components/StructuredDataScript'
 import { TagLabel } from '@/components/TagLabel'
 
+import { getInvolvedData } from '../data/getInvolvedData'
 import { getEventData } from '../utils/getEventData'
 
 import { ScheduleSection } from './components/ScheduleSection'
@@ -39,6 +41,7 @@ export function generateMetadata({ params }: EventProps) {
 export default function EventEntry({ params }: EventProps) {
   const { slug } = params
   const data = getEventData(slug)
+  const sponsorEventData = getInvolvedData[0]
 
   const {
     title,
@@ -88,6 +91,15 @@ export default function EventEntry({ params }: EventProps) {
       {eventHasSpeakers && <SpeakersSection speakers={speakers} />}
       {eventHasSchedule && <ScheduleSection schedule={schedule} />}
       {eventHasSponsors && <SponsorSection sponsors={sponsors} />}
+
+      <CTASection
+        title={sponsorEventData.title}
+        description={sponsorEventData.description}
+        cta={{
+          href: sponsorEventData.cta.href,
+          text: sponsorEventData.cta.text,
+        }}
+      />
     </PageLayout>
   )
 }


### PR DESCRIPTION
## 📝 Description

This PR adds the `CTASection` to the `EventEntry` page. It reuses the information from the `getInvolvedData` and includes a title, description, and a CTA button linking to relevant content.

Note: The current implementation differs from the [Figma design](https://www.figma.com/design/0pBfQs5tKI6bx5ypPIfVRA/FIL.org-V4-Prototypes?node-id=6708-93567&t=YZmuwHWJoWNz3qmp-4). This is due to an open request with the design team, which is still pending feedback.

## 📸 Screenshots
![CleanShot 2024-10-16 at 16 12 51@2x](https://github.com/user-attachments/assets/ddf61b8b-bacc-4951-bb53-51bcb2c91bfc)
