### PR TITLE
UXIT-1501 - Testing: remove trim and truncate text

### DIFF
--- a/src/app/digest/utils/getDigestArticleData.ts
+++ b/src/app/digest/utils/getDigestArticleData.ts
@@ -35,15 +35,17 @@ export function getAllDigestArticleDataSortedByNumber() {
 }
 
 function generatePreviewDescription(content: string) {
-  const truncatedContent = truncateText(content, DESCRIPTION_PREVIEW_MAX_LENGTH)
-  const plainText = removeMarkdown(truncatedContent)
-  return cleanAndTrim(plainText)
+  // const truncatedContent = truncateText(content, DESCRIPTION_PREVIEW_MAX_LENGTH)
+  const plainText = removeMarkdown(content)
+
+  // const text = cleanAndTrim(plainText)
+  return plainText
 }
 
-function truncateText(text: string, maxLength: number) {
-  return text.substring(0, maxLength)
-}
+// function truncateText(text: string, maxLength: number) {
+//   return text.substring(0, maxLength)
+// }
 
-function cleanAndTrim(text: string) {
-  return text.replace(/\s+/g, ' ').trim()
-}
+// function cleanAndTrim(text: string) {
+//   return text.replace(/\s+/g, ' ').trim()
+// }

--- a/src/app/digest/utils/getDigestArticleData.ts
+++ b/src/app/digest/utils/getDigestArticleData.ts
@@ -25,16 +25,10 @@ export function getAllDigestArticleData() {
 
   return articles.map((article) => ({
     ...article,
-    description: generatePreviewDescription(article.content),
+    description: removeMarkdown(article.content),
   }))
 }
 
 export function getAllDigestArticleDataSortedByNumber() {
   return getAllDigestArticleData().sort(sortArticlesByNumber)
-}
-
-function generatePreviewDescription(content: string) {
-  const plainText = removeMarkdown(content)
-
-  return plainText
 }

--- a/src/app/digest/utils/getDigestArticleData.ts
+++ b/src/app/digest/utils/getDigestArticleData.ts
@@ -8,7 +8,6 @@ import { DigestArticleFrontMatterSchema } from '../schemas/FrontMatterSchema'
 import { sortArticlesByNumber } from '../utils/sortArticlesByNumber'
 
 const DIGEST_DIRECTORY_PATH = PATHS.DIGEST.entriesContentPath as string
-const DESCRIPTION_PREVIEW_MAX_LENGTH = 220
 
 export function getDigestArticleData(slug: string) {
   return getMarkdownData({
@@ -35,17 +34,7 @@ export function getAllDigestArticleDataSortedByNumber() {
 }
 
 function generatePreviewDescription(content: string) {
-  // const truncatedContent = truncateText(content, DESCRIPTION_PREVIEW_MAX_LENGTH)
   const plainText = removeMarkdown(content)
 
-  // const text = cleanAndTrim(plainText)
   return plainText
 }
-
-// function truncateText(text: string, maxLength: number) {
-//   return text.substring(0, maxLength)
-// }
-
-// function cleanAndTrim(text: string) {
-//   return text.replace(/\s+/g, ' ').trim()
-// }


### PR DESCRIPTION
## 📝 Description

Removed `truncateText` and `cleanAndTrim` as we have `textIsClamped` in `Description` component that shortens the text. This might be cause the mismatch between server and client side HTML. 

- **Type:** Bug fix 

