### PR TITLE
[UXIT-1540] Refactor SEO title metadata 

### DIFF
--- a/cypress/e2e/critical/single_blog_post_page_spec.cy.ts
+++ b/cypress/e2e/critical/single_blog_post_page_spec.cy.ts
@@ -1,14 +1,20 @@
 import { PATHS } from '@/constants/paths'
 
 import { getRandomSlug } from '@/support/getRandomSlugUtil'
-import { verifyMetadata } from '@/support/verifyMetadataUtil'
+import { verifyMetadataForDynamicPages } from '@/support/verifyMetadataForDynamicPagesUtil'
 
 describe('Random Blog Post', () => {
   it('should check metadata', () => {
     const blogDirectoryPath = PATHS.BLOG.entriesContentPath as string
 
     getRandomSlug(blogDirectoryPath).then((slug) => {
-      verifyMetadata(blogDirectoryPath, `${PATHS.BLOG.path}/${slug}`, slug)
+      const fullPath = `${blogDirectoryPath}/${slug}.md`
+      const pagePath = `${PATHS.BLOG.path}/${slug}`
+
+      verifyMetadataForDynamicPages({
+        fullPath,
+        pagePath,
+      })
     })
   })
 })

--- a/cypress/e2e/critical/single_blog_post_page_spec.cy.ts
+++ b/cypress/e2e/critical/single_blog_post_page_spec.cy.ts
@@ -1,20 +1,22 @@
 import { PATHS } from '@/constants/paths'
 
+import { generateDynamicPaths } from '@/support/generateDynamicPathsUtil'
 import { getRandomSlug } from '@/support/getRandomSlugUtil'
 import { verifyMetadataForDynamicPages } from '@/support/verifyMetadataForDynamicPagesUtil'
 
 describe('Random Blog Post', () => {
   it('should check metadata', () => {
-    const BLOG_CONTENT_PATH = PATHS.BLOG.entriesContentPath as string
-    const BLOG_BASE_URL = PATHS.BLOG.path
+    const BLOG_BASE_PATHS = PATHS.BLOG
 
-    getRandomSlug(BLOG_CONTENT_PATH).then((slug) => {
-      const ENTRY_FILE_PATH = `${BLOG_CONTENT_PATH}/${slug}.md`
-      const PAGE_URL = `${BLOG_BASE_URL}/${slug}`
+    getRandomSlug(BLOG_BASE_PATHS.entriesContentPath as string).then((slug) => {
+      const { contentFilePath, pageUrl } = generateDynamicPaths(
+        BLOG_BASE_PATHS,
+        slug,
+      )
 
       verifyMetadataForDynamicPages({
-        contentFilePath: ENTRY_FILE_PATH,
-        urlPath: PAGE_URL,
+        contentFilePath,
+        urlPath: pageUrl,
       })
     })
   })

--- a/cypress/e2e/critical/single_blog_post_page_spec.cy.ts
+++ b/cypress/e2e/critical/single_blog_post_page_spec.cy.ts
@@ -5,15 +5,16 @@ import { verifyMetadataForDynamicPages } from '@/support/verifyMetadataForDynami
 
 describe('Random Blog Post', () => {
   it('should check metadata', () => {
-    const blogDirectoryPath = PATHS.BLOG.entriesContentPath as string
+    const BLOG_CONTENT_PATH = PATHS.BLOG.entriesContentPath as string
+    const BLOG_BASE_URL = PATHS.BLOG.path
 
-    getRandomSlug(blogDirectoryPath).then((slug) => {
-      const fullPath = `${blogDirectoryPath}/${slug}.md`
-      const pagePath = `${PATHS.BLOG.path}/${slug}`
+    getRandomSlug(BLOG_CONTENT_PATH).then((slug) => {
+      const ENTRY_FILE_PATH = `${BLOG_CONTENT_PATH}/${slug}.md`
+      const PAGE_URL = `${BLOG_BASE_URL}/${slug}`
 
       verifyMetadataForDynamicPages({
-        fullPath,
-        pagePath,
+        contentFilePath: ENTRY_FILE_PATH,
+        urlPath: PAGE_URL,
       })
     })
   })

--- a/cypress/e2e/critical/single_digest_article_page_spec.cy.ts
+++ b/cypress/e2e/critical/single_digest_article_page_spec.cy.ts
@@ -5,15 +5,16 @@ import { verifyMetadataForDynamicPages } from '@/support/verifyMetadataForDynami
 
 describe('Random Digest Article', () => {
   it('should check metadata', () => {
-    const digestDirectoryPath = PATHS.DIGEST.entriesContentPath as string
+    const DIGEST_CONTENT_PATH = PATHS.DIGEST.entriesContentPath as string
+    const DIGEST_BASE_URL = PATHS.DIGEST.path
 
-    getRandomSlug(digestDirectoryPath).then((slug) => {
-      const fullPath = `${digestDirectoryPath}/${slug}.md`
-      const pagePath = `${PATHS.DIGEST.path}/${slug}`
+    getRandomSlug(DIGEST_CONTENT_PATH).then((slug) => {
+      const ENTRY_FILE_PATH = `${DIGEST_CONTENT_PATH}/${slug}.md`
+      const PAGE_URL = `${DIGEST_BASE_URL}/${slug}`
 
       verifyMetadataForDynamicPages({
-        fullPath,
-        pagePath,
+        contentFilePath: ENTRY_FILE_PATH,
+        urlPath: PAGE_URL,
       })
     })
   })

--- a/cypress/e2e/critical/single_digest_article_page_spec.cy.ts
+++ b/cypress/e2e/critical/single_digest_article_page_spec.cy.ts
@@ -1,14 +1,20 @@
 import { PATHS } from '@/constants/paths'
 
 import { getRandomSlug } from '@/support/getRandomSlugUtil'
-import { verifyMetadata } from '@/support/verifyMetadataUtil'
+import { verifyMetadataForDynamicPages } from '@/support/verifyMetadataForDynamicPagesUtil'
 
 describe('Random Digest Article', () => {
   it('should check metadata', () => {
     const digestDirectoryPath = PATHS.DIGEST.entriesContentPath as string
 
     getRandomSlug(digestDirectoryPath).then((slug) => {
-      verifyMetadata(digestDirectoryPath, `${PATHS.DIGEST.path}/${slug}`, slug)
+      const fullPath = `${digestDirectoryPath}/${slug}.md`
+      const pagePath = `${PATHS.DIGEST.path}/${slug}`
+
+      verifyMetadataForDynamicPages({
+        fullPath,
+        pagePath,
+      })
     })
   })
 })

--- a/cypress/e2e/critical/single_digest_article_page_spec.cy.ts
+++ b/cypress/e2e/critical/single_digest_article_page_spec.cy.ts
@@ -1,21 +1,25 @@
 import { PATHS } from '@/constants/paths'
 
+import { generateDynamicPaths } from '@/support/generateDynamicPathsUtil'
 import { getRandomSlug } from '@/support/getRandomSlugUtil'
 import { verifyMetadataForDynamicPages } from '@/support/verifyMetadataForDynamicPagesUtil'
 
 describe('Random Digest Article', () => {
   it('should check metadata', () => {
-    const DIGEST_CONTENT_PATH = PATHS.DIGEST.entriesContentPath as string
-    const DIGEST_BASE_URL = PATHS.DIGEST.path
+    const DIGEST_BASE_PATHS = PATHS.DIGEST
 
-    getRandomSlug(DIGEST_CONTENT_PATH).then((slug) => {
-      const ENTRY_FILE_PATH = `${DIGEST_CONTENT_PATH}/${slug}.md`
-      const PAGE_URL = `${DIGEST_BASE_URL}/${slug}`
+    getRandomSlug(DIGEST_BASE_PATHS.entriesContentPath as string).then(
+      (slug) => {
+        const { contentFilePath, pageUrl } = generateDynamicPaths(
+          DIGEST_BASE_PATHS,
+          slug,
+        )
 
-      verifyMetadataForDynamicPages({
-        contentFilePath: ENTRY_FILE_PATH,
-        urlPath: PAGE_URL,
-      })
-    })
+        verifyMetadataForDynamicPages({
+          contentFilePath,
+          urlPath: pageUrl,
+        })
+      },
+    )
   })
 })

--- a/cypress/e2e/critical/single_ecosystem_page_spec.cy.ts
+++ b/cypress/e2e/critical/single_ecosystem_page_spec.cy.ts
@@ -1,24 +1,27 @@
 import { PATHS } from '@/constants/paths'
 
 import { METADATA_TITLE_SUFFIX } from '@/ecosystem-explorer/constants/metadata'
+import { generateDynamicPaths } from '@/support/generateDynamicPathsUtil'
 import { getRandomSlug } from '@/support/getRandomSlugUtil'
 import { verifyMetadataForDynamicPages } from '@/support/verifyMetadataForDynamicPagesUtil'
 
 describe('Random Ecosystem Explorer Project', () => {
   it('should check metadata', () => {
-    const ECOSYSTEM_CONTENT_PATH = PATHS.ECOSYSTEM_EXPLORER
-      .entriesContentPath as string
-    const ECOSYSTEM_BASE_URL = PATHS.ECOSYSTEM_EXPLORER.path
+    const ECOSYSTEM_BASE_PATHS = PATHS.ECOSYSTEM_EXPLORER
 
-    getRandomSlug(ECOSYSTEM_CONTENT_PATH).then((slug) => {
-      const ENTRY_FILE_PATH = `${ECOSYSTEM_CONTENT_PATH}/${slug}.md`
-      const PAGE_URL = `${ECOSYSTEM_BASE_URL}/${slug}`
+    getRandomSlug(ECOSYSTEM_BASE_PATHS.entriesContentPath as string).then(
+      (slug) => {
+        const { contentFilePath, pageUrl } = generateDynamicPaths(
+          ECOSYSTEM_BASE_PATHS,
+          slug,
+        )
 
-      verifyMetadataForDynamicPages({
-        contentFilePath: ENTRY_FILE_PATH,
-        urlPath: PAGE_URL,
-        metadataTitleSuffix: METADATA_TITLE_SUFFIX,
-      })
-    })
+        verifyMetadataForDynamicPages({
+          contentFilePath,
+          urlPath: pageUrl,
+          metadataTitleSuffix: METADATA_TITLE_SUFFIX,
+        })
+      },
+    )
   })
 })

--- a/cypress/e2e/critical/single_ecosystem_page_spec.cy.ts
+++ b/cypress/e2e/critical/single_ecosystem_page_spec.cy.ts
@@ -1,7 +1,8 @@
 import { PATHS } from '@/constants/paths'
 
+import { METADATA_TITLE_SUFFIX } from '@/ecosystem-explorer/constants/metadata'
 import { getRandomSlug } from '@/support/getRandomSlugUtil'
-import { verifyMetadata } from '@/support/verifyMetadataUtil'
+import { verifyMetadataForDynamicPages } from '@/support/verifyMetadataForDynamicPagesUtil'
 
 describe('Random Ecosystem Explorer Project', () => {
   it('should check metadata', () => {
@@ -9,11 +10,14 @@ describe('Random Ecosystem Explorer Project', () => {
       .entriesContentPath as string
 
     getRandomSlug(ecosystemDirectoryPath).then((slug) => {
-      verifyMetadata(
-        ecosystemDirectoryPath,
-        `${PATHS.ECOSYSTEM_EXPLORER.path}/${slug}`,
-        slug,
-      )
+      const fullPath = `${ecosystemDirectoryPath}/${slug}.md`
+      const pagePath = `${PATHS.ECOSYSTEM_EXPLORER.path}/${slug}`
+
+      verifyMetadataForDynamicPages({
+        fullPath,
+        pagePath,
+        seoTitleSuffix: METADATA_TITLE_SUFFIX,
+      })
     })
   })
 })

--- a/cypress/e2e/critical/single_ecosystem_page_spec.cy.ts
+++ b/cypress/e2e/critical/single_ecosystem_page_spec.cy.ts
@@ -6,17 +6,18 @@ import { verifyMetadataForDynamicPages } from '@/support/verifyMetadataForDynami
 
 describe('Random Ecosystem Explorer Project', () => {
   it('should check metadata', () => {
-    const ecosystemDirectoryPath = PATHS.ECOSYSTEM_EXPLORER
+    const ECOSYSTEM_CONTENT_PATH = PATHS.ECOSYSTEM_EXPLORER
       .entriesContentPath as string
+    const ECOSYSTEM_BASE_URL = PATHS.ECOSYSTEM_EXPLORER.path
 
-    getRandomSlug(ecosystemDirectoryPath).then((slug) => {
-      const fullPath = `${ecosystemDirectoryPath}/${slug}.md`
-      const pagePath = `${PATHS.ECOSYSTEM_EXPLORER.path}/${slug}`
+    getRandomSlug(ECOSYSTEM_CONTENT_PATH).then((slug) => {
+      const ENTRY_FILE_PATH = `${ECOSYSTEM_CONTENT_PATH}/${slug}.md`
+      const PAGE_URL = `${ECOSYSTEM_BASE_URL}/${slug}`
 
       verifyMetadataForDynamicPages({
-        fullPath,
-        pagePath,
-        seoTitleSuffix: METADATA_TITLE_SUFFIX,
+        contentFilePath: ENTRY_FILE_PATH,
+        urlPath: PAGE_URL,
+        metadataTitleSuffix: METADATA_TITLE_SUFFIX,
       })
     })
   })

--- a/cypress/e2e/critical/single_event_page_spec.cy.ts
+++ b/cypress/e2e/critical/single_event_page_spec.cy.ts
@@ -1,23 +1,25 @@
 import { PATHS } from '@/constants/paths'
 
-import { METADATA_TITLE_SUFFIX } from '@/events/constants/metadata'
+import { generateDynamicPaths } from '@/support/generateDynamicPathsUtil'
 import { getRandomSlug } from '@/support/getRandomSlugUtil'
 import { verifyMetadataForDynamicPages } from '@/support/verifyMetadataForDynamicPagesUtil'
 
-describe('Random Event Entry', () => {
+describe('Random Digest Article', () => {
   it('should check metadata', () => {
-    const EVENTS_CONTENT_PATH = PATHS.EVENTS.entriesContentPath as string
-    const EVENTS_BASE_URL = PATHS.EVENTS.path
+    const DIGEST_BASE_PATHS = PATHS.DIGEST
 
-    getRandomSlug(EVENTS_CONTENT_PATH).then((slug) => {
-      const ENTRY_FILE_PATH = `${EVENTS_CONTENT_PATH}/${slug}.md`
-      const PAGE_URL = `${EVENTS_BASE_URL}/${slug}`
+    getRandomSlug(DIGEST_BASE_PATHS.entriesContentPath as string).then(
+      (slug) => {
+        const { contentFilePath, pageUrl } = generateDynamicPaths(
+          DIGEST_BASE_PATHS,
+          slug,
+        )
 
-      verifyMetadataForDynamicPages({
-        contentFilePath: ENTRY_FILE_PATH,
-        urlPath: PAGE_URL,
-        metadataTitleSuffix: METADATA_TITLE_SUFFIX,
-      })
-    })
+        verifyMetadataForDynamicPages({
+          contentFilePath,
+          urlPath: pageUrl,
+        })
+      },
+    )
   })
 })

--- a/cypress/e2e/critical/single_event_page_spec.cy.ts
+++ b/cypress/e2e/critical/single_event_page_spec.cy.ts
@@ -6,16 +6,17 @@ import { verifyMetadataForDynamicPages } from '@/support/verifyMetadataForDynami
 
 describe('Random Event Entry', () => {
   it('should check metadata', () => {
-    const eventsDirectoryPath = PATHS.EVENTS.entriesContentPath as string
+    const EVENTS_CONTENT_PATH = PATHS.EVENTS.entriesContentPath as string
+    const EVENTS_BASE_URL = PATHS.EVENTS.path
 
-    getRandomSlug(eventsDirectoryPath).then((slug) => {
-      const fullPath = `${eventsDirectoryPath}/${slug}.md`
-      const pagePath = `${PATHS.EVENTS.path}/${slug}`
+    getRandomSlug(EVENTS_CONTENT_PATH).then((slug) => {
+      const ENTRY_FILE_PATH = `${EVENTS_CONTENT_PATH}/${slug}.md`
+      const PAGE_URL = `${EVENTS_BASE_URL}/${slug}`
 
       verifyMetadataForDynamicPages({
-        fullPath,
-        pagePath,
-        seoTitleSuffix: METADATA_TITLE_SUFFIX,
+        contentFilePath: ENTRY_FILE_PATH,
+        urlPath: PAGE_URL,
+        metadataTitleSuffix: METADATA_TITLE_SUFFIX,
       })
     })
   })

--- a/cypress/e2e/critical/single_event_page_spec.cy.ts
+++ b/cypress/e2e/critical/single_event_page_spec.cy.ts
@@ -1,14 +1,22 @@
 import { PATHS } from '@/constants/paths'
 
+import { METADATA_TITLE_SUFFIX } from '@/events/constants/metadata'
 import { getRandomSlug } from '@/support/getRandomSlugUtil'
-import { verifyMetadata } from '@/support/verifyMetadataUtil'
+import { verifyMetadataForDynamicPages } from '@/support/verifyMetadataForDynamicPagesUtil'
 
 describe('Random Event Entry', () => {
   it('should check metadata', () => {
     const eventsDirectoryPath = PATHS.EVENTS.entriesContentPath as string
 
     getRandomSlug(eventsDirectoryPath).then((slug) => {
-      verifyMetadata(eventsDirectoryPath, `${PATHS.EVENTS.path}/${slug}`, slug)
+      const fullPath = `${eventsDirectoryPath}/${slug}.md`
+      const pagePath = `${PATHS.EVENTS.path}/${slug}`
+
+      verifyMetadataForDynamicPages({
+        fullPath,
+        pagePath,
+        seoTitleSuffix: METADATA_TITLE_SUFFIX,
+      })
     })
   })
 })

--- a/cypress/support/generateDynamicPathsUtil.ts
+++ b/cypress/support/generateDynamicPathsUtil.ts
@@ -1,0 +1,17 @@
+import type { DynamicPathValues, PathValues } from '@/constants/paths'
+
+export function generateDynamicPaths(
+  basePaths: { entriesContentPath?: string; path: PathValues },
+  slug: string,
+) {
+  if (!basePaths.entriesContentPath) {
+    throw new Error(
+      'entriesContentPath is required to generate contentFilePath',
+    )
+  }
+
+  return {
+    contentFilePath: `${basePaths.entriesContentPath}/${slug}.md`,
+    pageUrl: `${basePaths.path}/${slug}` as DynamicPathValues,
+  }
+}

--- a/cypress/support/verifyMetadataForDynamicPagesUtil.ts
+++ b/cypress/support/verifyMetadataForDynamicPagesUtil.ts
@@ -5,36 +5,28 @@ import { verifyMetaDescription } from './verifyMetaDescriptionUtil'
 import { verifyPageTitle } from './verifyPageTitleUtil'
 
 export function verifyMetadataForDynamicPages({
-  fullPath,
-  pagePath,
-  seoTitleSuffix,
+  contentFilePath,
+  urlPath,
+  metadataTitleSuffix,
 }: {
-  fullPath: string
-  pagePath: string
-  seoTitleSuffix?: string
+  contentFilePath: string
+  urlPath: string
+  metadataTitleSuffix?: string
 }) {
-  cy.visit(pagePath)
+  cy.visit(urlPath)
 
-  // Verify the canonical link
-  verifyCanonicalLink(pagePath)
+  verifyCanonicalLink(urlPath)
 
-  // Retrieve and process the page's metadata
-  cy.readFile(fullPath).then((markdownContent: string) => {
-    const { title, seo } = matter(markdownContent).data as {
-      title: string
-      seo: {
-        title?: string
-        description: string
-        overrideDefaultTitle?: boolean
-      }
-    }
+  cy.readFile(contentFilePath).then((markdownContent: string) => {
+    const { title, seo } = matter(markdownContent).data
+    const seoTitle = generateSeoTitle(title, seo?.title, metadataTitleSuffix)
 
-    const fallbackTitle = seoTitleSuffix ? `${title}${seoTitleSuffix}` : title
-
-    const seoTitle = seo?.title || fallbackTitle
-
-    // Verify the page title and meta description
-    verifyPageTitle(pagePath, seoTitle, seo.overrideDefaultTitle ?? false)
+    verifyPageTitle(urlPath, seoTitle, seo.overrideDefaultTitle ?? false)
     verifyMetaDescription(seo.description)
   })
+}
+
+function generateSeoTitle(title: string, seoTitle?: string, suffix?: string) {
+  if (seoTitle) return seoTitle
+  return suffix ? `${title}${suffix}` : title
 }

--- a/cypress/support/verifyMetadataForDynamicPagesUtil.ts
+++ b/cypress/support/verifyMetadataForDynamicPagesUtil.ts
@@ -1,0 +1,40 @@
+import matter from 'gray-matter'
+
+import { verifyCanonicalLink } from './verifyCanonicalLinkUtil'
+import { verifyMetaDescription } from './verifyMetaDescriptionUtil'
+import { verifyPageTitle } from './verifyPageTitleUtil'
+
+export function verifyMetadataForDynamicPages({
+  fullPath,
+  pagePath,
+  seoTitleSuffix,
+}: {
+  fullPath: string
+  pagePath: string
+  seoTitleSuffix?: string
+}) {
+  cy.visit(pagePath)
+
+  // Verify the canonical link
+  verifyCanonicalLink(pagePath)
+
+  // Retrieve and process the page's metadata
+  cy.readFile(fullPath).then((markdownContent: string) => {
+    const { title, seo } = matter(markdownContent).data as {
+      title: string
+      seo: {
+        title?: string
+        description: string
+        overrideDefaultTitle?: boolean
+      }
+    }
+
+    const fallbackTitle = seoTitleSuffix ? `${title}${seoTitleSuffix}` : title
+
+    const seoTitle = seo?.title || fallbackTitle
+
+    // Verify the page title and meta description
+    verifyPageTitle(pagePath, seoTitle, seo.overrideDefaultTitle ?? false)
+    verifyMetaDescription(seo.description)
+  })
+}

--- a/public/admin/config.yml
+++ b/public/admin/config.yml
@@ -154,7 +154,7 @@ twitter_config: &twitter_config
           value: "player"
       required: false
       default: "summary"
-      hint: "If left empty, the default value will be 'Summary Card'."
+      hint: "If left empty, the default value will be 'Summary Card.'"
     - name: "site"
       label: "Twitter Handle for Website"
       widget: "string"
@@ -166,7 +166,7 @@ twitter_config: &twitter_config
       required: false
       hint: "Enter the Twitter handle of the content creator (e.g., @juanbenet). Defaults to @FilFoundation."
 
-meta_optional_title_config: &meta_optional_title_config
+meta_config_with_title_fallback: &meta_config_with_title_fallback
   name: "seo"
   label: "SEO Metadata"
   widget: "object"
@@ -175,7 +175,7 @@ meta_optional_title_config: &meta_optional_title_config
       label: "Meta Title"
       widget: "string"
       required: false
-      hint: "If left empty, the page title will be used as the SEO title. For events, '- Event' will be appended, and for ecosystem projects, '- Ecosystem Project'. Examples: 'Acasia - Ecosystem Project', 'FIL Bangkok 2024 - Event'."
+      hint: "If left empty, the main entry title will automatically become the SEO title. '- Filecoin Event' will be added for events, and '- Ecosystem Project' for ecosystem projects. For example: 'Acasia - Filecoin Ecosystem Project' or 'FIL Bangkok 2024 - Filecoin Event'."
     - name: "description"
       label: "Meta Description"
       widget: "text"
@@ -184,6 +184,7 @@ meta_optional_title_config: &meta_optional_title_config
         - "Must have at most 220 characters."
       hint: "To generate meta title and description, copy and paste the entry content into ChatGPT 4.0, then use the prompt: 'Generate a meta title and a meta description under 220 characters for the following content: [paste your content here].'"
     - *open_graph_config
+    - *twitter_config
 
 meta_config: &meta_config
   name: "seo"
@@ -201,6 +202,7 @@ meta_config: &meta_config
         - "Must have at most 220 characters."
       hint: "To generate meta title and description, copy and paste the entry content into ChatGPT 4.0, then use the prompt: 'Generate a meta title and a meta description under 220 characters for the following content: [paste your content here].'"
     - *open_graph_config
+    - *twitter_config
 
 collections:
   - name: "pages"
@@ -439,7 +441,7 @@ collections:
         widget: "text"
       - *image_config
       - *body_config
-      - *meta_optional_title_config
+      - *meta_config_with_title_fallback
 
   - name: "digest_articles"
     label: "Digest Articles"
@@ -497,7 +499,7 @@ collections:
             widget: "string"
       - *body_config
       - *image_config
-      - *meta_optional_title_config
+      - *meta_config_with_title_fallback
 
   - name: "ecosystem_projects_categories"
     label: "Ecosystem Projects Categories"
@@ -629,7 +631,7 @@ collections:
         label: Long Description
         widget: markdown
         required: false
-      - *meta_optional_title_config
+      - *meta_config_with_title_fallback
 
   - name: "event_entries"
     label: "Events"
@@ -850,4 +852,4 @@ collections:
             label: Event Recap YouTube Playlist URL
             widget: string
             required: false
-      - *meta_optional_title_config
+      - *meta_config_with_title_fallback

--- a/public/admin/config.yml
+++ b/public/admin/config.yml
@@ -108,6 +108,83 @@ event_sponsor_config: &event_sponsor_config
 
 seo_metadata_description_max_characters: &seo_metadata_description_max_characters 220
 
+open_graph_config: &open_graph_config
+  name: "open-graph"
+  label: "Open Graph Metadata"
+  widget: "object"
+  required: false
+  collapsed: true
+  hint: "Expand for more information on default values."
+  fields:
+    - name: "title"
+      label: "Open Graph Title"
+      widget: "string"
+      required: false
+      hint: "If left empty, the SEO meta title will be used."
+    - name: "description"
+      label: "Open Graph Description"
+      widget: "string"
+      required: false
+      hint: "If left empty, the SEO meta description will be used."
+    - name: "image"
+      label: "Open Graph Image"
+      widget: "image"
+      allow_multiple: false
+      choose_url: false
+      required: false
+      hint: "If left empty, the page header image will be used. If no header image is present, a default homepage image will be used."
+
+twitter_config: &twitter_config
+  name: "twitter"
+  label: "Twitter Metadata"
+  widget: "object"
+  required: false
+  collapsed: true
+  hint: "Expand for more information on default values."
+  fields:
+    - name: "card"
+      label: "Twitter Card"
+      widget: "select"
+      options:
+        - label: "Summary Card"
+          value: "summary"
+        - label: "Summary with Large Image"
+          value: "summary_large_image"
+        - label: "Player Card"
+          value: "player"
+      required: false
+      default: "summary"
+      hint: "If left empty, the default value will be 'Summary Card'."
+    - name: "site"
+      label: "Twitter Handle for Website"
+      widget: "string"
+      required: false
+      hint: "Enter the Twitter handle of the website or brand (e.g., @FilFoundation). Defaults to @FilFoundation."
+    - name: "creator"
+      label: "Twitter Creator"
+      widget: "string"
+      required: false
+      hint: "Enter the Twitter handle of the content creator (e.g., @juanbenet). Defaults to @FilFoundation."
+
+meta_optional_title_config: &meta_optional_title_config
+  name: "seo"
+  label: "SEO Metadata"
+  widget: "object"
+  fields:
+    - name: "title"
+      label: "Meta Title"
+      widget: "string"
+      required: false
+      hint: "If left empty, the page title will be used as the SEO title. For events, '- Event' will be appended, and for ecosystem projects, '- Ecosystem Project'. Examples: 'Acasia - Ecosystem Project', 'FIL Bangkok 2024 - Event'."
+    - name: "description"
+      label: "Meta Description"
+      widget: "text"
+      pattern:
+        - "^.{0,220}$"
+        - "Must have at most 220 characters."
+      hint: "To generate meta title and description, copy and paste the entry content into ChatGPT 4.0, then use the prompt: 'Generate a meta title and a meta description under 220 characters for the following content: [paste your content here].'"
+    - *open_graph_config
+
 meta_config: &meta_config
   name: "seo"
   label: "SEO Metadata"
@@ -123,60 +200,7 @@ meta_config: &meta_config
         - "^.{0,220}$"
         - "Must have at most 220 characters."
       hint: "To generate meta title and description, copy and paste the entry content into ChatGPT 4.0, then use the prompt: 'Generate a meta title and a meta description under 220 characters for the following content: [paste your content here].'"
-    - name: "open-graph"
-      label: "Open Graph Metadata"
-      widget: "object"
-      required: false
-      collapsed: true
-      hint: "Expand for more information on default values."
-      fields:
-        - name: "title"
-          label: "Open Graph Title"
-          widget: "string"
-          required: false
-          hint: "If left empty, the SEO meta title will be used."
-        - name: "description"
-          label: "Open Graph Description"
-          widget: "string"
-          required: false
-          hint: "If left empty, the SEO meta description will be used."
-        - name: "image"
-          label: "Open Graph Image"
-          widget: "image"
-          allow_multiple: false
-          choose_url: false
-          required: false
-          hint: "If left empty, the page header image will be used. If no header image is present, a default homepage image will be used."
-    - name: "twitter"
-      label: "Twitter Metadata"
-      widget: "object"
-      hint: "Expand for more information on default values."
-      required: false
-      collapsed: true
-      fields:
-        - name: "card"
-          label: "Twitter Card"
-          widget: "select"
-          options:
-            - label: "Summary Card"
-              value: "summary"
-            - label: "Summary with Large Image"
-              value: "summary_large_image"
-            - label: "Player Card"
-              value: "player"
-          required: false
-          default: "summary"
-          hint: "If left empty, the default value will be 'Summary Card'."
-        - name: "site"
-          label: "Twitter Handle for Website"
-          widget: "string"
-          required: false
-          hint: "Enter the Twitter handle of the website or brand (e.g., @FilFoundation). Defaults to @FilFoundation."
-        - name: "creator"
-          label: "Twitter Creator"
-          widget: "string"
-          required: false
-          hint: "Enter the Twitter handle of the content creator (e.g., @juanbenet). Defaults to @FilFoundation."
+    - *open_graph_config
 
 collections:
   - name: "pages"
@@ -415,7 +439,7 @@ collections:
         widget: "text"
       - *image_config
       - *body_config
-      - *meta_config
+      - *meta_optional_title_config
 
   - name: "digest_articles"
     label: "Digest Articles"
@@ -473,7 +497,7 @@ collections:
             widget: "string"
       - *body_config
       - *image_config
-      - *meta_config
+      - *meta_optional_title_config
 
   - name: "ecosystem_projects_categories"
     label: "Ecosystem Projects Categories"
@@ -605,7 +629,7 @@ collections:
         label: Long Description
         widget: markdown
         required: false
-      - *meta_config
+      - *meta_optional_title_config
 
   - name: "event_entries"
     label: "Events"
@@ -826,4 +850,4 @@ collections:
             label: Event Recap YouTube Playlist URL
             widget: string
             required: false
-      - *meta_config
+      - *meta_optional_title_config

--- a/src/app/_schemas/DynamicDataBaseSchema.ts
+++ b/src/app/_schemas/DynamicDataBaseSchema.ts
@@ -1,7 +1,7 @@
 import { z } from 'zod'
 
 import { ImagePropsSchema } from '@/schemas/ImagePropsSchema'
-import { SeoMetadataSchemaWithOptionalTitle } from '@/schemas/SeoMetadataSchema'
+import { SeoMetadataWithOptionalTitleSchema } from '@/schemas/SeoMetadataSchema'
 
 export const DynamicBaseDataSchema = z
   .object({
@@ -9,7 +9,7 @@ export const DynamicBaseDataSchema = z
     'updated-on': z.coerce.date().optional(),
     'published-on': z.coerce.date().optional(),
     image: ImagePropsSchema.optional(),
-    seo: SeoMetadataSchemaWithOptionalTitle,
+    seo: SeoMetadataWithOptionalTitleSchema,
   })
   .strict()
 

--- a/src/app/_schemas/DynamicDataBaseSchema.ts
+++ b/src/app/_schemas/DynamicDataBaseSchema.ts
@@ -1,7 +1,7 @@
 import { z } from 'zod'
 
 import { ImagePropsSchema } from '@/schemas/ImagePropsSchema'
-import { SeoMetadataSchema } from '@/schemas/SeoMetadataSchema'
+import { SeoMetadataSchemaWithOptionalTitle } from '@/schemas/SeoMetadataSchema'
 
 export const DynamicBaseDataSchema = z
   .object({
@@ -9,7 +9,7 @@ export const DynamicBaseDataSchema = z
     'updated-on': z.coerce.date().optional(),
     'published-on': z.coerce.date().optional(),
     image: ImagePropsSchema.optional(),
-    seo: SeoMetadataSchema,
+    seo: SeoMetadataSchemaWithOptionalTitle,
   })
   .strict()
 

--- a/src/app/_schemas/SeoMetadataSchema.ts
+++ b/src/app/_schemas/SeoMetadataSchema.ts
@@ -6,27 +6,35 @@ const { seo_metadata_description_max_characters } = configJson
 
 const TwitterCardType = z.enum(['summary', 'summary_large_image', 'player'])
 
+const OpenGraphMetadataSchema = z
+  .object({
+    title: z.string().optional(),
+    description: z.string().optional(),
+    image: z.string().optional(),
+  })
+  .strict()
+  .optional()
+
+const TwitterMetadataSchema = z
+  .object({
+    card: TwitterCardType.optional(),
+    site: z.string().optional(),
+    creator: z.string().optional(),
+  })
+  .strict()
+  .optional()
+
+const AbsoluteStringSchema = z.object({
+  absolute: z.string(),
+})
+
 export const SeoMetadataSchema = z
   .object({
-    title: z.string(),
+    title: z.union([z.string(), AbsoluteStringSchema]).optional(),
     description: z.string().max(seo_metadata_description_max_characters),
     image: z.string().optional(),
-    'open-graph': z
-      .object({
-        title: z.string().optional(),
-        description: z.string().optional(),
-        image: z.string().optional(),
-      })
-      .strict()
-      .optional(),
-    twitter: z
-      .object({
-        card: TwitterCardType.optional(),
-        site: z.string().optional(),
-        creator: z.string().optional(),
-      })
-      .strict()
-      .optional(),
+    'open-graph': OpenGraphMetadataSchema,
+    twitter: TwitterMetadataSchema,
   })
   .strict()
 

--- a/src/app/_schemas/SeoMetadataSchema.ts
+++ b/src/app/_schemas/SeoMetadataSchema.ts
@@ -34,7 +34,7 @@ export const SeoMetadataSchema = z
   })
   .strict()
 
-export const SeoMetadataSchemaWithOptionalTitle = z
+export const SeoMetadataWithOptionalTitleSchema = z
   .object({
     title: z.string().optional(),
     description: z.string().max(seo_metadata_description_max_characters),

--- a/src/app/_schemas/SeoMetadataSchema.ts
+++ b/src/app/_schemas/SeoMetadataSchema.ts
@@ -34,4 +34,14 @@ export const SeoMetadataSchema = z
   })
   .strict()
 
+export const SeoMetadataSchemaWithOptionalTitle = z
+  .object({
+    title: z.string().optional(),
+    description: z.string().max(seo_metadata_description_max_characters),
+    image: z.string().optional(),
+    'open-graph': OpenGraphMetadataSchema,
+    twitter: TwitterMetadataSchema,
+  })
+  .strict()
+
 export type SeoMetadata = z.infer<typeof SeoMetadataSchema>

--- a/src/app/_schemas/SeoMetadataSchema.ts
+++ b/src/app/_schemas/SeoMetadataSchema.ts
@@ -24,13 +24,9 @@ const TwitterMetadataSchema = z
   .strict()
   .optional()
 
-const AbsoluteStringSchema = z.object({
-  absolute: z.string(),
-})
-
 export const SeoMetadataSchema = z
   .object({
-    title: z.union([z.string(), AbsoluteStringSchema]).optional(),
+    title: z.string(),
     description: z.string().max(seo_metadata_description_max_characters),
     image: z.string().optional(),
     'open-graph': OpenGraphMetadataSchema,

--- a/src/app/_schemas/SeoMetadataSchema.ts
+++ b/src/app/_schemas/SeoMetadataSchema.ts
@@ -24,24 +24,19 @@ const TwitterMetadataSchema = z
   .strict()
   .optional()
 
-export const SeoMetadataSchema = z
-  .object({
-    title: z.string(),
-    description: z.string().max(seo_metadata_description_max_characters),
-    image: z.string().optional(),
-    'open-graph': OpenGraphMetadataSchema,
-    twitter: TwitterMetadataSchema,
-  })
-  .strict()
+const BaseSeoMetadataSchema = z.object({
+  description: z.string().max(seo_metadata_description_max_characters),
+  image: z.string().optional(),
+  'open-graph': OpenGraphMetadataSchema,
+  twitter: TwitterMetadataSchema,
+})
 
-export const SeoMetadataWithOptionalTitleSchema = z
-  .object({
-    title: z.string().optional(),
-    description: z.string().max(seo_metadata_description_max_characters),
-    image: z.string().optional(),
-    'open-graph': OpenGraphMetadataSchema,
-    twitter: TwitterMetadataSchema,
-  })
-  .strict()
+export const SeoMetadataSchema = BaseSeoMetadataSchema.extend({
+  title: z.string(),
+}).strict()
+
+export const SeoMetadataWithOptionalTitleSchema = BaseSeoMetadataSchema.extend({
+  title: z.string().optional(),
+}).strict()
 
 export type SeoMetadata = z.infer<typeof SeoMetadataSchema>

--- a/src/app/_utils/createMetadata.ts
+++ b/src/app/_utils/createMetadata.ts
@@ -32,7 +32,7 @@ export function createMetadata({
         seo['open-graph']?.image || seo.image || graphicsData.home.data.src,
     },
     twitter: {
-      card: seo.twitter?.card || 'summary',
+      card: seo.twitter?.card,
       site: seo.twitter?.site || FILECOIN_FOUNDATION_URLS.social.twitter.handle,
       creator:
         seo.twitter?.creator || FILECOIN_FOUNDATION_URLS.social.twitter.handle,
@@ -43,8 +43,8 @@ export function createMetadata({
 
   return {
     title: overrideDefaultTitle
-      ? { absolute: parsedEnrichedSEO.title }
-      : parsedEnrichedSEO.title,
+      ? { absolute: parsedEnrichedSEO.title as string }
+      : (parsedEnrichedSEO.title as string),
     description: parsedEnrichedSEO.description,
     openGraph: {
       title: parsedEnrichedSEO['open-graph']?.title,
@@ -52,7 +52,7 @@ export function createMetadata({
       images: parsedEnrichedSEO['open-graph']?.image,
     },
     twitter: {
-      card: parsedEnrichedSEO.twitter?.card,
+      card: parsedEnrichedSEO.twitter?.card ?? 'summary',
       site: parsedEnrichedSEO.twitter?.site,
       creator: parsedEnrichedSEO.twitter?.creator,
     },

--- a/src/app/_utils/createMetadata.ts
+++ b/src/app/_utils/createMetadata.ts
@@ -7,7 +7,7 @@ import { graphicsData } from '@/data/graphicsData'
 
 import {
   type SeoMetadata,
-  SeoMetadataWithOptionalTitleSchema,
+  SeoMetadataSchema,
 } from '@/schemas/SeoMetadataSchema'
 
 type CreateMetadataProps = {
@@ -32,18 +32,18 @@ export function createMetadata({
         seo['open-graph']?.image || seo.image || graphicsData.home.data.src,
     },
     twitter: {
-      card: seo.twitter?.card,
-      site: seo.twitter?.site,
-      creator: seo.twitter?.creator,
+      card: seo.twitter?.card || 'summary',
+      site: seo.twitter?.site || FILECOIN_FOUNDATION_URLS.social.twitter.handle,
+      creator:
+        seo.twitter?.creator || FILECOIN_FOUNDATION_URLS.social.twitter.handle,
     },
   }
 
-  const parsedEnrichedSEO =
-    SeoMetadataWithOptionalTitleSchema.parse(enrichedSEO)
+  const parsedEnrichedSEO = SeoMetadataSchema.parse(enrichedSEO)
 
   return {
     title: overrideDefaultTitle
-      ? { absolute: parsedEnrichedSEO.title as string }
+      ? { absolute: parsedEnrichedSEO.title }
       : parsedEnrichedSEO.title,
     description: parsedEnrichedSEO.description,
     openGraph: {
@@ -52,13 +52,9 @@ export function createMetadata({
       images: parsedEnrichedSEO['open-graph']?.image,
     },
     twitter: {
-      card: parsedEnrichedSEO.twitter?.card || 'summary',
-      site:
-        parsedEnrichedSEO.twitter?.site ||
-        FILECOIN_FOUNDATION_URLS.social.twitter.handle,
-      creator:
-        parsedEnrichedSEO.twitter?.creator ||
-        FILECOIN_FOUNDATION_URLS.social.twitter.handle,
+      card: parsedEnrichedSEO.twitter?.card,
+      site: parsedEnrichedSEO.twitter?.site,
+      creator: parsedEnrichedSEO.twitter?.creator,
     },
     alternates: {
       canonical: path,

--- a/src/app/_utils/createMetadata.ts
+++ b/src/app/_utils/createMetadata.ts
@@ -7,7 +7,7 @@ import { graphicsData } from '@/data/graphicsData'
 
 import {
   type SeoMetadata,
-  SeoMetadataSchema,
+  SeoMetadataSchemaWithOptionalTitle,
 } from '@/schemas/SeoMetadataSchema'
 
 type CreateMetadataProps = {
@@ -39,12 +39,13 @@ export function createMetadata({
     },
   }
 
-  const parsedEnrichedSEO = SeoMetadataSchema.parse(enrichedSEO)
+  const parsedEnrichedSEO =
+    SeoMetadataSchemaWithOptionalTitle.parse(enrichedSEO)
 
   return {
     title: overrideDefaultTitle
       ? { absolute: parsedEnrichedSEO.title as string }
-      : (parsedEnrichedSEO.title as string),
+      : parsedEnrichedSEO.title,
     description: parsedEnrichedSEO.description,
     openGraph: {
       title: parsedEnrichedSEO['open-graph']?.title,
@@ -52,7 +53,7 @@ export function createMetadata({
       images: parsedEnrichedSEO['open-graph']?.image,
     },
     twitter: {
-      card: parsedEnrichedSEO.twitter?.card ?? 'summary',
+      card: parsedEnrichedSEO.twitter?.card || 'summary',
       site: parsedEnrichedSEO.twitter?.site,
       creator: parsedEnrichedSEO.twitter?.creator,
     },

--- a/src/app/_utils/createMetadata.ts
+++ b/src/app/_utils/createMetadata.ts
@@ -7,7 +7,7 @@ import { graphicsData } from '@/data/graphicsData'
 
 import {
   type SeoMetadata,
-  SeoMetadataSchemaWithOptionalTitle,
+  SeoMetadataWithOptionalTitleSchema,
 } from '@/schemas/SeoMetadataSchema'
 
 type CreateMetadataProps = {
@@ -33,14 +33,13 @@ export function createMetadata({
     },
     twitter: {
       card: seo.twitter?.card,
-      site: seo.twitter?.site || FILECOIN_FOUNDATION_URLS.social.twitter.handle,
-      creator:
-        seo.twitter?.creator || FILECOIN_FOUNDATION_URLS.social.twitter.handle,
+      site: seo.twitter?.site,
+      creator: seo.twitter?.creator,
     },
   }
 
   const parsedEnrichedSEO =
-    SeoMetadataSchemaWithOptionalTitle.parse(enrichedSEO)
+    SeoMetadataWithOptionalTitleSchema.parse(enrichedSEO)
 
   return {
     title: overrideDefaultTitle
@@ -54,8 +53,12 @@ export function createMetadata({
     },
     twitter: {
       card: parsedEnrichedSEO.twitter?.card || 'summary',
-      site: parsedEnrichedSEO.twitter?.site,
-      creator: parsedEnrichedSEO.twitter?.creator,
+      site:
+        parsedEnrichedSEO.twitter?.site ||
+        FILECOIN_FOUNDATION_URLS.social.twitter.handle,
+      creator:
+        parsedEnrichedSEO.twitter?.creator ||
+        FILECOIN_FOUNDATION_URLS.social.twitter.handle,
     },
     alternates: {
       canonical: path,

--- a/src/app/blog/[slug]/page.tsx
+++ b/src/app/blog/[slug]/page.tsx
@@ -27,6 +27,7 @@ export function generateMetadata({ params }: BlogPostProps) {
   return createMetadata({
     seo: {
       ...data.seo,
+      title: data.title,
       image: data.image?.src || graphicsData.blog.data.src,
     },
     path: `${PATHS.BLOG.path}/${data.slug}` as DynamicPathValues,

--- a/src/app/blog/[slug]/page.tsx
+++ b/src/app/blog/[slug]/page.tsx
@@ -27,7 +27,7 @@ export function generateMetadata({ params }: BlogPostProps) {
   return createMetadata({
     seo: {
       ...data.seo,
-      title: data.title,
+      title: data.seo.title || data.title,
       image: data.image?.src || graphicsData.blog.data.src,
     },
     path: `${PATHS.BLOG.path}/${data.slug}` as DynamicPathValues,

--- a/src/app/blog/[slug]/page.tsx
+++ b/src/app/blog/[slug]/page.tsx
@@ -27,7 +27,6 @@ export function generateMetadata({ params }: BlogPostProps) {
   return createMetadata({
     seo: {
       ...data.seo,
-      title: data.seo.title || data.title,
       image: data.image?.src || graphicsData.blog.data.src,
     },
     path: `${PATHS.BLOG.path}/${data.slug}` as DynamicPathValues,

--- a/src/app/blog/utils/getBlogPostData.ts
+++ b/src/app/blog/utils/getBlogPostData.ts
@@ -7,6 +7,20 @@ import { BlogPostFrontMatterSchema } from '../schemas/FrontMatterSchema'
 const BLOG_DIRECTORY_PATH = PATHS.BLOG.entriesContentPath as string
 
 export function getBlogPostData(slug: string) {
+  const data = getBlogPostMarkdownData(slug)
+  return transformBlogPostData(data)
+}
+
+export function getBlogPostsData() {
+  const allPosts = getAllMarkdownData({
+    directoryPath: BLOG_DIRECTORY_PATH,
+    zodParser: BlogPostFrontMatterSchema.parse,
+  })
+
+  return allPosts.map(transformBlogPostData)
+}
+
+function getBlogPostMarkdownData(slug: string) {
   return getMarkdownData({
     slug,
     directoryPath: BLOG_DIRECTORY_PATH,
@@ -14,9 +28,14 @@ export function getBlogPostData(slug: string) {
   })
 }
 
-export function getBlogPostsData() {
-  return getAllMarkdownData({
-    directoryPath: BLOG_DIRECTORY_PATH,
-    zodParser: BlogPostFrontMatterSchema.parse,
-  })
+function transformBlogPostData(
+  post: ReturnType<typeof getBlogPostMarkdownData>,
+) {
+  return {
+    ...post,
+    seo: {
+      ...post.seo,
+      title: post.seo.title || post.title,
+    },
+  }
 }

--- a/src/app/digest/[slug]/page.tsx
+++ b/src/app/digest/[slug]/page.tsx
@@ -27,7 +27,6 @@ export function generateMetadata({ params }: DigestArticleProps) {
   return createMetadata({
     seo: {
       ...data.seo,
-      title: data.seo.title || data.title,
       image: data.image?.src || graphicsData.digest.data.src,
     },
     path: `${PATHS.DIGEST.path}/${data.slug}` as DynamicPathValues,

--- a/src/app/digest/[slug]/page.tsx
+++ b/src/app/digest/[slug]/page.tsx
@@ -27,7 +27,7 @@ export function generateMetadata({ params }: DigestArticleProps) {
   return createMetadata({
     seo: {
       ...data.seo,
-      title: data.title,
+      title: data.seo.title || data.title,
       image: data.image?.src || graphicsData.digest.data.src,
     },
     path: `${PATHS.DIGEST.path}/${data.slug}` as DynamicPathValues,

--- a/src/app/digest/[slug]/page.tsx
+++ b/src/app/digest/[slug]/page.tsx
@@ -27,6 +27,7 @@ export function generateMetadata({ params }: DigestArticleProps) {
   return createMetadata({
     seo: {
       ...data.seo,
+      title: data.title,
       image: data.image?.src || graphicsData.digest.data.src,
     },
     path: `${PATHS.DIGEST.path}/${data.slug}` as DynamicPathValues,

--- a/src/app/digest/[slug]/utils/generateStructuredData.ts
+++ b/src/app/digest/[slug]/utils/generateStructuredData.ts
@@ -12,7 +12,7 @@ export function generateStructuredData(
   const { seo } = data
 
   return generateWebPageStructuredData({
-    title: seo.title || data.title,
+    title: seo.title,
     description: seo.description,
     path: `${PATHS.DIGEST.path}/${data.slug}` as DynamicPathValues,
   })

--- a/src/app/digest/[slug]/utils/generateStructuredData.ts
+++ b/src/app/digest/[slug]/utils/generateStructuredData.ts
@@ -12,7 +12,7 @@ export function generateStructuredData(
   const { seo } = data
 
   return generateWebPageStructuredData({
-    title: seo.title,
+    title: seo.title || data.title,
     description: seo.description,
     path: `${PATHS.DIGEST.path}/${data.slug}` as DynamicPathValues,
   })

--- a/src/app/digest/page.tsx
+++ b/src/app/digest/page.tsx
@@ -19,10 +19,10 @@ import { PageSection } from '@/components/PageSection'
 import { StructuredDataScript } from '@/components/StructuredDataScript'
 
 import { generateStructuredData } from './utils/generateStructuredData'
-import { getAllDigestArticleDataSortedByNumber } from './utils/getDigestArticleData'
+import { getDigestArticlesData } from './utils/getDigestArticleData'
 
 const { header, seo } = attributes
-const articles = getAllDigestArticleDataSortedByNumber()
+const articles = getDigestArticlesData()
 
 export const metadata = createMetadata({
   seo: {
@@ -51,7 +51,7 @@ export default function Digest() {
         ]}
       >
         <CardGrid cols="smTwo">
-          {articles.map((digest) => {
+          {articles.map((article) => {
             const {
               title,
               image,
@@ -60,7 +60,7 @@ export default function Digest() {
               articleNumber,
               description,
               authors,
-            } = digest
+            } = article
 
             return (
               <Card

--- a/src/app/digest/utils/getDigestArticleData.ts
+++ b/src/app/digest/utils/getDigestArticleData.ts
@@ -5,11 +5,26 @@ import { PATHS } from '@/constants/paths'
 import { getAllMarkdownData, getMarkdownData } from '@/utils/getMarkdownData'
 
 import { DigestArticleFrontMatterSchema } from '../schemas/FrontMatterSchema'
-import { sortArticlesByNumber } from '../utils/sortArticlesByNumber'
 
 const DIGEST_DIRECTORY_PATH = PATHS.DIGEST.entriesContentPath as string
 
 export function getDigestArticleData(slug: string) {
+  const data = getDigestMarkdownData(slug)
+  return transformDigestArticleData(data)
+}
+
+export function getDigestArticlesData() {
+  const allArticles = getAllMarkdownData({
+    directoryPath: DIGEST_DIRECTORY_PATH,
+    zodParser: DigestArticleFrontMatterSchema.parse,
+  })
+
+  return allArticles
+    .map(transformDigestArticleData)
+    .sort((a, b) => a.articleNumber - b.articleNumber)
+}
+
+function getDigestMarkdownData(slug: string) {
   return getMarkdownData({
     slug,
     directoryPath: DIGEST_DIRECTORY_PATH,
@@ -17,18 +32,15 @@ export function getDigestArticleData(slug: string) {
   })
 }
 
-export function getAllDigestArticleData() {
-  const articles = getAllMarkdownData({
-    directoryPath: DIGEST_DIRECTORY_PATH,
-    zodParser: DigestArticleFrontMatterSchema.parse,
-  })
-
-  return articles.map((article) => ({
+function transformDigestArticleData(
+  article: ReturnType<typeof getDigestMarkdownData>,
+) {
+  return {
     ...article,
     description: removeMarkdown(article.content),
-  }))
-}
-
-export function getAllDigestArticleDataSortedByNumber() {
-  return getAllDigestArticleData().sort(sortArticlesByNumber)
+    seo: {
+      ...article.seo,
+      title: article.seo.title || article.title,
+    },
+  }
 }

--- a/src/app/digest/utils/sortArticlesByNumber.ts
+++ b/src/app/digest/utils/sortArticlesByNumber.ts
@@ -1,8 +1,0 @@
-import type { DigestArticleData } from '../types/digestType'
-
-export function sortArticlesByNumber(
-  a: DigestArticleData,
-  b: DigestArticleData,
-) {
-  return a.articleNumber - b.articleNumber
-}

--- a/src/app/ecosystem-explorer/[slug]/page.tsx
+++ b/src/app/ecosystem-explorer/[slug]/page.tsx
@@ -35,8 +35,6 @@ type EcosystemProjectProps = {
   }
 }
 
-export const SEO_TITLE_SUFFIX = ' - Filecoin Ecosystem Project'
-
 export function generateMetadata({ params }: EcosystemProjectProps) {
   const { slug } = params
   const data = getEcosystemProjectData(slug)
@@ -44,7 +42,6 @@ export function generateMetadata({ params }: EcosystemProjectProps) {
   return createMetadata({
     seo: {
       ...data.seo,
-      title: data.seo.title || `${data.title} ${SEO_TITLE_SUFFIX}`,
       image: graphicsData.ecosystem.data.src,
     },
     path: `${PATHS.ECOSYSTEM_EXPLORER.path}/${data.slug}` as DynamicPathValues,

--- a/src/app/ecosystem-explorer/[slug]/page.tsx
+++ b/src/app/ecosystem-explorer/[slug]/page.tsx
@@ -35,6 +35,8 @@ type EcosystemProjectProps = {
   }
 }
 
+export const SEO_TITLE_SUFFIX = ' - Filecoin Ecosystem Project'
+
 export function generateMetadata({ params }: EcosystemProjectProps) {
   const { slug } = params
   const data = getEcosystemProjectData(slug)
@@ -42,7 +44,7 @@ export function generateMetadata({ params }: EcosystemProjectProps) {
   return createMetadata({
     seo: {
       ...data.seo,
-      title: data.seo.title || `${data.title} - Filecoin Ecosystem Project`,
+      title: data.seo.title || `${data.title} ${SEO_TITLE_SUFFIX}`,
       image: graphicsData.ecosystem.data.src,
     },
     path: `${PATHS.ECOSYSTEM_EXPLORER.path}/${data.slug}` as DynamicPathValues,

--- a/src/app/ecosystem-explorer/[slug]/page.tsx
+++ b/src/app/ecosystem-explorer/[slug]/page.tsx
@@ -40,7 +40,11 @@ export function generateMetadata({ params }: EcosystemProjectProps) {
   const data = getEcosystemProjectData(slug)
 
   return createMetadata({
-    seo: { ...data.seo, image: graphicsData.ecosystem.data.src },
+    seo: {
+      ...data.seo,
+      title: `${data.title} - Ecosystem Project`,
+      image: graphicsData.ecosystem.data.src,
+    },
     path: `${PATHS.ECOSYSTEM_EXPLORER.path}/${data.slug}` as DynamicPathValues,
   })
 }

--- a/src/app/ecosystem-explorer/[slug]/page.tsx
+++ b/src/app/ecosystem-explorer/[slug]/page.tsx
@@ -42,7 +42,7 @@ export function generateMetadata({ params }: EcosystemProjectProps) {
   return createMetadata({
     seo: {
       ...data.seo,
-      title: `${data.title} - Ecosystem Project`,
+      title: data.seo.title || `${data.title} - Filecoin Ecosystem Project`,
       image: graphicsData.ecosystem.data.src,
     },
     path: `${PATHS.ECOSYSTEM_EXPLORER.path}/${data.slug}` as DynamicPathValues,

--- a/src/app/ecosystem-explorer/[slug]/utils/generateStructuredData.ts
+++ b/src/app/ecosystem-explorer/[slug]/utils/generateStructuredData.ts
@@ -8,7 +8,7 @@ export function generateStructuredData(data: EcosystemProject) {
   const { seo } = data
 
   return generateWebPageStructuredData({
-    title: seo.title,
+    title: data.seo.title || `${data.title} - Filecoin Ecosystem Project`,
     description: seo.description,
     path: `${PATHS.ECOSYSTEM_EXPLORER.path}/${data.slug}` as DynamicPathValues,
   })

--- a/src/app/ecosystem-explorer/[slug]/utils/generateStructuredData.ts
+++ b/src/app/ecosystem-explorer/[slug]/utils/generateStructuredData.ts
@@ -3,12 +3,13 @@ import { type DynamicPathValues, PATHS } from '@/constants/paths'
 import { generateWebPageStructuredData } from '@/utils/generateWebPageStructuredData'
 
 import type { EcosystemProject } from '../../types/ecosystemProjectType'
+import { SEO_TITLE_SUFFIX } from '../page'
 
 export function generateStructuredData(data: EcosystemProject) {
   const { seo } = data
 
   return generateWebPageStructuredData({
-    title: data.seo.title || `${data.title} - Filecoin Ecosystem Project`,
+    title: data.seo.title || `${data.title} ${SEO_TITLE_SUFFIX}`,
     description: seo.description,
     path: `${PATHS.ECOSYSTEM_EXPLORER.path}/${data.slug}` as DynamicPathValues,
   })

--- a/src/app/ecosystem-explorer/[slug]/utils/generateStructuredData.ts
+++ b/src/app/ecosystem-explorer/[slug]/utils/generateStructuredData.ts
@@ -3,13 +3,12 @@ import { type DynamicPathValues, PATHS } from '@/constants/paths'
 import { generateWebPageStructuredData } from '@/utils/generateWebPageStructuredData'
 
 import type { EcosystemProject } from '../../types/ecosystemProjectType'
-import { SEO_TITLE_SUFFIX } from '../page'
 
 export function generateStructuredData(data: EcosystemProject) {
   const { seo } = data
 
   return generateWebPageStructuredData({
-    title: data.seo.title || `${data.title} ${SEO_TITLE_SUFFIX}`,
+    title: seo.title,
     description: seo.description,
     path: `${PATHS.ECOSYSTEM_EXPLORER.path}/${data.slug}` as DynamicPathValues,
   })

--- a/src/app/ecosystem-explorer/constants/metadata.ts
+++ b/src/app/ecosystem-explorer/constants/metadata.ts
@@ -1,0 +1,1 @@
+export const METADATA_TITLE_SUFFIX = ' - Filecoin Ecosystem Project'

--- a/src/app/ecosystem-explorer/utils/getEcosystemProjectData.ts
+++ b/src/app/ecosystem-explorer/utils/getEcosystemProjectData.ts
@@ -2,9 +2,24 @@ import { ECOSYSTEM_PROJECTS_DIRECTORY_PATH } from '@/constants/paths'
 
 import { getAllMarkdownData, getMarkdownData } from '@/utils/getMarkdownData'
 
+import { METADATA_TITLE_SUFFIX } from '../constants/metadata'
 import { EcosystemProjectFrontMatter } from '../schemas/FrontMatterSchema'
 
 export function getEcosystemProjectData(slug: string) {
+  const data = getEcosystemProjectMarkdownData(slug)
+  return transformEcosystemProjectData(data)
+}
+
+export function getEcosystemProjectsData() {
+  const allProjects = getAllMarkdownData({
+    directoryPath: ECOSYSTEM_PROJECTS_DIRECTORY_PATH,
+    zodParser: EcosystemProjectFrontMatter.parse,
+  })
+
+  return allProjects.map(transformEcosystemProjectData)
+}
+
+function getEcosystemProjectMarkdownData(slug: string) {
   return getMarkdownData({
     slug,
     directoryPath: ECOSYSTEM_PROJECTS_DIRECTORY_PATH,
@@ -12,9 +27,14 @@ export function getEcosystemProjectData(slug: string) {
   })
 }
 
-export function getEcosystemProjectsData() {
-  return getAllMarkdownData({
-    directoryPath: ECOSYSTEM_PROJECTS_DIRECTORY_PATH,
-    zodParser: EcosystemProjectFrontMatter.parse,
-  })
+function transformEcosystemProjectData(
+  project: ReturnType<typeof getEcosystemProjectMarkdownData>,
+) {
+  return {
+    ...project,
+    seo: {
+      ...project.seo,
+      title: project.seo.title || `${project.title} ${METADATA_TITLE_SUFFIX}`,
+    },
+  }
 }

--- a/src/app/ecosystem-explorer/utils/sortEcosystemProjects.ts
+++ b/src/app/ecosystem-explorer/utils/sortEcosystemProjects.ts
@@ -1,6 +1,6 @@
 import type { ValidSortKey } from '@/types/sortTypes'
 
-import type { EcosystemProject } from '@/ecosystem-explorer/types/ecosystemProjectType'
+import type { EcosystemProject } from '../types/ecosystemProjectType'
 
 export function sortEcosystemProjectsAlphabeticalAsc(
   projects: Array<EcosystemProject>,

--- a/src/app/events/[slug]/page.tsx
+++ b/src/app/events/[slug]/page.tsx
@@ -30,6 +30,8 @@ type EventProps = {
   }
 }
 
+export const SEO_TITLE_SUFFIX = ' - Filecoin Event'
+
 export function generateMetadata({ params }: EventProps) {
   const { slug } = params
   const data = getEventData(slug)
@@ -37,7 +39,7 @@ export function generateMetadata({ params }: EventProps) {
   return createMetadata({
     seo: {
       ...data.seo,
-      title: data.seo.title || `${data.title} - Filecoin Event`,
+      title: data.seo.title || `${data.title} ${SEO_TITLE_SUFFIX}`,
       image: graphicsData.events1.data.src,
     },
     path: `${PATHS.EVENTS.path}/${data.slug}` as DynamicPathValues,

--- a/src/app/events/[slug]/page.tsx
+++ b/src/app/events/[slug]/page.tsx
@@ -35,7 +35,11 @@ export function generateMetadata({ params }: EventProps) {
   const data = getEventData(slug)
 
   return createMetadata({
-    seo: { ...data.seo, image: graphicsData.events1.data.src },
+    seo: {
+      ...data.seo,
+      title: `${data.title} - Event`,
+      image: graphicsData.events1.data.src,
+    },
     path: `${PATHS.EVENTS.path}/${data.slug}` as DynamicPathValues,
   })
 }

--- a/src/app/events/[slug]/page.tsx
+++ b/src/app/events/[slug]/page.tsx
@@ -30,8 +30,6 @@ type EventProps = {
   }
 }
 
-export const SEO_TITLE_SUFFIX = ' - Filecoin Event'
-
 export function generateMetadata({ params }: EventProps) {
   const { slug } = params
   const data = getEventData(slug)
@@ -39,7 +37,6 @@ export function generateMetadata({ params }: EventProps) {
   return createMetadata({
     seo: {
       ...data.seo,
-      title: data.seo.title || `${data.title} ${SEO_TITLE_SUFFIX}`,
       image: graphicsData.events1.data.src,
     },
     path: `${PATHS.EVENTS.path}/${data.slug}` as DynamicPathValues,

--- a/src/app/events/[slug]/page.tsx
+++ b/src/app/events/[slug]/page.tsx
@@ -37,7 +37,7 @@ export function generateMetadata({ params }: EventProps) {
   return createMetadata({
     seo: {
       ...data.seo,
-      title: `${data.title} - Event`,
+      title: data.seo.title || `${data.title} - Filecoin Event`,
       image: graphicsData.events1.data.src,
     },
     path: `${PATHS.EVENTS.path}/${data.slug}` as DynamicPathValues,

--- a/src/app/events/[slug]/utils/generateStructuredData.ts
+++ b/src/app/events/[slug]/utils/generateStructuredData.ts
@@ -14,6 +14,7 @@ import {
 } from '@/constants/structuredDataConstants'
 
 import type { Event } from '../../types/eventType'
+import { SEO_TITLE_SUFFIX } from '../page'
 
 type LocationType = Place | VirtualLocation | undefined
 
@@ -72,7 +73,7 @@ export function generateStructuredData(data: Event): WithContext<EventSchema> {
     '@context': SCHEMA_CONTEXT_URL,
     '@type': 'Event',
     eventAttendanceMode,
-    name: title,
+    name: data.seo.title || `${title} ${SEO_TITLE_SUFFIX}`,
     description,
     startDate: startDate.toISOString(),
     endDate: (endDate || startDate)?.toISOString(),

--- a/src/app/events/[slug]/utils/generateStructuredData.ts
+++ b/src/app/events/[slug]/utils/generateStructuredData.ts
@@ -14,7 +14,6 @@ import {
 } from '@/constants/structuredDataConstants'
 
 import type { Event } from '../../types/eventType'
-import { SEO_TITLE_SUFFIX } from '../page'
 
 type LocationType = Place | VirtualLocation | undefined
 
@@ -48,7 +47,6 @@ function getLocation({
 
 export function generateStructuredData(data: Event): WithContext<EventSchema> {
   const {
-    title,
     slug,
     description,
     startDate,
@@ -56,6 +54,7 @@ export function generateStructuredData(data: Event): WithContext<EventSchema> {
     image,
     location,
     externalLink,
+    seo,
   } = data
 
   const eventLocation: LocationType = getLocation({
@@ -73,7 +72,7 @@ export function generateStructuredData(data: Event): WithContext<EventSchema> {
     '@context': SCHEMA_CONTEXT_URL,
     '@type': 'Event',
     eventAttendanceMode,
-    name: data.seo.title || `${title} ${SEO_TITLE_SUFFIX}`,
+    name: seo.title,
     description,
     startDate: startDate.toISOString(),
     endDate: (endDate || startDate)?.toISOString(),

--- a/src/app/events/constants/metadata.ts
+++ b/src/app/events/constants/metadata.ts
@@ -1,0 +1,1 @@
+export const METADATA_TITLE_SUFFIX = ' - Filecoin Event'

--- a/src/app/events/utils/getEventData.ts
+++ b/src/app/events/utils/getEventData.ts
@@ -2,11 +2,26 @@ import { PATHS } from '@/constants/paths'
 
 import { getAllMarkdownData, getMarkdownData } from '@/utils/getMarkdownData'
 
+import { METADATA_TITLE_SUFFIX } from '../constants/metadata'
 import { EventFrontMatterSchema } from '../schemas/FrontMatterSchema'
 
 const EVENTS_DIRECTORY_PATH = PATHS.EVENTS.entriesContentPath as string
 
 export function getEventData(slug: string) {
+  const data = getEventMarkdownData(slug)
+  return transformEventData(data)
+}
+
+export function getEventsData() {
+  const allEvents = getAllMarkdownData({
+    directoryPath: EVENTS_DIRECTORY_PATH,
+    zodParser: EventFrontMatterSchema.parse,
+  })
+
+  return allEvents.map(transformEventData)
+}
+
+function getEventMarkdownData(slug: string) {
   return getMarkdownData({
     slug,
     directoryPath: EVENTS_DIRECTORY_PATH,
@@ -14,9 +29,12 @@ export function getEventData(slug: string) {
   })
 }
 
-export function getEventsData() {
-  return getAllMarkdownData({
-    directoryPath: EVENTS_DIRECTORY_PATH,
-    zodParser: EventFrontMatterSchema.parse,
-  })
+function transformEventData(event: ReturnType<typeof getEventMarkdownData>) {
+  return {
+    ...event,
+    seo: {
+      ...event.seo,
+      title: event.seo.title || `${event.title} ${METADATA_TITLE_SUFFIX}`,
+    },
+  }
 }

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -6,7 +6,7 @@ import { BASE_URL } from '@/constants/siteMetadata'
 import type { DynamicBaseData } from '@/schemas/DynamicDataBaseSchema'
 
 import { getBlogPostsData } from '@/blog/utils/getBlogPostData'
-import { getAllDigestArticleData } from '@/digest/utils/getDigestArticleData'
+import { getDigestArticlesData } from '@/digest/utils/getDigestArticleData'
 import { getEcosystemProjectsData } from '@/ecosystem-explorer/utils/getEcosystemProjectData'
 import { getEventsData } from '@/events/utils/getEventData'
 
@@ -35,8 +35,11 @@ export default function sitemap() {
   const blogPosts = getBlogPostsData()
   const dynamicBlogRoutes = generateDynamicRoutes(blogPosts, PATHS.BLOG.path)
 
-  const digests = getAllDigestArticleData()
-  const dynamicDigestRoutes = generateDynamicRoutes(digests, PATHS.DIGEST.path)
+  const digestArticles = getDigestArticlesData()
+  const dynamicDigestArticleRoutes = generateDynamicRoutes(
+    digestArticles,
+    PATHS.DIGEST.path,
+  )
 
   const ecosystemProjects = getEcosystemProjectsData()
   const dynamicEcosystemProjectRoutes = generateDynamicRoutes(
@@ -50,7 +53,7 @@ export default function sitemap() {
   return [
     ...staticRoutes,
     ...dynamicBlogRoutes,
-    ...dynamicDigestRoutes,
+    ...dynamicDigestArticleRoutes,
     ...dynamicEcosystemProjectRoutes,
     ...dynamicEventRoutes,
   ]

--- a/src/content/blog/10-tools-for-filecoin-storage-providers.md
+++ b/src/content/blog/10-tools-for-filecoin-storage-providers.md
@@ -11,7 +11,6 @@ image:
   src: /assets/images/92523-sptooling.png
 category: ecosystem
 seo:
-  title: Top 10 Tools for Filecoin Storage Providers
   description:
     Discover the top 10 tools for Filecoin storage providers to enhance
     performance and efficiency. Learn more now!

--- a/src/content/blog/2021-developer-grants-wrap.md
+++ b/src/content/blog/2021-developer-grants-wrap.md
@@ -11,7 +11,6 @@ image:
   src: /assets/images/image-c-16.png
 category: reports
 seo:
-  title: 2021 Developer Grants Wrap-Up by Filecoin Foundation
   description:
     A comprehensive wrap-up of the 2021 developer grants by Filecoin Foundation.
     See the innovative projects funded.

--- a/src/content/blog/ai-data-verifiability-and-decentralized-storage-a-recap-from-fil-vegas.md
+++ b/src/content/blog/ai-data-verifiability-and-decentralized-storage-a-recap-from-fil-vegas.md
@@ -11,7 +11,6 @@ description: >-
 image:
   src: /assets/images/filvegas_recap_header.png
 seo:
-  title: "AI, Data Verifiability, and Decentralized Storage: FIL Vegas Recap"
   description:
     "Recap of FIL Vegas: Exploring AI, data verifiability, and decentralized
     storage innovations."

--- a/src/content/blog/announcing-explorer-awards-by-filecoin-foundation-and-unfinished.md
+++ b/src/content/blog/announcing-explorer-awards-by-filecoin-foundation-and-unfinished.md
@@ -11,7 +11,6 @@ image:
   src: /assets/images/0609-ffxunfinished.png
 category: news
 seo:
-  title: Filecoin Foundation and Unfinished Announce Explorer Awards
   description:
     Explorer Awards announced by Filecoin Foundation and Unfinished to
     celebrate innovation in decentralized tech.

--- a/src/content/blog/announcing-network-upgrade-skyr.md
+++ b/src/content/blog/announcing-network-upgrade-skyr.md
@@ -11,7 +11,6 @@ image:
   src: /assets/images/64423a88f053c985627f3ae7_1-ko-wwh4crpe6t8ioqymtfq.png
 category: news
 seo:
-  title: Announcing Network Upgrade Skyr by Filecoin Foundation
   description:
     Filecoin Foundation announces Skyr network upgrade. Learn about the
     enhancements and new features.

--- a/src/content/blog/announcing-the-filecoin-community-roadmap.md
+++ b/src/content/blog/announcing-the-filecoin-community-roadmap.md
@@ -11,7 +11,6 @@ image:
   src: /assets/images/64423a8ab068b0286f5c29dc_1-puuomuuoq9o-ezxjtdpppw.png
 category: news
 seo:
-  title: Filecoin Community Roadmap Announcement
   description:
     Introducing the Filecoin Community Roadmap. Explore the future plans
     and upcoming projects.

--- a/src/content/blog/announcing-the-filecoin-nv22-dragon-upgrade-a-leap-forward-in-network-efficiency-and-flexibility.md
+++ b/src/content/blog/announcing-the-filecoin-nv22-dragon-upgrade-a-leap-forward-in-network-efficiency-and-flexibility.md
@@ -1,6 +1,6 @@
 ---
 title:
-  "Announcing the Filecoin nv22 Dragon Upgrade: A Leap Forward in Network Efficiency
+  "Announcing the Filecoin NV22 Dragon Upgrade: A Leap Forward in Network Efficiency
   and Flexibility"
 created-on: 2024-04-24T13:19:08.153000Z
 updated-on: 2024-04-24T13:19:08.172000Z
@@ -10,7 +10,6 @@ description: Filecoin nv22 Dragon upgrade has launched on mainnet.
 image:
   src: /assets/images/blog-header-_-nv22-upgrade.png
 seo:
-  title: "Filecoin NV22 Dragon Upgrade: Enhancing Network Efficiency"
   description:
     Announcing the Filecoin NV22 Dragon upgrade. Discover the leap forward
     in network efficiency and flexibility.

--- a/src/content/blog/announcing-the-filecoin-nv23-waffle-upgrade-enhancing-filecoins-efficiency-and-security.md
+++ b/src/content/blog/announcing-the-filecoin-nv23-waffle-upgrade-enhancing-filecoins-efficiency-and-security.md
@@ -10,7 +10,6 @@ description: "The NV23 Waffle upgrade for the Filecoin network has successfully
 image:
   src: /assets/images/blog-header-nv23-upgrade.webp
 seo:
-  title: Filecoin NV23 Waffle Upgrade Goes Live with Major Enhancements
   description: The NV23 Waffle upgrade for Filecoin, live on Aug 6, 2024, brings
     streamlined processes, better cryptographic support, and optimized proof
     mechanisms.

--- a/src/content/blog/announcing-the-public-data-commons-and-awards-program.md
+++ b/src/content/blog/announcing-the-public-data-commons-and-awards-program.md
@@ -11,7 +11,6 @@ image:
   src: /assets/images/64423a8c4e4c682bdff3f2e5_1-1hvgrfumdxuavwm1qy5flw.webp
 category: news
 seo:
-  title: Public Data Commons and Awards Program Announcement
   description:
     Filecoin Foundation announces the Public Data Commons and Awards Program.
     Recognizing contributions to open data.

--- a/src/content/blog/announcing-the-quality-phase-for-filecoin-plus-aligning-on-the-filecoin-plus-vision-mission-statement-and-roadmap.md
+++ b/src/content/blog/announcing-the-quality-phase-for-filecoin-plus-aligning-on-the-filecoin-plus-vision-mission-statement-and-roadmap.md
@@ -13,7 +13,6 @@ image:
   src: /assets/images/03292023-filplusmission.png
 category: ecosystem
 seo:
-  title: "Filecoin Plus Quality Phase: Vision and Roadmap"
   description:
     Announcing the Filecoin Plus quality phase. Learn about the vision,
     mission, and roadmap for the initiative.

--- a/src/content/blog/announcing-the-starling-lab.md
+++ b/src/content/blog/announcing-the-starling-lab.md
@@ -10,7 +10,6 @@ description: >-
   trust in the most sensitive digital records of our human history.
 category: news
 seo:
-  title: Announcing the Starling Lab by Filecoin Foundation
   description:
     Filecoin Foundation announces the Starling Lab. Discover how it aims
     to protect human history with decentralized tech.

--- a/src/content/blog/announcing-the-venushub-platform.md
+++ b/src/content/blog/announcing-the-venushub-platform.md
@@ -10,7 +10,6 @@ image:
   src: /assets/images/64423a911fe00b2cb076101a_1-_gcjaae5jjlt5kkzewfd6g.png
 category: news
 seo:
-  title: Filecoin Foundation Announces the Venushub Platform
   description:
     Introducing the Venushub platform by Filecoin Foundation. Learn how
     it fosters decentralized application development.

--- a/src/content/blog/announcing-watermelon-nv21-upgrade-extended-sector-commitments-synthetic-porep-fvm-enhancements-and-more.md
+++ b/src/content/blog/announcing-watermelon-nv21-upgrade-extended-sector-commitments-synthetic-porep-fvm-enhancements-and-more.md
@@ -13,7 +13,6 @@ description:
 image:
   src: /assets/images/twitter-_-nv21_upgrade.png
 seo:
-  title: Announcing Watermelon NV21 Upgrade by Filecoin Foundation
   description:
     Watermelon NV21 upgrade announced. Includes extended sector commitments,
     synthetic PoRep, FVM enhancements, and more.

--- a/src/content/blog/applications-are-open-for-filecoin-plus-notary-elections.md
+++ b/src/content/blog/applications-are-open-for-filecoin-plus-notary-elections.md
@@ -10,7 +10,6 @@ image:
   src: /assets/images/0218-filpluselection.png
 category: news
 seo:
-  title: Applications Open for Filecoin Plus Notary Elections
   description:
     Filecoin Plus notary elections are now open. Apply to contribute to
     the network's governance and trust framework.

--- a/src/content/blog/applications-are-open-for-the-filecoin-launchpad-accelerator-ii.md
+++ b/src/content/blog/applications-are-open-for-the-filecoin-launchpad-accelerator-ii.md
@@ -10,7 +10,6 @@ image:
   src: /assets/images/image-c-26.png
 category: news
 seo:
-  title: "Apply Now: Filecoin Launchpad Accelerator II"
   description:
     Applications are open for the Filecoin Launchpad Accelerator II. Join
     and accelerate your blockchain project.

--- a/src/content/blog/bbc-s-the-real-story-explores-the-promise-of-cryptocurrency.md
+++ b/src/content/blog/bbc-s-the-real-story-explores-the-promise-of-cryptocurrency.md
@@ -10,7 +10,6 @@ image:
   src: /assets/images/64423a958d1be740f4ce6485_1-idr5jnytk_i2rab2ggn9uq.png
 category: news
 seo:
-  title: "BBC's The Real Story: The Promise of Cryptocurrency"
   description:
     BBC's The Real Story delves into the promise of cryptocurrency. Explore
     the potential and challenges of digital currencies.

--- a/src/content/blog/bela-supernova-awarded-chainlink-filecoin-joint-grant-to-support-public-health-data-oracle.md
+++ b/src/content/blog/bela-supernova-awarded-chainlink-filecoin-joint-grant-to-support-public-health-data-oracle.md
@@ -13,7 +13,6 @@ image:
   src: /assets/images/64423a97d1b025cf67f903ec_1-k1bbzfo-mulctcjeu5e_da.png
 category: news
 seo:
-  title: Bela Supernova Receives Chainlink-Filecoin Joint Grant
   description:
     Bela Supernova awarded a joint grant by Chainlink and Filecoin to support
     public health data oracle development.

--- a/src/content/blog/blockchain-copyright-law.md
+++ b/src/content/blog/blockchain-copyright-law.md
@@ -10,7 +10,6 @@ image:
   src: /assets/images/image-c-30.png
 category: reports
 seo:
-  title: Exploring Blockchain and Copyright Law
   description:
     A deep dive into the intersection of blockchain technology and copyright
     law. Understand the legal implications.

--- a/src/content/blog/building-a-flow-nft-pet-store-part-1.md
+++ b/src/content/blog/building-a-flow-nft-pet-store-part-1.md
@@ -11,7 +11,6 @@ image:
   src: /assets/images/64423a9bd1b0256d85f907e2_0-al1sv2xu4ah_bwdo.png
 category: use-cases
 seo:
-  title: "Building a Flow NFT Pet Store: Part 1"
   description:
     Learn how to build an NFT pet store on Flow blockchain. Step-by-step
     guide for developers. Part 1 of the series.

--- a/src/content/blog/building-an-nft-store-on-flow-part-2.md
+++ b/src/content/blog/building-an-nft-store-on-flow-part-2.md
@@ -11,7 +11,6 @@ image:
   src: /assets/images/6452458c4af3f5baef0c433c_0-4zwhgcutykrxqrsw.jpg
 category: use-cases
 seo:
-  title: "Building an NFT Store on Flow: Part 2"
   description:
     Continue building your NFT store on Flow blockchain. Follow this detailed
     guide for developers. Part 2 of the series.

--- a/src/content/blog/call-for-community-feedback-weigh-in-on-the-new-filecoin-governance-process-proposal-fip0001v2.md
+++ b/src/content/blog/call-for-community-feedback-weigh-in-on-the-new-filecoin-governance-process-proposal-fip0001v2.md
@@ -13,7 +13,6 @@ description:
 image:
   src: /assets/images/231017-fip0001v2.png
 seo:
-  title: "Community Feedback: New Filecoin Governance Proposal"
   description:
     Weigh in on the new Filecoin governance process proposal FIP0001v2.
     Your feedback is crucial for the community.

--- a/src/content/blog/case-study-desci-labs-and-filecoin-enabling-a-future-of-open-science.md
+++ b/src/content/blog/case-study-desci-labs-and-filecoin-enabling-a-future-of-open-science.md
@@ -14,7 +14,6 @@ image:
   src: /assets/images/0719-cs-desci.png
 category: use-cases
 seo:
-  title: "Case Study: DeSci Labs and Filecoin - Enabling a Future of Open Science"
   description:
     Explore how DeSci Labs uses Filecoin to enable a future of open science.
     A detailed case study.

--- a/src/content/blog/case-study-genrait-leverages-filecoin-network-for-greater-visibility-access-and-storage-of-genomic-data.md
+++ b/src/content/blog/case-study-genrait-leverages-filecoin-network-for-greater-visibility-access-and-storage-of-genomic-data.md
@@ -14,7 +14,6 @@ image:
   src: /assets/images/image-c-02.png
 category: use-cases
 seo:
-  title: "Case Study: GenRait Leverages Filecoin for Genomic Data Storage"
   description:
     GenRait leverages Filecoin for greater visibility, access, and storage
     of genomic data. Read the full case study.

--- a/src/content/blog/case-study-opsci-how-an-open-science-commons-project-built-on-web3-infrastructure-empowers-community-discovery.md
+++ b/src/content/blog/case-study-opsci-how-an-open-science-commons-project-built-on-web3-infrastructure-empowers-community-discovery.md
@@ -12,7 +12,6 @@ image:
   src: /assets/images/0224-cs-opsci.png
 category: use-cases
 seo:
-  title: "Case Study: OpSci Empowers Community Discovery with Web3"
   description:
     Discover how OpSci uses Web3 infrastructure to empower community discovery.
     A comprehensive case study.

--- a/src/content/blog/case-study-redefining-web-presence-no-code-tools-meet-decentralized-hosting.md
+++ b/src/content/blog/case-study-redefining-web-presence-no-code-tools-meet-decentralized-hosting.md
@@ -10,9 +10,6 @@ image:
   src: /assets/images/0905-cs-ff.png
 category: use-cases
 seo:
-  title:
-    "Case Study: Redefining Web Presence with No-Code Tools and Decentralized
-    Hosting"
   description:
     Explore how no-code tools and decentralized hosting redefine web presence
     in this detailed case study.

--- a/src/content/blog/case-study-seal-storage-making-web3-accessible-for-all-through-ecosystem-leadership-and-the-filecoin-network-1.md
+++ b/src/content/blog/case-study-seal-storage-making-web3-accessible-for-all-through-ecosystem-leadership-and-the-filecoin-network-1.md
@@ -14,7 +14,6 @@ image:
   src: /assets/images/64423aa28d1be743ddce7ab2_1-inwzqgetwegv3q8q0c4fea.webp
 category: use-cases
 seo:
-  title: "Case Study: Seal Storage - Making Web3 Accessible for All"
   description:
     Seal Storage makes Web3 accessible through ecosystem leadership and
     the Filecoin network. Read the case study.

--- a/src/content/blog/congratulations-to-the-hedera-x-filecoin-grant-program-winners.md
+++ b/src/content/blog/congratulations-to-the-hedera-x-filecoin-grant-program-winners.md
@@ -10,7 +10,6 @@ image:
   src: /assets/images/64423aa44e4c6826a3f40982_0-3uh8nohy2qqafnfv.png
 category: news
 seo:
-  title: Congratulations to the Hedera x Filecoin Grant Program Winners
   description:
     Announcing the winners of the Hedera x Filecoin grant program. Congratulations
     to all the innovative projects.

--- a/src/content/blog/decentralizing-art-a-deep-dive-into-waterlily-ais-use-of-fvm-and-ai.md
+++ b/src/content/blog/decentralizing-art-a-deep-dive-into-waterlily-ais-use-of-fvm-and-ai.md
@@ -11,7 +11,6 @@ image:
   src: /assets/images/06262023-waterlilly.png
 category: use-cases
 seo:
-  title: "Decentralizing Art: Waterlily AI's Use of FVM and AI"
   description:
     Explore how Waterlily AI uses FVM and AI to decentralize art. A deep
     dive into their technology.

--- a/src/content/blog/deep-dive-on-messaris-q1-filecoin-ecosystem-report.md
+++ b/src/content/blog/deep-dive-on-messaris-q1-filecoin-ecosystem-report.md
@@ -10,7 +10,6 @@ description:
 image:
   src: /assets/images/050824-messariq1.png
 seo:
-  title: Deep Dive on Messari's Q1 Filecoin Ecosystem Report
   description:
     An in-depth look at Messari's Q1 report on the Filecoin ecosystem.
     Key insights and analysis.

--- a/src/content/blog/democracys-library-announces-more-than-a-petabyte-of-government-data-uploaded-to-the-filecoin-network.md
+++ b/src/content/blog/democracys-library-announces-more-than-a-petabyte-of-government-data-uploaded-to-the-filecoin-network.md
@@ -8,7 +8,6 @@ image:
   src: /assets/images/1018-sps-democracyslibrary.png
 category: news
 seo:
-  title: Democracy’s Library Uploads Over a Petabyte of Government Data to Filecoin Network
   description: Discover how Democracy’s Library has successfully uploaded over a petabyte of U.S. government data to the Filecoin network, ensuring long-term preservation and accessibility.
 ---
 

--- a/src/content/blog/dev-grant-spotlight-4everland.md
+++ b/src/content/blog/dev-grant-spotlight-4everland.md
@@ -11,8 +11,8 @@ description: 4EVERLAND is a blockchain technology-powered cloud computing
 image:
   src: /assets/images/64423aa58d1be7828cce7d89_1-45khiwwqpsgwtnrtjpkoqa.png
 seo:
-  title: "Dev Grant Spotlight: 4EVERLAND"
-  description: Spotlight on 4EVERLAND, a recipient of the Filecoin Foundation Dev
+  description:
+    Spotlight on 4EVERLAND, a recipient of the Filecoin Foundation Dev
     Grant. Learn about their contributions and innovations.
 ---
 

--- a/src/content/blog/dev-grant-spotlight-arlequin-the-artist-s-metaverse.md
+++ b/src/content/blog/dev-grant-spotlight-arlequin-the-artist-s-metaverse.md
@@ -11,7 +11,6 @@ description: Arlequin — the Artists Metaverse — is a community-driven,
 image:
   src: /assets/images/64423aa70425d34fa6f2743e_1-s1umhgp4fz8mfyk3fixjia.png
 seo:
-  title: "Dev Grant Spotlight: Arlequin - The Artist’s Metaverse"
   description: Arlequin's Artist’s Metaverse project spotlight. Discover their
     journey with the Filecoin Foundation Dev Grant.
 ---

--- a/src/content/blog/dev-grant-spotlight-datastation.md
+++ b/src/content/blog/dev-grant-spotlight-datastation.md
@@ -11,7 +11,6 @@ description: "DataStation is a platform that enhances the decentralized storage
 image:
   src: /assets/images/image-c-22.png
 seo:
-  title: "Dev Grant Spotlight: Datastation"
   description: Datastation's innovative solutions highlighted in this Filecoin
     Foundation Dev Grant spotlight. Learn more about their work.
 ---

--- a/src/content/blog/dev-grant-spotlight-encloud.md
+++ b/src/content/blog/dev-grant-spotlight-encloud.md
@@ -13,7 +13,6 @@ description: Businesses hold trillions of dollars of valuable data which,
 image:
   src: /assets/images/0405-dgs-180protocol.png
 seo:
-  title: "Dev Grant Spotlight: Encloud"
   description: Encloud's contributions to the ecosystem as a Filecoin Foundation
     Dev Grant recipient. Explore their achievements.
 ---

--- a/src/content/blog/dev-grant-spotlight-fileverse.md
+++ b/src/content/blog/dev-grant-spotlight-fileverse.md
@@ -10,7 +10,6 @@ description: This is the latest post in our series highlighting the builders and
 image:
   src: /assets/images/rectangle-31-.png
 seo:
-  title: "Dev Grant Spotlight: Fileverse"
   description: "Fileverse project spotlight: Discover their innovations and
     contributions as a Filecoin Foundation Dev Grant recipient."
 ---

--- a/src/content/blog/dev-grant-spotlight-freenet-2.md
+++ b/src/content/blog/dev-grant-spotlight-freenet-2.md
@@ -10,8 +10,8 @@ description: Freenet is free software that lets users anonymously chat, share
 image:
   src: /assets/images/64423aae5b72a20c3b84a368_0-y9cgmvjvrgwywsvt.png
 seo:
-  title: "Dev Grant Spotlight: Freenet 2"
-  description: Freenet 2's journey and achievements as a recipient of the Filecoin
+  description:
+    Freenet 2's journey and achievements as a recipient of the Filecoin
     Foundation Dev Grant. Learn more about their project.
 ---
 

--- a/src/content/blog/dev-grant-spotlight-geo-web.md
+++ b/src/content/blog/dev-grant-spotlight-geo-web.md
@@ -10,7 +10,6 @@ description: The Geo Web project, a participant in Filecoin’s Developer Grants
 image:
   src: /assets/images/64423aafa6ec4151d52a3dc9_0-eczvdfkkiozsdvgv.jpeg
 seo:
-  title: "Dev Grant Spotlight: Geo Web"
   description: Spotlight on Geo Web, exploring their innovative solutions and
     contributions to the Filecoin ecosystem.
 ---

--- a/src/content/blog/dev-grant-spotlight-jackal-storage.md
+++ b/src/content/blog/dev-grant-spotlight-jackal-storage.md
@@ -9,8 +9,8 @@ description: JACKAL Storage is a platform that provides a secure, private, and
 image:
   src: /assets/images/64423ab18d1be70ae7ce9031_1-qwnolzesajrp3gjwrthflg.png
 seo:
-  title: "Dev Grant Spotlight: Jackal Storage"
-  description: Jackal Storage's impactful work as a Filecoin Foundation Dev Grant
+  description:
+    Jackal Storage's impactful work as a Filecoin Foundation Dev Grant
     recipient. Dive into their project and achievements.
 ---
 

--- a/src/content/blog/dev-grant-spotlight-numbers-protocol-puts-digital-creators-in-control-of-their-assets.md
+++ b/src/content/blog/dev-grant-spotlight-numbers-protocol-puts-digital-creators-in-control-of-their-assets.md
@@ -11,8 +11,8 @@ description: "Numbers Protocol: Revolutionizing the creator economy by
 image:
   src: /assets/images/0315-dgs-numbers.png
 seo:
-  title: "Dev Grant Spotlight: Numbers Protocol - Empowering Digital Creators"
-  description: Numbers Protocol puts digital creators in control of their assets.
+  description:
+    Numbers Protocol puts digital creators in control of their assets.
     Explore their journey as a dev grant recipient.
 ---
 

--- a/src/content/blog/dev-grant-spotlight-portrait.md
+++ b/src/content/blog/dev-grant-spotlight-portrait.md
@@ -9,7 +9,6 @@ description: Portrait is the first open-source web page builder, allowing people
 image:
   src: /assets/images/64423ab50425d36d72f2895f_1-brm0bxgpfk7-tr5tfyq-la.png
 seo:
-  title: "Dev Grant Spotlight: Portrait"
   description: Portrait's contributions to the Filecoin ecosystem highlighted in
     this dev grant spotlight. Learn more.
 ---

--- a/src/content/blog/dev-grant-spotlight-renovi.md
+++ b/src/content/blog/dev-grant-spotlight-renovi.md
@@ -10,7 +10,6 @@ description: If you build it they will come. That’s the aim of Renovi, a
 image:
   src: /assets/images/image-c-11.png
 seo:
-  title: "Dev Grant Spotlight: Renovi"
   description: Renovi's journey and innovative solutions as a recipient of the
     Filecoin Foundation Dev Grant. Explore their work.
 ---

--- a/src/content/blog/dev-grant-spotlight-ukraine-art-collective.md
+++ b/src/content/blog/dev-grant-spotlight-ukraine-art-collective.md
@@ -10,8 +10,8 @@ description: Ukraine Art Collective’s (UkraineArtCo) mission is to unite artis
 image:
   src: /assets/images/64423ab8fa70d13d126ff4f7_1-4bia5dzrvjftkirryi_bxq.png
 seo:
-  title: "Dev Grant Spotlight: Ukraine Art Collective"
-  description: Ukraine Art Collective's impactful project highlighted in this dev
+  description:
+    Ukraine Art Collective's impactful project highlighted in this dev
     grant spotlight. Discover their contributions.
 ---
 

--- a/src/content/blog/dev-grant-spotlight-webrecorder.md
+++ b/src/content/blog/dev-grant-spotlight-webrecorder.md
@@ -13,7 +13,6 @@ image:
   src: /assets/images/image-c-14.png
 category: reports
 seo:
-  title: "Dev Grant Spotlight: Webrecorder"
   description:
     Webrecorder's journey and achievements as a recipient of the Filecoin
     dev grant. Learn more about their project.

--- a/src/content/blog/developer-grants-updates-august-2024.md
+++ b/src/content/blog/developer-grants-updates-august-2024.md
@@ -9,7 +9,6 @@ description: The Developer Grants Updates series brings news and highlights from
 image:
   src: /assets/images/0701-dg-updates.webp
 seo:
-  title: Filecoin Foundation Developer Grants Updates August 2024
   description:
     Explore the Filecoin Foundation's latest Developer Grants Updates,
     featuring 2024 highlights, new projects, and funding innovations. Discover

--- a/src/content/blog/driving-widespread-filecoin-adoption-key-initiatives-and-community-involvement-in-2024.md
+++ b/src/content/blog/driving-widespread-filecoin-adoption-key-initiatives-and-community-involvement-in-2024.md
@@ -14,7 +14,6 @@ description:
 image:
   src: /assets/images/050924-adoption.png
 seo:
-  title: "Driving Widespread Filecoin Adoption: Key Initiatives for 2024"
   description:
     Explore key initiatives and community involvement driving widespread
     Filecoin adoption in 2024.

--- a/src/content/blog/dweb-on-the-rise-the-many-uses-for-decentralized-storage.md
+++ b/src/content/blog/dweb-on-the-rise-the-many-uses-for-decentralized-storage.md
@@ -14,7 +14,6 @@ image:
   src: /assets/images/0905-dweb-on-the-rise.png
 category: ecosystem
 seo:
-  title: "DWeb on the Rise: Uses for Decentralized Storage"
   description:
     Decentralized web (DWeb) on the rise. Discover the many uses for decentralized
     storage solutions.

--- a/src/content/blog/dzk-foundation-awarded-chainlink-filecoin-joint-grant-to-support-zk-rollup-research.md
+++ b/src/content/blog/dzk-foundation-awarded-chainlink-filecoin-joint-grant-to-support-zk-rollup-research.md
@@ -13,7 +13,6 @@ created-on: "2023-04-21T07:26:52.479Z"
 published-on: "2023-04-21T07:33:56.200Z"
 category: news
 seo:
-  title: DZK Foundation Awarded Grant for ZK-Rollup Research
   description:
     DZK Foundation receives Chainlink-Filecoin joint grant to support ZK-Rollup
     research. Learn more.

--- a/src/content/blog/ecosystem-spotlight-ghostdrives-secure-decentralized-storage-now-on-mobile.md
+++ b/src/content/blog/ecosystem-spotlight-ghostdrives-secure-decentralized-storage-now-on-mobile.md
@@ -11,7 +11,6 @@ image:
   src: /assets/images/0604-ghostdrive.png
 category: ecosystem
 seo:
-  title: "Ecosystem Spotlight: GhostDrive's Secure, Decentralized Storage Now on Mobile"
   description: "Explore GhostDrive’s secure decentralized storage on mobile, leveraging Filecoin for enhanced redundancy and security. Now available on App Store and Google Play."
 ---
 

--- a/src/content/blog/ecosystem-spotlight-transfer-q-a-on-preserving-artistic-value-with-decentralized-technology-data-sovereignty-and-harnessing-value-of-data.md
+++ b/src/content/blog/ecosystem-spotlight-transfer-q-a-on-preserving-artistic-value-with-decentralized-technology-data-sovereignty-and-harnessing-value-of-data.md
@@ -13,7 +13,6 @@ description: >
 image:
   src: /assets/images/020124-transfer.png
 seo:
-  title: "Ecosystem Spotlight: Transfer Q&A on Decentralized Technology"
   description:
     "Transfer Q&A: Preserving artistic value, data sovereignty, and harnessing
     data value with decentralized tech."

--- a/src/content/blog/empowering-governance-the-launch-of-metropolis-to-the-filecoin-community.md
+++ b/src/content/blog/empowering-governance-the-launch-of-metropolis-to-the-filecoin-community.md
@@ -10,7 +10,6 @@ description:
 image:
   src: /assets/images/blog-header-_-metropolis.png
 seo:
-  title: "Empowering Governance: Launch of Metropolis for Filecoin Community"
   description:
     Announcing the launch of Metropolis to empower governance in the Filecoin
     community. Learn more.

--- a/src/content/blog/everything-you-need-to-know-about-fip0036-deliberation-discussion-and-next-steps.md
+++ b/src/content/blog/everything-you-need-to-know-about-fip0036-deliberation-discussion-and-next-steps.md
@@ -13,7 +13,6 @@ created-on: "2023-04-21T07:26:54.116Z"
 published-on: "2023-04-21T07:33:56.200Z"
 category: ecosystem
 seo:
-  title: "FIP0036: Deliberation, Discussion, and Next Steps"
   description:
     "Everything you need to know about FIP0036: Deliberation, discussion,
     and next steps. Get involved."

--- a/src/content/blog/ff-x-lockheed-martin-mission-announcement.md
+++ b/src/content/blog/ff-x-lockheed-martin-mission-announcement.md
@@ -14,7 +14,6 @@ image:
   src: /assets/images/01-lockheed-p-1080.png
 category: news
 seo:
-  title: Filecoin Foundation x Lockheed Martin Mission Announcement
   description:
     Announcing the Filecoin Foundation and Lockheed Martin mission collaboration.
     Explore the details.

--- a/src/content/blog/fil-austin-2022-recap-fil-ling-you-in.md
+++ b/src/content/blog/fil-austin-2022-recap-fil-ling-you-in.md
@@ -11,7 +11,6 @@ image:
   src: /assets/images/image-c-15.png
 category: events
 seo:
-  title: "FIL Austin 2022 Recap: FIL-ling You In"
   description:
     Recap of FIL Austin 2022. Get FIL-led in on the highlights and key
     takeaways from the event.

--- a/src/content/blog/fil-toronto-2022-recap.md
+++ b/src/content/blog/fil-toronto-2022-recap.md
@@ -11,7 +11,6 @@ image:
   src: /assets/images/image-c-07.png
 category: events
 seo:
-  title: FIL Toronto 2022 Recap
   description: Recap of FIL Toronto 2022. Highlights and key takeaways from the event.
 ---
 

--- a/src/content/blog/filecoin-as-a-depin-prototype.md
+++ b/src/content/blog/filecoin-as-a-depin-prototype.md
@@ -9,7 +9,6 @@ description: The Decentralized Physical Infrastructure Network (DePIN) movement
 image:
   src: /assets/images/022624-depin.png
 seo:
-  title: Filecoin as a DePIN Prototype
   description: Exploring Filecoin's role as a decentralized physical
     infrastructure network (DePIN) prototype.
 ---

--- a/src/content/blog/filecoin-community-approves-change-to-storage-provider-terminology.md
+++ b/src/content/blog/filecoin-community-approves-change-to-storage-provider-terminology.md
@@ -11,7 +11,6 @@ image:
   src: /assets/images/fip18.png
 category: news
 seo:
-  title: Filecoin Community Approves Change to Storage Provider Terminology
   description:
     The Filecoin community approves a change in storage provider terminology.
     Learn more.

--- a/src/content/blog/filecoin-ecosystem-shines-at-fil-hong-kong-ai-depin-fvm-and-more.md
+++ b/src/content/blog/filecoin-ecosystem-shines-at-fil-hong-kong-ai-depin-fvm-and-more.md
@@ -10,7 +10,6 @@ description:
 image:
   src: /assets/images/blogheader-filhk24recap-1-.png
 seo:
-  title: "Filecoin Ecosystem Shines at FIL Hong Kong: AI, DePIN, FVM, and More"
   description:
     Highlights from FIL Hong Kong, showcasing AI, DePIN, FVM, and more
     in the Filecoin ecosystem.

--- a/src/content/blog/filecoin-foundation-2022-annual-report.md
+++ b/src/content/blog/filecoin-foundation-2022-annual-report.md
@@ -10,7 +10,6 @@ image:
   src: /assets/images/64423ac6b068b0a9945c5010_0206-ff-22-annual-report.png
 category: reports
 seo:
-  title: Filecoin Foundation 2022 Annual Report
   description:
     Review the Filecoin Foundation's 2022 annual report. Key achievements
     and milestones.

--- a/src/content/blog/filecoin-foundation-2023-annual-report.md
+++ b/src/content/blog/filecoin-foundation-2023-annual-report.md
@@ -13,7 +13,6 @@ description:
 image:
   src: /assets/images/022624-ff-anualreport.png
 seo:
-  title: Filecoin Foundation 2023 Annual Report
   description:
     Explore the Filecoin Foundation's 2023 annual report. Highlights and
     future plans.

--- a/src/content/blog/filecoin-foundation-and-blockchain-law-for-social-good-center-accelerate-web3-education-1.md
+++ b/src/content/blog/filecoin-foundation-and-blockchain-law-for-social-good-center-accelerate-web3-education-1.md
@@ -12,9 +12,6 @@ created-on: "2023-04-21T07:27:04.336Z"
 published-on: "2023-04-21T07:33:56.200Z"
 category: news
 seo:
-  title:
-    Filecoin Foundation and Blockchain Law for Social Good Center Accelerate
-    Web3 Education
   description:
     Collaborative efforts to accelerate Web3 education by Filecoin Foundation
     and Blockchain Law for Social Good Center.

--- a/src/content/blog/filecoin-foundation-and-blockchain-law-for-social-good-center-accelerate-web3-education.md
+++ b/src/content/blog/filecoin-foundation-and-blockchain-law-for-social-good-center-accelerate-web3-education.md
@@ -13,9 +13,6 @@ created-on: "2023-04-21T07:27:05.729Z"
 published-on: "2023-04-21T07:33:56.200Z"
 category: news
 seo:
-  title:
-    Filecoin Foundation and Blockchain Law for Social Good Center Accelerate
-    Web3 Education
   description:
     Efforts by Filecoin Foundation and Blockchain Law for Social Good Center
     to promote Web3 education.

--- a/src/content/blog/filecoin-foundation-and-ffdw-team-up-with-the-internet-archive-to-preserve-government-datasets-in-new-democracy-s-library-initiative.md
+++ b/src/content/blog/filecoin-foundation-and-ffdw-team-up-with-the-internet-archive-to-preserve-government-datasets-in-new-democracy-s-library-initiative.md
@@ -13,7 +13,6 @@ created-on: "2023-04-21T07:27:07.444Z"
 published-on: "2023-04-21T07:33:56.200Z"
 category: news
 seo:
-  title: Filecoin Foundation and FFDW Team Up with Internet Archive
   description:
     Filecoin Foundation, FFDW, and Internet Archive collaborate to preserve
     government datasets in Democracy’s Library initiative.

--- a/src/content/blog/filecoin-foundation-and-filecoin-foundation-for-the-decentralized-web-expand-boards.md
+++ b/src/content/blog/filecoin-foundation-and-filecoin-foundation-for-the-decentralized-web-expand-boards.md
@@ -14,7 +14,6 @@ image:
   src: /assets/images/64423acca6ec4184be2a4866_1-kequqilr3jvs6nq_e7naqq.png
 category: news
 seo:
-  title: Filecoin Foundation and FFDW Expand Boards
   description:
     Filecoin Foundation and Filecoin Foundation for the Decentralized Web
     announce board expansions.

--- a/src/content/blog/filecoin-foundation-and-filecoin-foundation-for-the-decentralized-web-gain-momentum.md
+++ b/src/content/blog/filecoin-foundation-and-filecoin-foundation-for-the-decentralized-web-gain-momentum.md
@@ -12,7 +12,6 @@ image:
   src: /assets/images/64423aceef619d5dc5b60e52_1-e009tiaipq2vndk-evb9ng.png
 category: news
 seo:
-  title: Filecoin Foundation and FFDW Gain Momentum
   description:
     The Filecoin Foundation and Filecoin Foundation for the Decentralized
     Web gain momentum. Discover their latest initiatives.

--- a/src/content/blog/filecoin-foundation-and-lockheed-martin-bring-decentralized-storage-to-space.md
+++ b/src/content/blog/filecoin-foundation-and-lockheed-martin-bring-decentralized-storage-to-space.md
@@ -15,7 +15,6 @@ image:
   src: /assets/images/01-lockheed-p-1080.png
 category: news
 seo:
-  title: Filecoin Foundation and Lockheed Martin Bring Decentralized Storage to Space
   description:
     Learn about the collaboration between Filecoin Foundation and Lockheed
     Martin to bring decentralized storage to space.

--- a/src/content/blog/filecoin-foundation-and-protocol-labs-embark-on-experimental-project-to-put-new-york-city-open-data-on-the-filecoin-network.md
+++ b/src/content/blog/filecoin-foundation-and-protocol-labs-embark-on-experimental-project-to-put-new-york-city-open-data-on-the-filecoin-network.md
@@ -15,7 +15,6 @@ image:
   src: /assets/images/64423ad14e4c686170f43f8e_1-_l1pjw5m2ayuddshdifbcg.png
 category: news
 seo:
-  title: Filecoin Foundation and Protocol Labs' NYC Open Data Project
   description:
     Experimental project by Filecoin Foundation and Protocol Labs to put
     New York City open data on the Filecoin network.

--- a/src/content/blog/filecoin-foundation-announces-board-of-directors.md
+++ b/src/content/blog/filecoin-foundation-announces-board-of-directors.md
@@ -10,7 +10,6 @@ image:
   src: /assets/images/image-c-06.png
 category: news
 seo:
-  title: Filecoin Foundation Announces Board of Directors
   description:
     Filecoin Foundation announces the new board of directors. Learn about
     the new members.

--- a/src/content/blog/filecoin-foundation-chair-marta-belcher-testifies-before-us-senate-banking-committee.md
+++ b/src/content/blog/filecoin-foundation-chair-marta-belcher-testifies-before-us-senate-banking-committee.md
@@ -15,7 +15,6 @@ image:
   src: /assets/images/64423ad4d7488e39d6b03c3a_0-oh5oa7medvgzjscu.png
 category: news
 seo:
-  title: Filecoin Foundation Chair Testifies Before US Senate
   description:
     Filecoin Foundation Chair Marta Belcher testifies before the US Senate
     Banking Committee. Key points and implications.

--- a/src/content/blog/filecoin-foundation-first-half-year-in-review.md
+++ b/src/content/blog/filecoin-foundation-first-half-year-in-review.md
@@ -11,7 +11,6 @@ created-on: "2023-04-21T07:27:18.330Z"
 published-on: "2023-04-21T07:33:56.200Z"
 category: reports
 seo:
-  title: Filecoin Foundation First Half-Year in Review
   description:
     A review of the Filecoin Foundation's achievements in the first half
     of the year. Highlights and milestones.

--- a/src/content/blog/filecoin-foundation-introduces-fil-lisbon-2022-to-bring-the-web3-community-together-announces-speakers.md
+++ b/src/content/blog/filecoin-foundation-introduces-fil-lisbon-2022-to-bring-the-web3-community-together-announces-speakers.md
@@ -12,7 +12,6 @@ created-on: "2023-04-21T07:27:19.915Z"
 published-on: "2023-04-21T07:33:56.200Z"
 category: events
 seo:
-  title: Filecoin Foundation Introduces FIL Lisbon 2022
   description:
     Introducing FIL Lisbon 2022 by Filecoin Foundation. Bringing the Web3
     community together. Announcing speakers.

--- a/src/content/blog/filecoin-foundation-joins-blockchain-for-europe.md
+++ b/src/content/blog/filecoin-foundation-joins-blockchain-for-europe.md
@@ -11,7 +11,6 @@ created-on: "2023-04-21T07:27:21.334Z"
 published-on: "2023-04-21T07:33:56.200Z"
 category: news
 seo:
-  title: Filecoin Foundation Joins Blockchain for Europe
   description:
     Filecoin Foundation joins Blockchain for Europe. Learn about the significance
     and objectives of this partnership.

--- a/src/content/blog/filecoin-foundation-quarterly-update-october-2024.md
+++ b/src/content/blog/filecoin-foundation-quarterly-update-october-2024.md
@@ -13,7 +13,6 @@ seo:
     card: summary
   description: "This month, Filecoin Foundation (FF) is launching quarterly
     updates designed to hone in on different trends across our ecosystem. "
-  title: "Filecoin Foundation Quarterly Update: October 2024"
 ---
 
 ## Empowering AI through Decentralization and Innovation

--- a/src/content/blog/filecoin-foundation-successfully-deploys-interplanetary-file-system-ipfs-in-space.md
+++ b/src/content/blog/filecoin-foundation-successfully-deploys-interplanetary-file-system-ipfs-in-space.md
@@ -14,7 +14,6 @@ description:
 image:
   src: /assets/images/01-lockheed.png
 seo:
-  title: Filecoin Foundation Successfully Deploys IPFS in Space
   description:
     Filecoin Foundation successfully deploys IPFS in space. Discover the
     details of this groundbreaking achievement.

--- a/src/content/blog/filecoin-foundation-wave-9-dev-grant-proposals-due-friday-july-30.md
+++ b/src/content/blog/filecoin-foundation-wave-9-dev-grant-proposals-due-friday-july-30.md
@@ -11,7 +11,6 @@ image:
   src: /assets/images/image-c-17.png
 category: news
 seo:
-  title: Filecoin Foundation Wave 9 Dev Grant Proposals Due
   description:
     Submit your proposals for Filecoin Foundation's Wave 9 Dev Grant by
     Friday, July 30. Learn more about the application process.

--- a/src/content/blog/filecoin-mainnet-marks-four-years.md
+++ b/src/content/blog/filecoin-mainnet-marks-four-years.md
@@ -13,7 +13,6 @@ image:
 seo:
   twitter:
     card: summary
-  title: Filecoin Mainnet Marks Four Years
   description:
     Today, we say a huge thank you to the incredible Filecoin community
     of builders, storage providers, data clients, and all those who are helping

--- a/src/content/blog/filecoin-mainnet-marks-three-years.md
+++ b/src/content/blog/filecoin-mainnet-marks-three-years.md
@@ -9,7 +9,6 @@ description: This week, Filecoin Foundation celebrates the three-year
 image:
   src: /assets/images/image-3-.png
 seo:
-  title: Filecoin Mainnet Marks Three Years
   description: Celebrating three years of Filecoin mainnet. Reflecting on the
     achievements and looking forward to the future.
 ---

--- a/src/content/blog/filecoin-network-base-at-consensus-2023-wrapped.md
+++ b/src/content/blog/filecoin-network-base-at-consensus-2023-wrapped.md
@@ -12,7 +12,6 @@ image:
   src: /assets/images/051823-austin-recap.png
 category: events
 seo:
-  title: Filecoin Network Base at Consensus 2023 Wrapped
   description:
     Wrapping up the Filecoin Network Base at Consensus 2023. Highlights
     and key takeaways from the event.

--- a/src/content/blog/filecoin-nv19-lightning-upgrade.md
+++ b/src/content/blog/filecoin-nv19-lightning-upgrade.md
@@ -12,7 +12,6 @@ image:
   src: /assets/images/06012023-lightningupgrade.png
 category: news
 seo:
-  title: Filecoin NV19 Lightning Upgrade
   description:
     Announcing the Filecoin NV19 Lightning upgrade. Discover the improvements
     and new features.

--- a/src/content/blog/filecoin-storage-provider-spotlight-dcent.md
+++ b/src/content/blog/filecoin-storage-provider-spotlight-dcent.md
@@ -11,7 +11,6 @@ image:
   src: /assets/images/0524-sps-dcent.png
 category: ecosystem
 seo:
-  title: "Filecoin Storage Provider Spotlight: Dcent"
   description:
     Spotlight on Dcent, a prominent Filecoin storage provider. Discover
     their contributions and innovations.

--- a/src/content/blog/filecoin-storage-provider-spotlight-filswan.md
+++ b/src/content/blog/filecoin-storage-provider-spotlight-filswan.md
@@ -12,7 +12,6 @@ created-on: "2023-04-21T07:27:26.180Z"
 published-on: "2023-04-21T07:33:56.200Z"
 category: ecosystem
 seo:
-  title: "Filecoin Storage Provider Spotlight: Filswan"
   description:
     Explore the achievements and offerings of Filswan, a key player in
     the Filecoin storage ecosystem.

--- a/src/content/blog/filecoin-storage-provider-spotlight-linix.md
+++ b/src/content/blog/filecoin-storage-provider-spotlight-linix.md
@@ -13,7 +13,6 @@ created-on: "2023-04-21T07:27:27.712Z"
 published-on: "2023-04-21T07:33:56.200Z"
 category: ecosystem
 seo:
-  title: "Filecoin Storage Provider Spotlight: Linix"
   description:
     Linix's role and impact as a Filecoin storage provider highlighted
     in this spotlight feature.

--- a/src/content/blog/filecoin-storage-provider-spotlight-meta-blockchain.md
+++ b/src/content/blog/filecoin-storage-provider-spotlight-meta-blockchain.md
@@ -12,7 +12,6 @@ created-on: "2023-04-21T07:27:29.284Z"
 published-on: "2023-04-21T07:33:56.200Z"
 category: ecosystem
 seo:
-  title: "Filecoin Storage Provider Spotlight: Meta Blockchain"
   description:
     Meta Blockchain's contributions to the Filecoin storage network. Learn
     more about their innovations.

--- a/src/content/blog/filecoin-storage-provider-spotlight-nonentropy.md
+++ b/src/content/blog/filecoin-storage-provider-spotlight-nonentropy.md
@@ -8,7 +8,6 @@ image:
   src: /assets/images/64423ae2ef619d69dab60e9f_0-qyjcuk2pe_bhv2jh.png
 category: ecosystem
 seo:
-  title: "Filecoin Storage Provider Spotlight: Nonentropy"
   description:
     Discover Nonentropy's role and impact as a Filecoin storage provider
     in this spotlight feature.

--- a/src/content/blog/filecoin-storage-provider-spotlight-origin-storage.md
+++ b/src/content/blog/filecoin-storage-provider-spotlight-origin-storage.md
@@ -11,7 +11,6 @@ image:
   src: /assets/images/image-c-01.png
 category: ecosystem
 seo:
-  title: "Filecoin Storage Provider Spotlight: Origin Storage"
   description:
     Spotlight on Origin Storage, a key player in the Filecoin storage ecosystem.
     Explore their contributions.

--- a/src/content/blog/filecoin-storage-provider-spotlight-piknik.md
+++ b/src/content/blog/filecoin-storage-provider-spotlight-piknik.md
@@ -11,7 +11,6 @@ created-on: "2023-04-21T07:27:34.032Z"
 published-on: "2023-04-21T07:33:56.200Z"
 category: ecosystem
 seo:
-  title: "Filecoin Storage Provider Spotlight: Piknik"
   description:
     Learn about Piknik's offerings and impact as a Filecoin storage provider
     in this spotlight feature.

--- a/src/content/blog/filecoin-storage-provider-spotlight-seal-storage-technology.md
+++ b/src/content/blog/filecoin-storage-provider-spotlight-seal-storage-technology.md
@@ -11,7 +11,6 @@ created-on: "2023-04-21T07:27:36.061Z"
 published-on: "2023-04-21T07:33:56.200Z"
 category: ecosystem
 seo:
-  title: "Filecoin Storage Provider Spotlight: Seal Storage Technology"
   description:
     Seal Storage Technology's role and contributions to the Filecoin storage
     network. Discover more.

--- a/src/content/blog/filswan-awarded-chainlink-filecoin-joint-grant-to-create-multi-chain-decentralized-data-storage-payment-solution.md
+++ b/src/content/blog/filswan-awarded-chainlink-filecoin-joint-grant-to-create-multi-chain-decentralized-data-storage-payment-solution.md
@@ -14,7 +14,6 @@ created-on: "2023-04-21T07:27:37.543Z"
 published-on: "2023-04-21T07:33:56.200Z"
 category: news
 seo:
-  title: Filswan Awarded Chainlink-Filecoin Joint Grant
   description:
     Filswan receives Chainlink-Filecoin joint grant to develop a multi-chain
     decentralized data storage payment solution.

--- a/src/content/blog/fip0056-in-last-call-until-03-24-introducing-a-sector-duration-multiplier-and-increasing-sector-duration-times.md
+++ b/src/content/blog/fip0056-in-last-call-until-03-24-introducing-a-sector-duration-multiplier-and-increasing-sector-duration-times.md
@@ -12,7 +12,6 @@ image:
   src: /assets/images/0621-2022-01.png
 category: ecosystem
 seo:
-  title: "FIP0056: Introducing Sector Duration Multiplier"
   description:
     Learn about FIP0056, which introduces a sector duration multiplier
     and increases sector duration times.

--- a/src/content/blog/fip0056-update-proposal-rejected-following-community-feedback-and-deliberation.md
+++ b/src/content/blog/fip0056-update-proposal-rejected-following-community-feedback-and-deliberation.md
@@ -13,7 +13,6 @@ image:
   src: /assets/images/0621-2022-01.png
 category: news
 seo:
-  title: "FIP0056 Update: Proposal Rejected"
   description:
     FIP0056 proposal rejected following community feedback and deliberation.
     Explore the details.

--- a/src/content/blog/fresh-from-ff-early-april.md
+++ b/src/content/blog/fresh-from-ff-early-april.md
@@ -10,7 +10,6 @@ description:
 image:
   src: /assets/images/0215-ff-3-.png
 seo:
-  title: "Fresh from FF: Early April 2024"
   description: Catch up on the latest updates from Filecoin Foundation in early April 2024.
 ---
 

--- a/src/content/blog/fresh-from-ff-early-august-2024.md
+++ b/src/content/blog/fresh-from-ff-early-august-2024.md
@@ -9,7 +9,6 @@ description: "Check out the latest updates about what the Filecoin Foundation
 image:
   src: /assets/images/0215-ff-13-.webp
 seo:
-  title: "Early August Highlights: Filecoin Upgrades, Events, and New Developments"
   description: Discover Filecoin's upcoming upgrade, FIL Bangkok, the redesigned
     fil.org, and more in our early August highlights. Stay updated on events,
     governance, and community news!

--- a/src/content/blog/fresh-from-ff-early-july-2024.md
+++ b/src/content/blog/fresh-from-ff-early-july-2024.md
@@ -9,7 +9,6 @@ description: Check out the latest updates about what the Filecoin Foundation
 image:
   src: /assets/images/0215-ff-16-.webp
 seo:
-  title: "Fresh From FF: Early July, 2024"
   description: "Discover FIL Brussels events, including sessions with top
     innovators, software storage solutions, new grants, and the Data Economy
     Day. Explore decentralized AI and more. "

--- a/src/content/blog/fresh-from-ff-early-june-2024.md
+++ b/src/content/blog/fresh-from-ff-early-june-2024.md
@@ -8,7 +8,6 @@ image:
   src: /assets/images/0215-ff-7-.png
 category: news
 seo:
-  title: "Fresh From Filecoin Foundation: Early June 2024 Updates"
   description: "Get the latest updates from Filecoin Foundation, including events, governance, and ecosystem highlights from early June 2024."
 ---
 

--- a/src/content/blog/fresh-from-ff-early-march-2024.md
+++ b/src/content/blog/fresh-from-ff-early-march-2024.md
@@ -10,7 +10,6 @@ description:
 image:
   src: /assets/images/0215-ff-1-.png
 seo:
-  title: "Fresh from FF: Early March 2024"
   description:
     Stay informed with the latest updates from Filecoin Foundation in early
     March 2024. Key news and events.

--- a/src/content/blog/fresh-from-ff-early-may-2024.md
+++ b/src/content/blog/fresh-from-ff-early-may-2024.md
@@ -10,7 +10,6 @@ description:
 image:
   src: /assets/images/fresh-from-ff-early-may.png
 seo:
-  title: "Fresh from FF: Early May 2024"
   description:
     Discover the latest news and updates from Filecoin Foundation in early
     May 2024. Highlights and events.

--- a/src/content/blog/fresh-from-ff-early-september-2024.md
+++ b/src/content/blog/fresh-from-ff-early-september-2024.md
@@ -9,7 +9,6 @@ description: Check out the latest updates about what the Filecoin Foundation
 image:
   src: /assets/images/0215-ff-16-.webp
 seo:
-  title: "Fresh From FF: Early September"
   description:
     "Learn how decentralized AI and data storage are building trust in
     AI, the launch of FF's new Developer Grants blog series, and more. "

--- a/src/content/blog/fresh-from-ff-mid-april-2024.md
+++ b/src/content/blog/fresh-from-ff-mid-april-2024.md
@@ -10,7 +10,6 @@ description:
 image:
   src: /assets/images/0215-ff-4-.png
 seo:
-  title: "Fresh from FF: Mid April 2024"
   description:
     Mid-April 2024 updates from Filecoin Foundation. Key news, events,
     and highlights.

--- a/src/content/blog/fresh-from-ff-mid-august.md
+++ b/src/content/blog/fresh-from-ff-mid-august.md
@@ -9,7 +9,6 @@ description: Check out the latest updates about what the Filecoin Foundation
 image:
   src: /assets/images/0215-ff-15-.webp
 seo:
-  title: NV23 Waffle Upgrade and Filecoin's Latest Developments
   description: Discover Filecoin's NV23 Waffle upgrade and its enhancements. Get
     insights from Messari’s Q2 2024 report, join FIL Singapore, and stay updated
     with the latest FIPs, governance proposals, and community events.

--- a/src/content/blog/fresh-from-ff-mid-february-2024.md
+++ b/src/content/blog/fresh-from-ff-mid-february-2024.md
@@ -13,7 +13,6 @@ description:
 image:
   src: /assets/images/0215-ff.png
 seo:
-  title: "Fresh from FF: Mid February 2024"
   description:
     Catch up on the latest news and updates from Filecoin Foundation in
     mid-February 2024.

--- a/src/content/blog/fresh-from-ff-mid-march-2024.md
+++ b/src/content/blog/fresh-from-ff-mid-march-2024.md
@@ -10,7 +10,6 @@ description:
 image:
   src: /assets/images/0215-ff-2-.png
 seo:
-  title: "Fresh from FF: Mid March 2024"
   description:
     Stay updated with the latest news and highlights from Filecoin Foundation
     in mid-March 2024.

--- a/src/content/blog/fresh-from-ff-mid-may-2024.md
+++ b/src/content/blog/fresh-from-ff-mid-may-2024.md
@@ -10,7 +10,6 @@ description:
 image:
   src: /assets/images/0215-ff-6-.png
 seo:
-  title: "Fresh from FF: Mid May 2024"
   description:
     Discover the latest updates and news from Filecoin Foundation in mid-May
     1.    Key highlights.

--- a/src/content/blog/fresh-from-ff-october-2024.md
+++ b/src/content/blog/fresh-from-ff-october-2024.md
@@ -9,7 +9,6 @@ description: "Check out the latest updates about what the Filecoin Foundation
 image:
   src: /assets/images/0215-ff-19-.webp
 seo:
-  title: "Fresh From FF: October, 2024"
   description: Filecoin Foundation teams up with Aethir, the Filecoin Ecosystem
     Digest is published, and DocumentCloud is now using Filecoin to ensure
     long-term preservation and distribution of documents.

--- a/src/content/blog/from-roadmap-to-reality-three-takeaways-on-the-future-of-filecoin-with-jonathan-victor.md
+++ b/src/content/blog/from-roadmap-to-reality-three-takeaways-on-the-future-of-filecoin-with-jonathan-victor.md
@@ -14,7 +14,6 @@ description:
 image:
   src: /assets/images/jonathan-victor.png
 seo:
-  title: "From Roadmap to Reality: Future of Filecoin with Jonathan Victor"
   description:
     Three key takeaways on the future of Filecoin with Jonathan Victor.
     From roadmap to reality.

--- a/src/content/blog/gathering-community-input-on-fip-0018-for-miner-to-storage-provider-terminology-change.md
+++ b/src/content/blog/gathering-community-input-on-fip-0018-for-miner-to-storage-provider-terminology-change.md
@@ -12,7 +12,6 @@ image:
   src: /assets/images/fip-header.png
 category: ecosystem
 seo:
-  title: Gathering Community Input on FIP-0018
   description:
     Weigh in on FIP-0018 for changing miner to storage provider terminology.
     Community feedback needed.

--- a/src/content/blog/guest-post-if-the-library-of-alexandria-were-built-better.md
+++ b/src/content/blog/guest-post-if-the-library-of-alexandria-were-built-better.md
@@ -10,7 +10,6 @@ description:
 image:
   src: /assets/images/021224-guest-moca-1-.png
 seo:
-  title: "Guest Post: If the Library of Alexandria Were Built Better"
   description:
     A thought-provoking guest post exploring the concept of a better-built
     Library of Alexandria.

--- a/src/content/blog/hack-away-in-summer-2021.md
+++ b/src/content/blog/hack-away-in-summer-2021.md
@@ -10,7 +10,6 @@ image:
   src: /assets/images/image-c-31.png
 category: events
 seo:
-  title: Hack Away in Summer 2021
   description:
     Join the hacking events in summer 2021. Learn, build, and collaborate
     with the Filecoin community.

--- a/src/content/blog/harvesting-change-filecoin-s-role-in-addressing-agricultural-challenges-in-africa.md
+++ b/src/content/blog/harvesting-change-filecoin-s-role-in-addressing-agricultural-challenges-in-africa.md
@@ -10,7 +10,6 @@ description: "Q&A with Filecoin Orbit ambassador about the potential impact of
 image:
   src: /assets/images/09282024-africaagriculture.png
 seo:
-  title: Filecoin and Blockchain Revolutionizing Agriculture in Africa
   description: Discover how Filecoin’s blockchain technology is addressing
     agricultural challenges in Africa through supply chain transparency,
     sustainable farming, and smart contracts for crop insurance.

--- a/src/content/blog/help-us-improve-filecoin-docs-plus-how-to-receive-grant-funding-up-to-50-000.md
+++ b/src/content/blog/help-us-improve-filecoin-docs-plus-how-to-receive-grant-funding-up-to-50-000.md
@@ -8,7 +8,6 @@ image:
   src: /assets/images/052924-docgrants.png
 category: reports
 seo:
-  title: "Improve Filecoin Docs & Receive Grant Funding up to $50,000"
   description: "Enhance Filecoin documentation and educational resources with our grants program. Funding up to $50,000 available for critical development projects."
 ---
 

--- a/src/content/blog/help-us-increase-utility-for-filecoin-and-zcash-chains.md
+++ b/src/content/blog/help-us-increase-utility-for-filecoin-and-zcash-chains.md
@@ -12,7 +12,6 @@ created-on: "2023-04-21T07:27:45.806Z"
 published-on: "2023-04-21T07:33:56.200Z"
 category: ecosystem
 seo:
-  title: Help Us Increase Utility for Filecoin and Zcash Chains
   description:
     Join the initiative to enhance utility for Filecoin and Zcash chains.
     Learn how you can contribute.

--- a/src/content/blog/how-artifact-labs-is-preserving-and-connecting-history-and-culture-using-the-blockchain.md
+++ b/src/content/blog/how-artifact-labs-is-preserving-and-connecting-history-and-culture-using-the-blockchain.md
@@ -16,7 +16,6 @@ image:
   src: /assets/images/070723-qa-artifactlabs.png
 category: use-cases
 seo:
-  title: How Artifact Labs Uses Blockchain to Preserve History
   description:
     Discover how Artifact Labs preserves and connects history and culture
     using blockchain technology.

--- a/src/content/blog/how-basic-beasts-uses-the-filecoin-network-to-design-the-next-generation-of-decentralized-gaming.md
+++ b/src/content/blog/how-basic-beasts-uses-the-filecoin-network-to-design-the-next-generation-of-decentralized-gaming.md
@@ -17,7 +17,6 @@ image:
   src: /assets/images/0517-dgs-_.png
 category: use-cases
 seo:
-  title: How Basic Beasts Uses Filecoin for Decentralized Gaming
   description:
     Learn how Basic Beasts leverages the Filecoin network to design the
     next generation of decentralized gaming.

--- a/src/content/blog/how-decentralized-ai-and-data-storage-is-building-trust-in-ai.md
+++ b/src/content/blog/how-decentralized-ai-and-data-storage-is-building-trust-in-ai.md
@@ -9,8 +9,6 @@ description: The world of AI is rapidly growing. For AI models, data is fuel.
 image:
   src: /assets/images/08192024-decentralized-ai.webp
 seo:
-  title: "Decentralized AI: Filecoin's Role in Transforming AI Data Storage and
-    Integrity"
   description: Explore how Filecoin leverages decentralized storage to enhance
     AI's security, transparency, and scalability, preventing centralization
     risks and promoting a future where AI benefits everyone.

--- a/src/content/blog/how-swash-is-leveraging-filecoin-s-decentralized-storage-network-to-preserve-and-protect-consumer-data.md
+++ b/src/content/blog/how-swash-is-leveraging-filecoin-s-decentralized-storage-network-to-preserve-and-protect-consumer-data.md
@@ -13,7 +13,6 @@ image:
   src: /assets/images/64423af3e3c08f488e4f519c_1-pyb3swiscnbniykvqyrrdq.png
 category: use-cases
 seo:
-  title: How Swash Uses Filecoin to Protect Consumer Data
   description:
     Explore how Swash leverages Filecoin's decentralized storage network
     to preserve and protect consumer data.

--- a/src/content/blog/insights-from-dweb-decoded-jenks-guo-on-decentralization-and-developer-relations.md
+++ b/src/content/blog/insights-from-dweb-decoded-jenks-guo-on-decentralization-and-developer-relations.md
@@ -12,7 +12,6 @@ description:
 image:
   src: /assets/images/jenks-guo.png
 seo:
-  title: "Insights from DWeb Decoded: Jenks Guo on Decentralization"
   description:
     Jenks Guo discusses decentralization and developer relations in this
     insightful DWeb Decoded session.

--- a/src/content/blog/insights-into-responsible-ai-with-the-founder-of-ai-guardian-1.md
+++ b/src/content/blog/insights-into-responsible-ai-with-the-founder-of-ai-guardian-1.md
@@ -16,7 +16,6 @@ description: >-
 image:
   src: /assets/images/chris-hackney.png
 seo:
-  title: Insights into Responsible AI with AI Guardian Founder
   description:
     AI Guardian founder shares insights into responsible AI development
     and deployment.

--- a/src/content/blog/introducing-co-rise-course-building-web3-applications-and-filecoin-ipfs.md
+++ b/src/content/blog/introducing-co-rise-course-building-web3-applications-and-filecoin-ipfs.md
@@ -11,7 +11,6 @@ image:
   src: /assets/images/64423af4e3c08f6f124f519f_1-gvlzuxsp3dbmsdxwobsexq.png
 category: news
 seo:
-  title: "Introducing Co-Rise Course: Building Web3 Applications"
   description:
     Learn to build Web3 applications with Filecoin and IPFS in the new
     Co-Rise course. Enroll now!

--- a/src/content/blog/introducing-the-filecoin-storage-provider-incubation-center.md
+++ b/src/content/blog/introducing-the-filecoin-storage-provider-incubation-center.md
@@ -10,7 +10,6 @@ image:
   src: /assets/images/image-c-21.png
 category: news
 seo:
-  title: Introducing the Filecoin Storage Provider Incubation Center
   description:
     Filecoin Foundation launches the Storage Provider Incubation Center
     to support new providers.

--- a/src/content/blog/introducing-the-future-rules-a-new-podcast-series-from-the-filecoin-foundation-and-forkast-news.md
+++ b/src/content/blog/introducing-the-future-rules-a-new-podcast-series-from-the-filecoin-foundation-and-forkast-news.md
@@ -13,7 +13,6 @@ image:
   src: /assets/images/image-c-33.png
 category: news
 seo:
-  title: Introducing 'The Future Rules' Podcast by Filecoin Foundation
   description:
     Check out 'The Future Rules', a new podcast series by Filecoin Foundation
     and Forkast News.

--- a/src/content/blog/introducing-the-orbit-community-program.md
+++ b/src/content/blog/introducing-the-orbit-community-program.md
@@ -10,7 +10,6 @@ image:
   src: /assets/images/0114-orbitcommunity-twitter.png
 category: news
 seo:
-  title: Introducing the Orbit Community Program
   description:
     Join the new Orbit Community Program by Filecoin Foundation to connect
     and collaborate with peers.

--- a/src/content/blog/introducing-the-storage-provider-bounty-board.md
+++ b/src/content/blog/introducing-the-storage-provider-bounty-board.md
@@ -11,7 +11,6 @@ image:
   src: /assets/images/image-c-08.png
 category: news
 seo:
-  title: Introducing the Storage Provider Bounty Board
   description:
     Filecoin Foundation launches the Storage Provider Bounty Board. Learn
     how to participate and earn rewards.

--- a/src/content/blog/introducing-the-wave-7-developer-grant-recipients.md
+++ b/src/content/blog/introducing-the-wave-7-developer-grant-recipients.md
@@ -11,7 +11,6 @@ image:
   src: /assets/images/image-c-32.png
 category: news
 seo:
-  title: Introducing the Wave 7 Developer Grant Recipients
   description:
     Meet the recipients of Filecoin Foundation's Wave 7 developer grants.
     Discover their innovative projects.

--- a/src/content/blog/join-20-fascinating-startups-on-september-28-for-filecoin-launchpad-accelerator-demo-day.md
+++ b/src/content/blog/join-20-fascinating-startups-on-september-28-for-filecoin-launchpad-accelerator-demo-day.md
@@ -12,7 +12,6 @@ image:
   src: /assets/images/64423afe4e4c68b60af47060_0-8alsa5xsesgbjyrr.png
 category: events
 seo:
-  title: Join Filecoin Launchpad Accelerator Demo Day on September 28
   description:
     Join us on September 28 for the Filecoin Launchpad Accelerator Demo
     Day and meet 20 fascinating startups.

--- a/src/content/blog/join-the-filecoin-foundation-team-for-a-hiring-webinar.md
+++ b/src/content/blog/join-the-filecoin-foundation-team-for-a-hiring-webinar.md
@@ -10,7 +10,6 @@ image:
   src: /assets/images/64423b004e4c68dc35f473ac_0-zlsuhdrlo5hqa1zy.png
 category: news
 seo:
-  title: Join the Filecoin Foundation Team for a Hiring Webinar
   description:
     Learn about career opportunities at Filecoin Foundation. Join our hiring
     webinar to get started.

--- a/src/content/blog/join-us-as-we-build-a-better-web.md
+++ b/src/content/blog/join-us-as-we-build-a-better-web.md
@@ -11,7 +11,6 @@ image:
   src: /assets/images/64423b02e3c08f20a74f51df_1-l9a-l_g2zxiuk3zdsi5lwq-1-.png
 category: ecosystem
 seo:
-  title: Join Us as We Build a Better Web
   description:
     Collaborate with us at Filecoin Foundation to build a better, decentralized
     web. Get involved today.

--- a/src/content/blog/join-us-in-celebrating-filecoin-mainnet-s-one-year-milestone.md
+++ b/src/content/blog/join-us-in-celebrating-filecoin-mainnet-s-one-year-milestone.md
@@ -10,7 +10,6 @@ created-on: "2023-04-21T07:28:04.262Z"
 published-on: "2023-04-21T07:33:56.200Z"
 category: events
 seo:
-  title: Celebrate Filecoin Mainnet's One-Year Milestone with Us
   description:
     Join us in celebrating the one-year milestone of Filecoin mainnet.
     Reflect on achievements and future goals.

--- a/src/content/blog/leading-ai-projects-choose-filecoin-to-advance-ai-marking-the-networks-leading-role-as-depin-backbone-for-ai.md
+++ b/src/content/blog/leading-ai-projects-choose-filecoin-to-advance-ai-marking-the-networks-leading-role-as-depin-backbone-for-ai.md
@@ -10,8 +10,6 @@ description: "Network announcements include collaborations with SingularityNET,
 image:
   src: /assets/images/120624-brussels.jpg
 seo:
-  title: "Leading AI Projects Collaborate with Filecoin Foundation to Drive AI
-    Innovation"
   description: Filecoin Foundation collaborates with SingularityNET, Theoriq,
     Bagel, Nuklai, and more to enhance AI with decentralized storage and secure
     data solutions.

--- a/src/content/blog/linkstorage-awarded-chainlink-filecoin-joint-grant-to-create-blockchain-data-storage-protocol.md
+++ b/src/content/blog/linkstorage-awarded-chainlink-filecoin-joint-grant-to-create-blockchain-data-storage-protocol.md
@@ -14,7 +14,6 @@ image:
   src: /assets/images/64423b050425d3f577f2eb36_1-qzfjf0m6l6_fzcxuic-8zg.png
 category: news
 seo:
-  title: LinkStorage Awarded Chainlink-Filecoin Joint Grant
   description:
     LinkStorage receives Chainlink-Filecoin joint grant to develop a blockchain
     data storage protocol.

--- a/src/content/blog/look-back-and-look-forward-filecoin-foundation-in-2021-and-2022.md
+++ b/src/content/blog/look-back-and-look-forward-filecoin-foundation-in-2021-and-2022.md
@@ -10,7 +10,6 @@ created-on: "2023-04-21T07:28:07.363Z"
 published-on: "2023-04-21T07:33:56.200Z"
 category: reports
 seo:
-  title: "Looking Back and Forward: Filecoin Foundation in 2021 and 2022"
   description:
     A retrospective and future outlook for Filecoin Foundation's activities
     in 2021 and 2022.

--- a/src/content/blog/marta-belcher-talks-crypto-privacy-or-lack-thereof-at-consensus-2021.md
+++ b/src/content/blog/marta-belcher-talks-crypto-privacy-or-lack-thereof-at-consensus-2021.md
@@ -10,7 +10,6 @@ image:
   src: /assets/images/64423b080425d3dc88f2efd0_0-ujllypeozzx_ebfb.png
 category: events
 seo:
-  title: Marta Belcher Discusses Crypto Privacy at Consensus 2021
   description:
     Marta Belcher talks about crypto privacy and its challenges at Consensus
     2021.

--- a/src/content/blog/meet-filecoin-foundation-developer-advocate-sonia-john.md
+++ b/src/content/blog/meet-filecoin-foundation-developer-advocate-sonia-john.md
@@ -10,7 +10,6 @@ image:
   src: /assets/images/64423b0ae3c08f37be4f5200_1-ollwmtygvgvih2kjh6jffq.png
 category: interviews
 seo:
-  title: Meet Filecoin Foundation Developer Advocate Sonia John
   description:
     Get to know Sonia John, developer advocate at Filecoin Foundation.
     Learn about her role and contributions.

--- a/src/content/blog/meet-filecoin-foundation-senior-fellow-danny-o-brien.md
+++ b/src/content/blog/meet-filecoin-foundation-senior-fellow-danny-o-brien.md
@@ -10,7 +10,6 @@ created-on: "2023-04-21T07:28:12.620Z"
 published-on: "2023-04-21T07:33:56.200Z"
 category: interviews
 seo:
-  title: Meet Filecoin Foundation Senior Fellow Danny O'Brien
   description:
     Introducing Danny O'Brien, senior fellow at Filecoin Foundation. Learn
     about his work and insights.

--- a/src/content/blog/meet-orbit-community-program-ambassadors.md
+++ b/src/content/blog/meet-orbit-community-program-ambassadors.md
@@ -12,7 +12,6 @@ image:
   src: /assets/images/0713-orbitcommunity.png
 category: ecosystem
 seo:
-  title: Meet Orbit Community Program Ambassadors
   description:
     Get to know the ambassadors of the Orbit Community Program. Learn about
     their roles and contributions.

--- a/src/content/blog/meet-the-filecoin-foundation-and-the-filecoin-foundation-for-the-decentralized-web.md
+++ b/src/content/blog/meet-the-filecoin-foundation-and-the-filecoin-foundation-for-the-decentralized-web.md
@@ -13,7 +13,6 @@ image:
   src: /assets/images/64423b0f4e4c686c88f481d6_1-mg36oqbqdetgd3sn8-bgsq.png
 category: ecosystem
 seo:
-  title: Meet the Filecoin Foundations
   description:
     Meet the teams behind the Filecoin Foundation and the Filecoin Foundation
     for the Decentralized Web.

--- a/src/content/blog/meet-the-new-programs-making-it-easier-to-contribute-to-the-filecoin-network.md
+++ b/src/content/blog/meet-the-new-programs-making-it-easier-to-contribute-to-the-filecoin-network.md
@@ -10,7 +10,6 @@ image:
   src: /assets/images/12202022-saturnandstation.png
 category: ecosystem
 seo:
-  title: New Programs to Contribute to the Filecoin Network
   description:
     Discover the new programs designed to make it easier to contribute
     to the Filecoin network.

--- a/src/content/blog/meet-the-newest-members-of-the-filecoin-foundation-team.md
+++ b/src/content/blog/meet-the-newest-members-of-the-filecoin-foundation-team.md
@@ -11,7 +11,6 @@ image:
   src: /assets/images/image-c-29.png
 category: news
 seo:
-  title: Meet the Newest Members of the Filecoin Foundation Team
   description:
     Introducing the newest members of the Filecoin Foundation team. Learn
     about their roles and backgrounds.

--- a/src/content/blog/new-agreement-between-filecoin-foundation-and-electric-coin-co-simplifies-halo-licensing-and-creates-grant-pool-for-filecoin-zcash-projects.md
+++ b/src/content/blog/new-agreement-between-filecoin-foundation-and-electric-coin-co-simplifies-halo-licensing-and-creates-grant-pool-for-filecoin-zcash-projects.md
@@ -10,7 +10,6 @@ created-on: "2023-04-21T07:31:35.155Z"
 published-on: "2023-04-21T07:33:56.200Z"
 category: news
 seo:
-  title: Filecoin and Electric Coin Co. Simplify Halo Licensing, Create Joint Grants Pool
   description: Filecoin Foundation and Electric Coin Co. simplify Halo licensing and establish a $5 million joint grants pool for Filecoin and Zcash projects.
 ---
 

--- a/src/content/blog/new-survey-american-consumers-are-ready-to-change-up-to-web3.md
+++ b/src/content/blog/new-survey-american-consumers-are-ready-to-change-up-to-web3.md
@@ -11,7 +11,6 @@ image:
   src: /assets/images/643e66ba7403cdfbea565a6e_1-57prfcg89azmw_kf5bqvjw.webp
 category: reports
 seo:
-  title: "New Survey: American Consumers Ready to Embrace Web3"
   description:
     A new survey reveals that American consumers are ready to embrace Web3.
     Explore the findings.

--- a/src/content/blog/new-wave-9-developer-grant-recipients.md
+++ b/src/content/blog/new-wave-9-developer-grant-recipients.md
@@ -11,7 +11,6 @@ image:
   src: /assets/images/image-c-17.png
 category: news
 seo:
-  title: Announcing the New Wave 9 Developer Grant Recipients
   description:
     Meet the new recipients of the Filecoin Wave 9 developer grants. Discover
     their innovative projects.

--- a/src/content/blog/one-year-of-programmability-smart-contracts-and-dapp-growth-on-filecoin.md
+++ b/src/content/blog/one-year-of-programmability-smart-contracts-and-dapp-growth-on-filecoin.md
@@ -4,16 +4,12 @@ created-on: 2024-03-14T13:04:08.972000Z
 updated-on: 2024-03-14T13:04:09.018000Z
 published-on: 2024-03-14T13:04:09.031000Z
 category: ecosystem
-description:
-  One year ago on March 14, 2023, the launch of the Filecoin Virtual Machine
-  (FVM) brought onchain programmability and smart contracts live on Filecoin mainnet.
+description: "One year ago on March 14, 2023, the launch of the Filecoin Virtual Machine (FVM) brought onchain programmability and smart contracts live on Filecoin mainnet."
 image:
   src: /assets/images/031224-fvm-anniversary.png
 seo:
-  title: "One Year of Programmability: Smart Contracts and DApp Growth on Filecoin"
-  description:
-    Celebrating one year of programmability on Filecoin. Explore the growth
-    of smart contracts and DApps.
+  description: "Celebrating one year of programmability on Filecoin. Explore the growth
+  of smart contracts and DApps."
 ---
 
 One year ago at 3:14 PM UTC on March 14, 2023 (epoch 2,683,348), the launch of the [Filecoin Virtual Machine](https://fvm.filecoin.io/) (FVM) brought onchain programmability and smart contracts to Filecoin Mainnet. Dapps can tap into storage primitives on Filecoin with valuable workflows including perpetual storage, data access control, compute-over-data, Data DAOs, and more. These capabilities solidify Filecoin’s position as the Layer-1 blockchain uniquely positioned to power an open data economy.

--- a/src/content/blog/orbit-fvm-open-hack-days.md
+++ b/src/content/blog/orbit-fvm-open-hack-days.md
@@ -13,7 +13,6 @@ image:
   src: /assets/images/0208-orbitfvm.png
 category: events
 seo:
-  title: Join the Orbit FVM Open Hack Days
   description:
     Participate in the Orbit FVM Open Hack Days. Collaborate, innovate,
     and build with the Filecoin community.

--- a/src/content/blog/orbit-year-in-review-growing-a-global-community-of-builders.md
+++ b/src/content/blog/orbit-year-in-review-growing-a-global-community-of-builders.md
@@ -10,7 +10,6 @@ description:
 image:
   src: /assets/images/231205-orbit-year.png
 seo:
-  title: "Orbit Year in Review: Growing a Global Community of Builders"
   description:
     A review of the Orbit program's achievements in growing a global community
     of builders. Key highlights.

--- a/src/content/blog/orbiting-ethdenver-perspectives-from-a-filecoin-orbit-ambassador.md
+++ b/src/content/blog/orbiting-ethdenver-perspectives-from-a-filecoin-orbit-ambassador.md
@@ -11,7 +11,6 @@ description:
 image:
   src: /assets/images/032224-orbit-austin.png
 seo:
-  title: "Orbiting ETHDenver: Insights from a Filecoin Orbit Ambassador"
   description:
     Insights and perspectives from a Filecoin Orbit Ambassador at ETHDenver.
     Explore the experiences.

--- a/src/content/blog/participate-in-the-filecoin-network-s-poll-on-extending-the-maximum-lifetime-of-v1-sectors.md
+++ b/src/content/blog/participate-in-the-filecoin-network-s-poll-on-extending-the-maximum-lifetime-of-v1-sectors.md
@@ -13,7 +13,6 @@ image:
   src: /assets/images/64423bdeb13e032a58960cfb_1-xicc70v_m64rcu1wlbq6qq.png
 category: ecosystem
 seo:
-  title: Participate in Filecoin's Poll on Extending V1 Sector Lifetime
   description:
     Weigh in on extending the maximum lifetime of V1 sectors in the Filecoin
     network. Your input matters.

--- a/src/content/blog/participating-in-the-filecoin-ecosystem-bounties-microgrants-and-fips.md
+++ b/src/content/blog/participating-in-the-filecoin-ecosystem-bounties-microgrants-and-fips.md
@@ -10,7 +10,6 @@ image:
   src: /assets/images/image-c-20.png
 category: ecosystem
 seo:
-  title: "Get Involved in the Filecoin Ecosystem: Bounties, Microgrants, and FIPs"
   description:
     Learn how to participate in the Filecoin ecosystem through bounties,
     microgrants, and FIPs.

--- a/src/content/blog/recapping-ethdenver-ipc-announcement-exploring-depin-and-connecting-with-the-community.md
+++ b/src/content/blog/recapping-ethdenver-ipc-announcement-exploring-depin-and-connecting-with-the-community.md
@@ -13,7 +13,6 @@ description:
 image:
   src: /assets/images/ethdenver.png
 seo:
-  title: "Recapping ETHDenver: IPC Announcement, DePIN, and Community Connections"
   description:
     Highlights from ETHDenver, including the IPC announcement, DePIN exploration,
     and community connections.

--- a/src/content/blog/recapping-filecoin-foundation-at-davos-ipfs-deployed-in-space-exploring-the-future-of-ai-and-web3-future-proofing-regulation-and-more.md
+++ b/src/content/blog/recapping-filecoin-foundation-at-davos-ipfs-deployed-in-space-exploring-the-future-of-ai-and-web3-future-proofing-regulation-and-more.md
@@ -11,7 +11,6 @@ description: The Filecoin Sanctuary in Davos brought together the world’s
 image:
   src: /assets/images/020724-davos.png
 seo:
-  title: "Filecoin Foundation at Davos: Key Highlights and Future Prospects"
   description: Recap of Filecoin Foundation at Davos. Highlights include IPFS in
     space, AI and Web3 future, and more.
 ---

--- a/src/content/blog/recapping-filecoin-foundation-s-2021-governance-summit.md
+++ b/src/content/blog/recapping-filecoin-foundation-s-2021-governance-summit.md
@@ -11,7 +11,6 @@ image:
   src: /assets/images/image-c-18.png
 category: events
 seo:
-  title: Recap of Filecoin Foundation's 2021 Governance Summit
   description:
     A comprehensive recap of the Filecoin Foundation's 2021 Governance
     Summit. Key discussions and outcomes.

--- a/src/content/blog/recognizing-the-recipients-of-the-explorer-awards.md
+++ b/src/content/blog/recognizing-the-recipients-of-the-explorer-awards.md
@@ -11,7 +11,6 @@ image:
   src: /assets/images/645244ea3a4dd637ee3c0347_0609-ffxunfinished.jpg
 category: news
 seo:
-  title: Recognizing the Recipients of the Explorer Awards
   description:
     Celebrate the recipients of the Explorer Awards. Recognizing innovation
     and excellence in decentralized tech.

--- a/src/content/blog/remixing-the-art-world-with-blockchain-technology-a-q-a-with-ntent.md
+++ b/src/content/blog/remixing-the-art-world-with-blockchain-technology-a-q-a-with-ntent.md
@@ -11,7 +11,6 @@ image:
   src: /assets/images/06012023-ntent.png
 category: interviews
 seo:
-  title: "Remixing the Art World with Blockchain: A Q&A with Ntent"
   description:
     A Q&A with Ntent on how blockchain technology is remixing the art world.
     Explore their insights.

--- a/src/content/blog/second-round-of-filecoin-plus-notaries-elected-5-pib-more-datacap-awarded.md
+++ b/src/content/blog/second-round-of-filecoin-plus-notaries-elected-5-pib-more-datacap-awarded.md
@@ -10,7 +10,6 @@ image:
   src: /assets/images/image-c-34.png
 category: news
 seo:
-  title: Second Round of Filecoin Plus Notaries Elected
   description:
     Announcing the second round of Filecoin Plus notaries. Over 5 PiB of
     Datacap awarded. Learn more.

--- a/src/content/blog/social-media-on-the-decentralized-web.md
+++ b/src/content/blog/social-media-on-the-decentralized-web.md
@@ -11,7 +11,6 @@ image:
   src: /assets/images/64423be63db3a0a2416bac69_1-vcqlzywn6ec6brxs8lmzng.webp
 category: use-cases
 seo:
-  title: Social Media on the Decentralized Web
   description:
     Explore how social media operates on the decentralized web. Benefits,
     challenges, and future prospects.

--- a/src/content/blog/spotlight-new-filecoin-virtual-machine-projects-unlocking-smart-contract-programmability-1.md
+++ b/src/content/blog/spotlight-new-filecoin-virtual-machine-projects-unlocking-smart-contract-programmability-1.md
@@ -13,7 +13,6 @@ image:
   src: /assets/images/rectangle-32-.png
 category: news
 seo:
-  title: "Spotlight: New Filecoin Virtual Machine Projects"
   description:
     Highlighting new projects on the Filecoin Virtual Machine. Unlocking
     smart contract programmability.

--- a/src/content/blog/spotlight-seal-storage.md
+++ b/src/content/blog/spotlight-seal-storage.md
@@ -15,7 +15,6 @@ seo:
   description: Discover how Seal Storage, a Filecoin ecosystem pioneer, partners
     with CERN, IEEE, and others to provide scalable, decentralized cloud storage
     for research institutions worldwide.
-  title: "Spotlight: Seal Storage"
 ---
 
 ## Bridging Filecoin with Scientific and Academic Research: Seal’s Role in the Ecosystem

--- a/src/content/blog/storage-company-ewesion-leverages-filecoin-network-for-data-preservation-1.md
+++ b/src/content/blog/storage-company-ewesion-leverages-filecoin-network-for-data-preservation-1.md
@@ -11,7 +11,6 @@ image:
   src: /assets/images/643e66c80a81033d920c68ba_1-b1odemnhfczn_24q2linww.webp
 category: use-cases
 seo:
-  title: Storage Company Ewesion Leverages Filecoin for Data Preservation
   description:
     How Ewesion leverages the Filecoin network for data preservation. Discover
     their use case.

--- a/src/content/blog/storage-company-ewesion-leverages-filecoin-network-for-data-preservation.md
+++ b/src/content/blog/storage-company-ewesion-leverages-filecoin-network-for-data-preservation.md
@@ -11,7 +11,6 @@ image:
   src: /assets/images/643e66c80a810364460c68bb_1-b1odemnhfczn_24q2linww.png
 category: use-cases
 seo:
-  title: Storage Company Ewesion Uses Filecoin for Data Preservation
   description:
     Ewesion utilizes the Filecoin network for preserving data. Learn more
     about their approach.

--- a/src/content/blog/storage-spotlight-how-twin-quasar-and-celeste-are-bringing-green-data-hosting-to-european-data-storage-clients.md
+++ b/src/content/blog/storage-spotlight-how-twin-quasar-and-celeste-are-bringing-green-data-hosting-to-european-data-storage-clients.md
@@ -12,7 +12,6 @@ image:
   src: /assets/images/twin-quasar-celeste-filecoin-blog-image.png
 category: use-cases
 seo:
-  title: "Storage Spotlight: Green Data Hosting with Twin Quasar and Celeste"
   description:
     Twin Quasar and Celeste bring green data hosting to European clients.
     Explore their sustainable approach.

--- a/src/content/blog/storing-ai-datasets-on-the-decentralized-web.md
+++ b/src/content/blog/storing-ai-datasets-on-the-decentralized-web.md
@@ -13,7 +13,6 @@ image:
   src: /assets/images/643e66c9def161164793d8aa_0-ykastlsfwq52kr4r.png
 category: use-cases
 seo:
-  title: Storing AI Datasets on the Decentralized Web
   description:
     Learn how AI datasets are stored on the decentralized web using Filecoin.
     Benefits and challenges.

--- a/src/content/blog/supporting-the-community-the-filecoin-storage-provider-group.md
+++ b/src/content/blog/supporting-the-community-the-filecoin-storage-provider-group.md
@@ -11,7 +11,6 @@ image:
   src: /assets/images/image-c-04.png
 category: ecosystem
 seo:
-  title: "Supporting the Community: The Filecoin Storage Provider Group"
   description:
     Discover how the Filecoin Storage Provider Group supports the community.
     Learn about their initiatives.

--- a/src/content/blog/surveying-the-filecoin-community-priorities-and-opportunities-for-2022.md
+++ b/src/content/blog/surveying-the-filecoin-community-priorities-and-opportunities-for-2022.md
@@ -10,7 +10,6 @@ image:
   src: /assets/images/643e66cbb75bbf237f8e1292_1-1dqtfatumnkf7vdkmw1rhq.png
 category: reports
 seo:
-  title: "Surveying the Filecoin Community: 2022 Priorities and Opportunities"
   description:
     An overview of the Filecoin community's priorities and opportunities
     for 2022. Key insights.

--- a/src/content/blog/takeaways-from-the-filecoin-community-at-consensus-2024.md
+++ b/src/content/blog/takeaways-from-the-filecoin-community-at-consensus-2024.md
@@ -8,7 +8,6 @@ image:
   src: /assets/images/060624-consensus.png
 category: events
 seo:
-  title: "Filecoin Community Highlights from Consensus 2024"
   description: "Discover key highlights and innovations presented by the Filecoin community at Consensus 2024 in Austin."
 ---
 

--- a/src/content/blog/thanks-for-participating-in-fip-0014.md
+++ b/src/content/blog/thanks-for-participating-in-fip-0014.md
@@ -10,7 +10,6 @@ image:
   src: /assets/images/64423bf6ba1528b0814f3496_0-w3wa_u-ynigzoedy.png
 category: news
 seo:
-  title: Thank You for Participating in FIP-0014
   description:
     A thank you note to the community for participating in FIP-0014. Your
     contributions are valued.

--- a/src/content/blog/the-filecoin-foundation-announces-50-000-fil-grant-to-the-internet-archive.md
+++ b/src/content/blog/the-filecoin-foundation-announces-50-000-fil-grant-to-the-internet-archive.md
@@ -11,7 +11,6 @@ image:
   src: /assets/images/64423bf8da735f52ab392c9a_0-gxap0iqlhpvsxnst.png
 category: news
 seo:
-  title: Filecoin Foundation Announces $50,000 FIL Grant to Internet Archive
   description:
     The Filecoin Foundation awards a $50,000 FIL grant to the Internet
     Archive. Learn about the initiative.

--- a/src/content/blog/the-filecoin-virtual-machine-has-arrived.md
+++ b/src/content/blog/the-filecoin-virtual-machine-has-arrived.md
@@ -12,7 +12,6 @@ image:
   src: /assets/images/64423bf9da735f547c392f21_unnamed-14.png
 category: news
 seo:
-  title: The Filecoin Virtual Machine Has Arrived
   description:
     Announcing the arrival of the Filecoin Virtual Machine. Explore its
     features and capabilities.

--- a/src/content/blog/the-foundations-roles-in-the-filecoin-ecosystem.md
+++ b/src/content/blog/the-foundations-roles-in-the-filecoin-ecosystem.md
@@ -10,7 +10,6 @@ image:
   src: /assets/images/64423bfbca39dd7d4d1f170f_1-mbcuqyncw-uoyzwsbrapqw.png
 category: ecosystem
 seo:
-  title: The Foundation's Roles in the Filecoin Ecosystem
   description:
     Learn about the roles and responsibilities of the foundation within
     the Filecoin ecosystem.

--- a/src/content/blog/the-growth-of-filecoin-plus-and-upcoming-notary-elections.md
+++ b/src/content/blog/the-growth-of-filecoin-plus-and-upcoming-notary-elections.md
@@ -12,7 +12,6 @@ image:
   src: /assets/images/64524524a1a3e64e1d97de7f_0202-filpluselection.jpg
 category: news
 seo:
-  title: The Growth of Filecoin Plus and Upcoming Notary Elections
   description:
     Explore the growth of Filecoin Plus and get ready for the upcoming
     notary elections.

--- a/src/content/blog/the-web-isn-t-forever-new-research-findings-from-not-your-parents-web-project.md
+++ b/src/content/blog/the-web-isn-t-forever-new-research-findings-from-not-your-parents-web-project.md
@@ -15,8 +15,6 @@ seo:
     card: summary
   description: The "Not Your Parents' Web" project reveals the fragile lifespan
     of online content.
-  title: "The Web Isn’t Forever: New Research Findings from “Not Your Parents'
-    Web” Project"
 ---
 
 Today, we’re excited to share the release of findings from the "Not Your Parents' Web" project –– an extensive study that explores the lifespan of millions of web pages across the last 26 years. The collaborative project from Internet Archive, Old Dominion University’s Web Science & Digital Libraries Research Group, and Filecoin Foundation (FF) analyzed data from the Wayback Machine to reveal key insights into the lifespan of URLs and the ephemeral nature of the web.

--- a/src/content/blog/unleashing-the-power-of-decentralized-compute-with-filecoin.md
+++ b/src/content/blog/unleashing-the-power-of-decentralized-compute-with-filecoin.md
@@ -13,7 +13,6 @@ description:
 image:
   src: /assets/images/decentralized-compute-v2.png
 seo:
-  title: Unleashing the Power of Decentralized Compute with Filecoin
   description:
     Discover how Filecoin unleashes the power of decentralized compute.
     Key benefits and use cases.

--- a/src/content/blog/unveiling-the-filecoin-ecosystem-explorer.md
+++ b/src/content/blog/unveiling-the-filecoin-ecosystem-explorer.md
@@ -10,7 +10,6 @@ description:
 image:
   src: /assets/images/240109-ecosystemexplorerlaunch_blogheader.png
 seo:
-  title: Unveiling the Filecoin Ecosystem Explorer
   description:
     Introducing the Filecoin Ecosystem Explorer. Navigate and discover
     the Filecoin ecosystem easily.

--- a/src/content/blog/venus-v1-0-0-passes-least-authority-security-audit.md
+++ b/src/content/blog/venus-v1-0-0-passes-least-authority-security-audit.md
@@ -11,7 +11,6 @@ image:
   src: /assets/images/image-c-28.png
 category: news
 seo:
-  title: Venus v1.0.0 Passes Least Authority Security Audit
   description:
     Announcing that Venus v1.0.0 has passed the Least Authority security
     audit. Learn more about the results.

--- a/src/content/blog/wave-11-dev-grant-recipients.md
+++ b/src/content/blog/wave-11-dev-grant-recipients.md
@@ -11,7 +11,6 @@ image:
   src: /assets/images/image-c-17.png
 category: news
 seo:
-  title: Announcing the Wave 11 Dev Grant Recipients
   description:
     Meet the new recipients of the Filecoin Wave 11 developer grants. Discover
     their innovative projects.

--- a/src/content/blog/welcome-to-the-forest-with-chainsafe-s-filecoin.md
+++ b/src/content/blog/welcome-to-the-forest-with-chainsafe-s-filecoin.md
@@ -10,7 +10,6 @@ image:
   src: /assets/images/image-c-19.png
 category: ecosystem
 seo:
-  title: Welcome to the Forest with ChainSafe's Filecoin
   description:
     Explore ChainSafe's Filecoin project, 'Welcome to the Forest.' Learn
     about its features and benefits.

--- a/src/content/blog/what-to-know-about-the-future-of-digital-public-infrastructure-in-five-minutes.md
+++ b/src/content/blog/what-to-know-about-the-future-of-digital-public-infrastructure-in-five-minutes.md
@@ -11,7 +11,6 @@ image:
   src: /assets/images/0928-filecoinfortnight.png
 category: ecosystem
 seo:
-  title: The Future of Digital Public Infrastructure in Five Minutes
   description:
     Learn about the future of digital public infrastructure in this quick,
     five-minute read.

--- a/src/content/blog/what-to-know-about-the-uses-of-decentralization-in-online-community-governance-in-five-minutes.md
+++ b/src/content/blog/what-to-know-about-the-uses-of-decentralization-in-online-community-governance-in-five-minutes.md
@@ -16,7 +16,6 @@ image:
   src: /assets/images/n-schneider-blogpost-banner.png
 category: ecosystem
 seo:
-  title: Decentralization in Online Community Governance in Five Minutes
   description:
     Understand the uses of decentralization in online community governance
     in this brief overview.

--- a/src/content/blog/whats-new-with-the-filecoin-plus-notary-election-and-filecoin-day-highlights-from-labweek23.md
+++ b/src/content/blog/whats-new-with-the-filecoin-plus-notary-election-and-filecoin-day-highlights-from-labweek23.md
@@ -14,7 +14,6 @@ category: news
 image:
   src: /assets/images/231120-fd-fpd.png
 seo:
-  title: Highlights from Filecoin Plus Notary Election and Filecoin Day at LabWeek23
   description: Discover the latest updates from Filecoin Plus Notary Election and Filecoin Day at LabWeek23, including AI and decentralized storage discussions.
 ---
 

--- a/src/content/blog/xinshu-technology-how-the-chinese-shutterfly-uses-the-filecoin-network-to-keep-a-competitive-edge-in-the-photo-sharing-industry.md
+++ b/src/content/blog/xinshu-technology-how-the-chinese-shutterfly-uses-the-filecoin-network-to-keep-a-competitive-edge-in-the-photo-sharing-industry.md
@@ -13,7 +13,6 @@ image:
   src: /assets/images/643e66da3820f63a69cf3f15_1-mspvlfvj4hi7yykisqwcfg.png
 category: use-cases
 seo:
-  title: "Xinshu Technology: How the Chinese Shutterfly Uses Filecoin"
   description:
     Discover how Xinshu Technology uses the Filecoin network to stay competitive
     in the photo-sharing industry.

--- a/src/content/blog/you-re-invited-filecoin-fall.md
+++ b/src/content/blog/you-re-invited-filecoin-fall.md
@@ -12,7 +12,6 @@ image:
   src: /assets/images/64423c054821268e6e8e743b_1-rdpz1p6lnwm1fnnk37urdw.png
 category: events
 seo:
-  title: You're Invited to Filecoin Fall
   description:
     Join us for Filecoin Fall. Learn about upcoming events, activities,
     and opportunities to get involved.

--- a/src/content/digest/enterprise-storage-market-insights-from-the-field.md
+++ b/src/content/digest/enterprise-storage-market-insights-from-the-field.md
@@ -12,7 +12,6 @@ authors:
 image:
   src: /assets/images/enterprise-storage-market-insights-from-the-field.webp
 seo:
-  title: "Enterprise Storage Market Insights From the Field"
   description: "At DeStor, we are dedicated to revolutionizing decentralized storage solutions by seamlessly integrating them with enterprise applications. With over 50 years of combined experience in enterprise data storage, our..."
 ---
 

--- a/src/content/digest/from-participant-to-organizer-how-community-led-activities-drive-innovation-in-decentralized-systems.md
+++ b/src/content/digest/from-participant-to-organizer-how-community-led-activities-drive-innovation-in-decentralized-systems.md
@@ -13,8 +13,6 @@ authors:
 image:
   src: /assets/images/from-participant-to-organizer.webp
 seo:
-  title: "From Participant to Organizer: How Community-Led Activities Drive
-    Innovation in Decentralized Systems"
   description:
     Harnessing the Power of Decentralized Ecosystems — The strength of
     decentralized ecosystems lies in their broad participation and spirit of

--- a/src/content/digest/interplanetary-resilience.md
+++ b/src/content/digest/interplanetary-resilience.md
@@ -12,8 +12,6 @@ authors:
 image:
   src: /assets/images/interplanetary-resilience.webp
 seo:
-  title: "Interplanetary Resilience
-    Communication"
   description: "The vision of Filecoin is of verifiably robust storage of data scaling to meet the needs of humanity over centuries. In order to achieve this vision we need to _literally_ aim for the stars. We’re at a turning..."
 ---
 

--- a/src/content/digest/letter-from-the-guest-editor.md
+++ b/src/content/digest/letter-from-the-guest-editor.md
@@ -12,7 +12,6 @@ authors:
 image:
   src: /assets/images/letter-from-the-guest-editor.webp
 seo:
-  title: Letter from the Guest Editor
   description: "Dear Readers, Welcome to the inaugural edition of The Filecoin
     Ecosystem Digest: All Systems Go - a journey into the transformative power
     of the decentralized web and its far-reaching implications across

--- a/src/content/digest/storage-is-just-the-start-three-focus-areas-for-the-filecoin-network-in-2024.md
+++ b/src/content/digest/storage-is-just-the-start-three-focus-areas-for-the-filecoin-network-in-2024.md
@@ -12,9 +12,6 @@ authors:
 image:
   src: /assets/images/storage-is-just-the-start.webp
 seo:
-  title:
-    "Storage is Just the Start: Three Focus Areas for the Filecoin Network in
-    2024"
   description: Data storage and retrieval are core to how the Internet works.
     Today’s data infrastructure is dominated by Big Tech. But technologies like
     the InterPlanetary File System (IPFS) and Filecoin...

--- a/src/content/digest/the-future-of-data-lies-at-the-green-edge.md
+++ b/src/content/digest/the-future-of-data-lies-at-the-green-edge.md
@@ -12,7 +12,6 @@ authors:
 image:
   src: /assets/images/the-future-of-data-is-green-edge.webp
 seo:
-  title: "The Future of Data Lies at the Green Edge"
   description: "As we move into the era of digital autonomy, driven by machines and machine-generated data, we need to vastly improve the world’s capacity to manage and process data at a scale previously unimaginable. At Holon..."
 ---
 

--- a/src/content/digest/the-potential-for-decentralized-technology-to-rebuild-digital-trust.md
+++ b/src/content/digest/the-potential-for-decentralized-technology-to-rebuild-digital-trust.md
@@ -15,7 +15,6 @@ authors:
 image:
   src: /assets/images/the-potential-for-decentralized-technology-to-rebuild-media-trust-and-empower-content-creators.webp
 seo:
-  title: "Rebuilding Digital Trust: The Role of Decentralized Technology"
   description: "In April 2024, a 30-second video featuring Bollywood star Aamir Khan circulated widely across the Indian internet. Khan was seen criticizing Indian Prime Minister Narendra Modi for unfulfilled campaign promises..."
 ---
 

--- a/src/content/ecosystem-explorer/projects/3pad.md
+++ b/src/content/ecosystem-explorer/projects/3pad.md
@@ -19,9 +19,6 @@ tech:
 repo: https://github.com/3Pad
 year-joined: 2024-04-05T17:29:47.737Z
 seo:
-  title:
-    Transition to Web3 Effortlessly with 3Pad - Secure, Decentralized Landing
-    Pages
   description:
     Seamlessly engage your audience with 3Pad's decentralized platform.
     Experience web3 with secure IPFS hosting, passwordless NFT logins, and

--- a/src/content/ecosystem-explorer/projects/acaisia.md
+++ b/src/content/ecosystem-explorer/projects/acaisia.md
@@ -18,8 +18,6 @@ tech:
 repo: https://github.com/team-acaisia
 year-joined: 2023-09-01T18:56:33.186Z
 seo:
-  title: "Acaisia by Eliovp: Optimized Cloud Platform with Intelligent Workload
-    Distribution"
   description: Acaisia's platform optimizes your cloud with smart workload
     distribution and hardware autotuning. Reduce costs, minimize idle resources,
     and maximize ROI with power-efficient scheduling and Sealing As A Service.

--- a/src/content/ecosystem-explorer/projects/ahdx-aihealthdataxchain.md
+++ b/src/content/ecosystem-explorer/projects/ahdx-aihealthdataxchain.md
@@ -20,9 +20,6 @@ tech:
 twitter: https://twitter.com/aihdxc/
 year-joined: 2023-10-09T16:51:25.169Z
 seo:
-  title:
-    Blockchain-Based Data Storage & Decentralized Health Data Marketplace for
-    Secure Sharing
   description:
     Protect against data breaches with blockchain-based storage. AHDX's
     decentralized marketplace on Filecoin and IPFS enables secure health data

--- a/src/content/ecosystem-explorer/projects/akave.md
+++ b/src/content/ecosystem-explorer/projects/akave.md
@@ -18,7 +18,6 @@ tech:
   - ipfs
 twitter: https://x.com/akavenetwork
 seo:
-  title: Akave - The First L2 Storage Chain for Scalable, Decentralized AI Data Lakes
   description: Discover Akave, the pioneering L2 storage chain that enables
     scalable, decentralized AI with on-chain data lakes, revolutionizing data
     storage and accessibility in the AI ecosystem.

--- a/src/content/ecosystem-explorer/projects/algovera.md
+++ b/src/content/ecosystem-explorer/projects/algovera.md
@@ -19,7 +19,6 @@ tech:
 repo: https://github.com/AlgoveraAI
 twitter: https://twitter.com/algoveraai
 seo:
-  title: "Algovera: No-Code Platform for Building AI Apps & Data Science Tools"
   description:
     Build AI apps effortlessly with Algovera's no-code platform. Access
     an AI hub for data scientists, decentralized storage, and integrations with

--- a/src/content/ecosystem-explorer/projects/ankr.md
+++ b/src/content/ecosystem-explorer/projects/ankr.md
@@ -15,7 +15,6 @@ tech:
 twitter: https://twitter.com/ankr
 year-joined: 2024-03-29T21:28:48.751Z
 seo:
-  title: Ankr
   description: Ankr offers decentralized cloud computing and blockchain infrastructure.
 email: encrypted::U2FsdGVkX18K4Lsav7+8cvMqPjAXgx30b4YXLU8yNorkCATKRANgM/omt99+Ic4A
 full-name: encrypted::U2FsdGVkX19hG8+au1vZlMfou3BPcMh6qX6UJByr/b0=

--- a/src/content/ecosystem-explorer/projects/anytype.md
+++ b/src/content/ecosystem-explorer/projects/anytype.md
@@ -18,8 +18,6 @@ tech:
 twitter: https://twitter.com/AnytypeLabs
 year-joined: 2024-04-05T17:13:02.017Z
 seo:
-  title: "Anytype: Private Hub for Data with Privacy-First Architecture and IPFS
-    Storage"
   description:
     Protect your data with Anytype, a private hub for docs, tasks, and
     more. Create dashboards and knowledge graphs with privacy across devices

--- a/src/content/ecosystem-explorer/projects/archly.md
+++ b/src/content/ecosystem-explorer/projects/archly.md
@@ -20,7 +20,6 @@ twitter: https://twitter.com/archlyfinance/
 video-url: https://www.youtube.com/embed/8rt11F3qG1I
 year-joined: 2024-04-25T17:07:12.859Z
 seo:
-  title: "Archly: Seamless Cross-Chain Experiences with DEX & Rainbow Road"
   description: Archly enables seamless cross-chain experiences with its DEX and
     Rainbow Road platforms. Build liquidity, offer services across chains, and
     utilize Filecoin for storage, all in one ecosystem.

--- a/src/content/ecosystem-explorer/projects/artifact-labs.md
+++ b/src/content/ecosystem-explorer/projects/artifact-labs.md
@@ -19,7 +19,6 @@ repo: https://github.com/ArtifactLabsOfficial/EIPs
 featured-content: https://fil.org/blog/how-artifact-labs-is-preserving-and-connecting-history-and-culture-using-the-blockchain/
 twitter: https://twitter.com/ArtifactLabs_
 seo:
-  title: "Artifact Labs: Preserving Culture and History on the Filecoin Network"
   description: Artifact Labs stores and shares cultural artifacts on the
     blockchain. Explore thousands of preserved items from the Titanic and
     beyond, secured on the Filecoin network for future generations.

--- a/src/content/ecosystem-explorer/projects/astral.md
+++ b/src/content/ecosystem-explorer/projects/astral.md
@@ -17,7 +17,6 @@ tech:
 twitter: https://twitter.com/astralprotocol
 year-joined: 2024-03-29T21:28:48.588Z
 seo:
-  title: "Astral: Pioneering Location-Based Decentralized Web with GeoDIDs on IPFS"
   description: Astral offers decentralized solutions for data retrieval and management.
 ---
 

--- a/src/content/ecosystem-explorer/projects/atlas-experiment-at-cern.md
+++ b/src/content/ecosystem-explorer/projects/atlas-experiment-at-cern.md
@@ -19,7 +19,6 @@ twitter: "https://twitter.com/ATLASexperiment"
 subcategories:
   - decentralized-science
 seo:
-  title: ATLAS Experiment at CERN
   description: Explore the ATLAS Experiment at CERN using decentralized storage solutions.
 email: encrypted::U2FsdGVkX180yXAP8t71XhT8wj/uSaUpEhBy4q36CbXl7uTJlIhSMqHrZCO2L+VA
 full-name: encrypted::U2FsdGVkX18+69wboV7Pxfbbh79Zk3zZJeNJasDan0I=

--- a/src/content/ecosystem-explorer/projects/audius.md
+++ b/src/content/ecosystem-explorer/projects/audius.md
@@ -19,8 +19,6 @@ repo: https://github.com/AudiusProject
 featured-content: https://docs.ipfs.tech/case-studies/audius/
 twitter: https://twitter.com/audius
 seo:
-  title: "Audius: Decentralized Music Platform Empowering Artists with Control
-    Over Their Content"
   description: Audius offers artists a direct connection to listeners using
     decentralized technology and IPFS, ensuring control over their music and
     distribution without the need for record labels.

--- a/src/content/ecosystem-explorer/projects/bagel.md
+++ b/src/content/ecosystem-explorer/projects/bagel.md
@@ -16,7 +16,6 @@ tech:
 twitter: https://x.com/bagel_network
 year-joined: 2024-07-08T16:00:00.000Z
 seo:
-  title: Bagel
   description: Explore Bagel, an AI and cryptography research lab pioneering GPU
     restaking for enhanced AI productivity. Partnered with Filecoin for
     cutting-edge developments.

--- a/src/content/ecosystem-explorer/projects/banyan.md
+++ b/src/content/ecosystem-explorer/projects/banyan.md
@@ -22,7 +22,6 @@ year-joined: 2024-02-01T20:41:25.602Z
 subcategories:
   - data-storage-management
 seo:
-  title: Banyan
   description: Banyan offers decentralized data management solutions for enterprises.
 email: encrypted::U2FsdGVkX1+aBk8bAf6fekov/9WaGvLz/5UNeNBce6ElFipZ0xkri1q1jiHzc6po
 full-name: encrypted::U2FsdGVkX1+/emHS5H5JyJtytspect2NInkGajToAJI=

--- a/src/content/ecosystem-explorer/projects/basic-beasts.md
+++ b/src/content/ecosystem-explorer/projects/basic-beasts.md
@@ -15,7 +15,6 @@ tech:
 twitter: https://twitter.com/basicbeastsnft
 year-joined: 2024-03-29T21:28:48.611Z
 seo:
-  title: Basic Beasts
   description: Basic Beasts creates NFT-based collectibles on the Filecoin network.
 email: encrypted::U2FsdGVkX19i92+k9CGS3qh1wH2lwEuCcb4/oe1q7qFa2lVIwsR0TzUv04zmg3QM
 full-name: encrypted::U2FsdGVkX1+7nV/qiGeik6dXC5BFS23hGDItKpMnPzs=

--- a/src/content/ecosystem-explorer/projects/ceramic-network-3box.md
+++ b/src/content/ecosystem-explorer/projects/ceramic-network-3box.md
@@ -17,7 +17,7 @@ tech:
 twitter: https://twitter.com/ceramicnetwork
 year-joined: 2024-03-29T21:28:48.709Z
 seo:
-  title: "Ceramic Network: 3Box"
+  title: "Ceramic Network (3Box)"
   description: Ceramic Network offers decentralized data storage and management solutions.
 ---
 

--- a/src/content/ecosystem-explorer/projects/chainstack.md
+++ b/src/content/ecosystem-explorer/projects/chainstack.md
@@ -17,7 +17,6 @@ year-joined: 2024-03-29T21:28:49.352000Z
 subcategories:
   - infrastructure
 seo:
-  title: Chainstack
   description: Chainstack provides blockchain infrastructure and development tools.
 email: encrypted::U2FsdGVkX19FdYxtIAXza4rObxyDiDeMfSaRtvVl+I6PIXLRps2UyuSnSSMWG8DQ
 full-name: encrypted::U2FsdGVkX1/q8XIL64Ua+NUTUVrDPHd6uv8IU6yPnVs=

--- a/src/content/ecosystem-explorer/projects/chemotronix.md
+++ b/src/content/ecosystem-explorer/projects/chemotronix.md
@@ -17,7 +17,6 @@ tech:
 twitter: https://twitter.com/chemotronix
 year-joined: 2024-03-29T21:28:49.980Z
 seo:
-  title: Chemotronix
   description: Chemotronix offers decentralized science solutions for data management.
 ---
 

--- a/src/content/ecosystem-explorer/projects/cidgravity.md
+++ b/src/content/ecosystem-explorer/projects/cidgravity.md
@@ -16,7 +16,6 @@ year-joined: 2024-04-03T17:39:33.807000Z
 subcategories:
   - data-storage-management
 seo:
-  title: CIDGravity
   description: CIDGravity offers decentralized solutions for content addressable storage.
 email: encrypted::U2FsdGVkX19ZRigfAdHG/gks5UW+pCjDvys3lhZxo2yMbsRKQn2IOUqKFX7Q+iQf
 full-name: encrypted::U2FsdGVkX19+uTk/EBZyR8zpmJmDXbcZ9S8QllRebQI=

--- a/src/content/ecosystem-explorer/projects/clover.md
+++ b/src/content/ecosystem-explorer/projects/clover.md
@@ -18,7 +18,6 @@ repo: https://github.com/useclover/clover-warp
 twitter: https://twitter.com/cloversuite
 year-joined: 2024-03-29T21:28:50.458Z
 seo:
-  title: Clover
   description: Clover provides tools for decentralized finance and blockchain
     interoperability.
 ---

--- a/src/content/ecosystem-explorer/projects/collectif-dao.md
+++ b/src/content/ecosystem-explorer/projects/collectif-dao.md
@@ -18,7 +18,6 @@ year-joined: 2024-01-24T13:50:38.359000Z
 subcategories:
   - governance-daos-public-goods
 seo:
-  title: Collectif DAO
   description:
     Collectif DAO is a decentralized autonomous organization for creative
     communities.

--- a/src/content/ecosystem-explorer/projects/cookbook-dev.md
+++ b/src/content/ecosystem-explorer/projects/cookbook-dev.md
@@ -17,7 +17,6 @@ year-joined: 2024-04-04T20:26:55.709000Z
 subcategories:
   - developer-tools
 seo:
-  title: Cookbook Dev
   description: Cookbook Dev offers decentralized development tools and resources.
 email: encrypted::U2FsdGVkX180elBw9qreUH2gRpV1J40jTDpVtaClljLevqXzLeYGE+RMrUJ4PlCe
 full-name: encrypted::U2FsdGVkX19o6c9U4OrRYvQpMtzk/cXQAnzEkv6CHLs=

--- a/src/content/ecosystem-explorer/projects/cooperdb.md
+++ b/src/content/ecosystem-explorer/projects/cooperdb.md
@@ -14,7 +14,6 @@ year-joined: 2024-04-05T14:44:50.326000Z
 subcategories:
   - data-storage-management
 seo:
-  title: CooperDB
   description:
     CooperDB provides decentralized database solutions for secure data
     management.

--- a/src/content/ecosystem-explorer/projects/coophive.md
+++ b/src/content/ecosystem-explorer/projects/coophive.md
@@ -17,7 +17,6 @@ year-joined: 2024-04-24T19:28:43.576000Z
 subcategories:
   - governance-daos-public-goods
 seo:
-  title: CoopHive
   description:
     CoopHive offers decentralized solutions for cooperative management
     and governance.

--- a/src/content/ecosystem-explorer/projects/corgi-1.md
+++ b/src/content/ecosystem-explorer/projects/corgi-1.md
@@ -18,7 +18,6 @@ year-joined: 2024-02-28T23:14:40.521000Z
 subcategories:
   - data-storage-management
 seo:
-  title: Corgi
   description: Corgi provides decentralized storage solutions for digital assets.
 email: encrypted::U2FsdGVkX1/d8gW0Rk+DXRqkr430QiMckgPA0WmNqsyGnVBsOw40QsXnEHbbM/Y/
 full-name: encrypted::U2FsdGVkX18b3wK+8h6ZjJGOB9AzOLCVmfIbZ2TcEys=

--- a/src/content/ecosystem-explorer/projects/crossfi.md
+++ b/src/content/ecosystem-explorer/projects/crossfi.md
@@ -17,7 +17,6 @@ tech:
 twitter: https://twitter.com/globalcrossfi/
 year-joined: 2024-01-17T14:44:30.896Z
 seo:
-  title: CrossFi
   description: CrossFi offers decentralized finance solutions for cross-chain
     interoperability.
 ---

--- a/src/content/ecosystem-explorer/projects/cryptoworth.md
+++ b/src/content/ecosystem-explorer/projects/cryptoworth.md
@@ -18,7 +18,6 @@ tech:
 twitter: https://twitter.com/cryptoworthapp/
 year-joined: 2023-08-01T20:34:10.316Z
 seo:
-  title: Cryptoworth
   description:
     Cryptoworth provides tools for managing and tracking cryptocurrency
     portfolios.

--- a/src/content/ecosystem-explorer/projects/daln.md
+++ b/src/content/ecosystem-explorer/projects/daln.md
@@ -16,7 +16,6 @@ repo: https://github.com/DALN-app/monorepo_v2
 twitter: https://twitter.com/DataHaus_
 year-joined: 2024-04-03T16:51:43.504Z
 seo:
-  title: DALN
   description: DALN offers decentralized solutions for data archiving and long-term storage.
 email: encrypted::U2FsdGVkX1+xqqnoLLCnwwXss3cQyj0pA58MFsGD58T619nPMRCY82kIPvg93L5f
 full-name: encrypted::U2FsdGVkX1+dHmXUnjOw8mGZA/bMG8QtaPhPMX02PqE=

--- a/src/content/ecosystem-explorer/projects/datahaus.md
+++ b/src/content/ecosystem-explorer/projects/datahaus.md
@@ -18,7 +18,6 @@ tech:
 twitter: https://twitter.com/DataHaus_
 year-joined: 2024-03-29T21:28:52.788Z
 seo:
-  title: DataHaus
   description: DataHaus provides decentralized data management and analytics solutions.
 ---
 

--- a/src/content/ecosystem-explorer/projects/datalatte.md
+++ b/src/content/ecosystem-explorer/projects/datalatte.md
@@ -16,7 +16,6 @@ year-joined: 2024-03-29T21:28:49.704000Z
 subcategories:
   - data-storage-management
 seo:
-  title: DataLatte
   description: DataLatte offers decentralized data storage and retrieval services.
 email: encrypted::U2FsdGVkX1/eZS4gxwa4w1YvUZDhonLOsgK9fH6MuT84wLdoNUWGJZeFjJxmlot4
 full-name: encrypted::U2FsdGVkX194K6rzMzbUPYycpCdNoySpRfk4l3KxHoQ=

--- a/src/content/ecosystem-explorer/projects/dcent.md
+++ b/src/content/ecosystem-explorer/projects/dcent.md
@@ -18,7 +18,6 @@ year-joined: 2023-08-01T20:34:10.316000Z
 subcategories:
   - wallets-identity-authentication
 seo:
-  title: DCent
   description: DCent provides decentralized identity and authentication solutions.
 email: encrypted::U2FsdGVkX1+xUerzS2FpwpYZDkRzAYaW4/6tW1yG3aVINfi+N/GunQ9qFOsKa7ZC
 full-name: encrypted::U2FsdGVkX19LxxmGL9j/G1ZtdNIyo28D0myhBBBoD7c=

--- a/src/content/ecosystem-explorer/projects/ddrive.md
+++ b/src/content/ecosystem-explorer/projects/ddrive.md
@@ -14,7 +14,6 @@ year-joined: 2024-04-03T17:23:12.660000Z
 subcategories:
   - data-storage-management
 seo:
-  title: DDrive
   description:
     DDrive offers decentralized storage solutions for personal and enterprise
     use.

--- a/src/content/ecosystem-explorer/projects/decentroge.md
+++ b/src/content/ecosystem-explorer/projects/decentroge.md
@@ -15,7 +15,6 @@ tech:
   - ipfs
 year-joined: 2024-04-03T17:57:20.241Z
 seo:
-  title: Decentroge
   description: Decentroge provides decentralized tools for data storage and management.
 email: encrypted::U2FsdGVkX18nDydseUXszS1n9QiAWT7YTnITBkb7ApoEd8nvgSPakareabOROhaZ
 full-name: encrypted::U2FsdGVkX19UTgahvuEhb4WyC2Nun8V05K09qhlIAMU=

--- a/src/content/ecosystem-explorer/projects/defluencer.md
+++ b/src/content/ecosystem-explorer/projects/defluencer.md
@@ -17,7 +17,6 @@ year-joined: 2024-04-03T18:07:28.347000Z
 subcategories:
   - dapp
 seo:
-  title: Defluencer
   description: Defluencer offers decentralized solutions for influencer marketing.
 email: encrypted::U2FsdGVkX1/pRNfoX+q8IEk2x9yZO7/j93LEYco/TNDapjjFNtvU1Pr95kgFNuV6
 full-name: encrypted::U2FsdGVkX1/vkO8fvhc+Oo2h0MHbSLdSbKgVgfOUhSE=

--- a/src/content/ecosystem-explorer/projects/democracys-library.md
+++ b/src/content/ecosystem-explorer/projects/democracys-library.md
@@ -19,7 +19,6 @@ tech:
 featured-content: https://fil.org/blog/democracy%E2%80%99s-library-announces-more-than-a-petabyte-of-government-data-uploaded-to-the-filecoin-network/
 twitter: https://twitter.com/internetarchive
 seo:
-  title: Democracy's Library
   description:
     Democracy's Library provides access to public government data using
     decentralized storage.

--- a/src/content/ecosystem-explorer/projects/desci-labs.md
+++ b/src/content/ecosystem-explorer/projects/desci-labs.md
@@ -20,7 +20,6 @@ video-url: https://www.youtube.com/embed/q_5hAe2AzhE
 subcategories:
   - decentralized-science
 seo:
-  title: DeSci Labs
   description:
     DeSci Labs offers decentralized science solutions for data management
     and collaboration.

--- a/src/content/ecosystem-explorer/projects/destor.md
+++ b/src/content/ecosystem-explorer/projects/destor.md
@@ -18,7 +18,6 @@ tech:
 twitter: https://x.com/FilecoinDeStor
 year-joined: 2024-04-01T16:28:00.000Z
 seo:
-  title: DeStor
   description: Discover DeStor, a leader in decentralized storage services using
     blockchain technology. Connects data owners with Filecoin storage providers
     for secure, scalable storage.

--- a/src/content/ecosystem-explorer/projects/domainfns.md
+++ b/src/content/ecosystem-explorer/projects/domainfns.md
@@ -17,7 +17,6 @@ repo: https://github.com/OpenGateLab/FNS
 twitter: https://twitter.com/DomainFNS
 year-joined: 2024-05-16T14:33:32.622Z
 seo:
-  title: DomainFNS
   description:
     DomainFNS provides decentralized solutions for domain name services
     and management.

--- a/src/content/ecosystem-explorer/projects/dosier.md
+++ b/src/content/ecosystem-explorer/projects/dosier.md
@@ -15,7 +15,6 @@ tech:
 twitter: https://twitter.com/dosier_ai
 year-joined: 2024-04-05T23:07:24.336Z
 seo:
-  title: Dosier
   description: Dosier offers decentralized storage solutions for digital documents.
 email: encrypted::U2FsdGVkX19t2udgs3CCoKH2sf/GJ7d5X4Z/e5wq69s+SpD/PI/+nMSwfelUevLy
 full-name: encrypted::U2FsdGVkX1979eBYW+lUnTMKK5YaLreBplrBq0PjAKw=

--- a/src/content/ecosystem-explorer/projects/drpc.md
+++ b/src/content/ecosystem-explorer/projects/drpc.md
@@ -16,7 +16,6 @@ year-joined: 2024-04-05T13:32:22.117000Z
 subcategories:
   - data-retrieval
 seo:
-  title: DRPC
   description:
     DRPC provides decentralized solutions for remote procedure calls and
     data retrieval.

--- a/src/content/ecosystem-explorer/projects/dvol.md
+++ b/src/content/ecosystem-explorer/projects/dvol.md
@@ -15,7 +15,6 @@ tech:
 twitter: https://twitter.com/dvolfinance
 year-joined: 2024-04-05T00:07:23.591Z
 seo:
-  title: DVol
   description: DVol offers decentralized solutions for volume storage and data management.
 email: encrypted::U2FsdGVkX1/oGOrU62BdGDrd0JrwkM8EyqKk/wD4ltRkQ6JClzUKewj2ao+NmU/w
 full-name: encrypted::U2FsdGVkX19WgeO3+WqSZN/5D+ElFKgfl27o08n65S8=

--- a/src/content/ecosystem-explorer/projects/e-ipfs.md
+++ b/src/content/ecosystem-explorer/projects/e-ipfs.md
@@ -13,7 +13,6 @@ year-joined: 2024-04-05T00:10:47.116000Z
 subcategories:
   - data-storage-management
 seo:
-  title: E-IPFS
   description:
     E-IPFS provides enhanced IPFS solutions for decentralized storage and
     retrieval.

--- a/src/content/ecosystem-explorer/projects/easier-data-initiative.md
+++ b/src/content/ecosystem-explorer/projects/easier-data-initiative.md
@@ -18,7 +18,6 @@ year-joined: 2022-10-12T20:29:27.704000Z
 subcategories:
   - data-storage-management
 seo:
-  title: Easier Data Initiative
   description:
     Easier Data Initiative offers decentralized solutions for data management
     and accessibility.

--- a/src/content/ecosystem-explorer/projects/eastore.md
+++ b/src/content/ecosystem-explorer/projects/eastore.md
@@ -15,7 +15,6 @@ year-joined: 2024-04-05T00:15:15.170000Z
 subcategories:
   - data-storage-management
 seo:
-  title: EAStore
   description: EAStore provides decentralized storage solutions for enterprise applications.
 email: encrypted::U2FsdGVkX19eXg63RFCHAynLV95x69mUp8GnQCJRa5WLG7p0qY7wSWDt1rREPDyZ
 full-name: encrypted::U2FsdGVkX1/g3YwfBAf7V0meGE/ifvrabefZjwrvZcU=

--- a/src/content/ecosystem-explorer/projects/ecko.md
+++ b/src/content/ecosystem-explorer/projects/ecko.md
@@ -15,7 +15,6 @@ tech:
   - filecoin
 year-joined: 2024-04-05T00:20:25.941Z
 seo:
-  title: Ecko
   description: Ecko offers decentralized solutions for blockchain infrastructure
     and development.
 email: encrypted::U2FsdGVkX1//Xw16FyGK/X/HsElvHjvv0SeKrE+6BD4hBydwvd9lnF2l7H+iRCtp

--- a/src/content/ecosystem-explorer/projects/elastic.md
+++ b/src/content/ecosystem-explorer/projects/elastic.md
@@ -14,7 +14,6 @@ year-joined: 2024-04-05T00:28:51.844000Z
 subcategories:
   - data-storage-management
 seo:
-  title: Elastic
   description: Elastic provides decentralized data storage and management solutions.
 email: encrypted::U2FsdGVkX1+evrKdHTJLD6B99t9rY0aw0xk+BzR1V5+EOANxp58ZkyOE2kwPE956
 full-name: encrypted::U2FsdGVkX1+v6XGh6Cbu/gsbAYzs0hXJcYC2MYU93pk=

--- a/src/content/ecosystem-explorer/projects/encryption-pinner.md
+++ b/src/content/ecosystem-explorer/projects/encryption-pinner.md
@@ -15,7 +15,6 @@ year-joined: 2024-04-05T01:09:47.927000Z
 subcategories:
   - data-storage-management
 seo:
-  title: Encryption Pinner
   description: Encryption Pinner offers secure and decentralized data pinning services.
 email: encrypted::U2FsdGVkX19irI5xwEIvelRPtM9LpOKtqU3GCt/FUTZypvztNfvaJ25SgBxDI5Rw
 full-name: encrypted::U2FsdGVkX188DJkgvVh1LaaQQ3Mo2VHReSZH8B7U85w=

--- a/src/content/ecosystem-explorer/projects/eqty-lab-arc-collective.md
+++ b/src/content/ecosystem-explorer/projects/eqty-lab-arc-collective.md
@@ -17,7 +17,6 @@ year-joined: 2024-03-29T21:28:50.218000Z
 subcategories:
   - data-storage-management
 seo:
-  title: Eqty Lab ARC Collective
   description:
     Eqty Lab ARC Collective provides decentralized solutions for data management
     and collaboration.

--- a/src/content/ecosystem-explorer/projects/ethereum-name-service.md
+++ b/src/content/ecosystem-explorer/projects/ethereum-name-service.md
@@ -14,7 +14,6 @@ tech:
   - ipfs
 year-joined: 2024-04-05T01:47:43.309Z
 seo:
-  title: Ethereum Name Service
   description:
     Ethereum Name Service offers decentralized domain name services for
     the Ethereum network.

--- a/src/content/ecosystem-explorer/projects/expanso.md
+++ b/src/content/ecosystem-explorer/projects/expanso.md
@@ -17,7 +17,6 @@ year-joined: 2024-03-29T21:28:52.162000Z
 subcategories:
   - data-storage-management
 seo:
-  title: Expanso
   description:
     Expanso provides decentralized storage solutions for data archiving
     and management.

--- a/src/content/ecosystem-explorer/projects/filecoin-foundation-for-the-decentralized-web.md
+++ b/src/content/ecosystem-explorer/projects/filecoin-foundation-for-the-decentralized-web.md
@@ -20,7 +20,6 @@ tech:
 featured-content: https://ffdweb.org/resources/
 twitter: https://twitter.com/ffdweb
 seo:
-  title: Filecoin Foundation for the Decentralized Web
   description: The Filecoin Foundation for the Decentralized Web supports the
     growth of decentralized web technologies.
 ---

--- a/src/content/ecosystem-explorer/projects/filecoin-foundation.md
+++ b/src/content/ecosystem-explorer/projects/filecoin-foundation.md
@@ -19,7 +19,6 @@ tech:
 featured-content: https://fil.org/blog/
 twitter: https://twitter.com/FilFoundation
 seo:
-  title: Filecoin Foundation
   description: The Filecoin Foundation supports the Filecoin network and its ecosystem.
 ---
 

--- a/src/content/ecosystem-explorer/projects/filecoin-green.md
+++ b/src/content/ecosystem-explorer/projects/filecoin-green.md
@@ -18,7 +18,6 @@ tech:
   - ipfs
 twitter: https://twitter.com/filecoingreen
 seo:
-  title: Filecoin Green
   description: Filecoin Green provides sustainable solutions for decentralized storage.
 ---
 

--- a/src/content/ecosystem-explorer/projects/filecoin-incentive-designlabs.md
+++ b/src/content/ecosystem-explorer/projects/filecoin-incentive-designlabs.md
@@ -17,7 +17,6 @@ year-joined: 2024-05-16T14:44:42.714000Z
 subcategories:
   - developer-tools
 seo:
-  title: Filecoin Incentive DesignLabs
   description:
     Filecoin Incentive DesignLabs offers tools and resources for designing
     incentives on the Filecoin network.

--- a/src/content/ecosystem-explorer/projects/filecoin-saturn.md
+++ b/src/content/ecosystem-explorer/projects/filecoin-saturn.md
@@ -18,7 +18,6 @@ year-joined: 2024-01-19T18:46:07.011000Z
 subcategories:
   - data-storage-management
 seo:
-  title: Filecoin Saturn
   description:
     Filecoin Saturn provides decentralized storage solutions for the Filecoin
     network.

--- a/src/content/ecosystem-explorer/projects/filecoin-station.md
+++ b/src/content/ecosystem-explorer/projects/filecoin-station.md
@@ -20,7 +20,6 @@ tech:
 repo: https://github.com/filecoin-station/desktop
 featured-content: https://blog.filecointldr.io/filecoins-retrieval-markets-update-spotlight-on-project-saturn-9f233ed133ed
 seo:
-  title: Filecoin Station
   description: Filecoin Station offers decentralized tools and resources for the
     Filecoin community.
 ---

--- a/src/content/ecosystem-explorer/projects/filedrive.md
+++ b/src/content/ecosystem-explorer/projects/filedrive.md
@@ -18,7 +18,6 @@ twitter: "https://twitter.com/FileDrive1"
 subcategories:
   - data-storage-management
 seo:
-  title: FileDrive
   description:
     FileDrive provides decentralized storage solutions for personal and
     enterprise use.

--- a/src/content/ecosystem-explorer/projects/filemarket.md
+++ b/src/content/ecosystem-explorer/projects/filemarket.md
@@ -20,7 +20,6 @@ year-joined: 2022-09-01T15:06:37.800000Z
 subcategories:
   - dapp
 seo:
-  title: FileMarket
   description: FileMarket offers decentralized marketplace solutions for digital assets.
 email: encrypted::U2FsdGVkX1/SlT9vk4zMX23EQ7brjnGv0cyR8SWlhmgQm9y91u7/IwraElAE9IBJ
 full-name: encrypted::U2FsdGVkX18x2Y7KZCSH6M7nR4nFtme+mVXfseQbpzc=

--- a/src/content/ecosystem-explorer/projects/filenova.md
+++ b/src/content/ecosystem-explorer/projects/filenova.md
@@ -15,7 +15,6 @@ tech:
 repo: https://github.com/Filenova
 year-joined: 2024-04-24T19:39:19.948Z
 seo:
-  title: FileNova
   description: FileNova provides decentralized storage and data management solutions.
 email: encrypted::U2FsdGVkX1+vWydQ9LjxHns5R3jUXUP2gnFwi5/1Ug177+RIiuCs2b4dex3QZMnh
 full-name: encrypted::U2FsdGVkX18h3EknFRoDYtFXB16N0OlVWTopDAPM6qE=

--- a/src/content/ecosystem-explorer/projects/filet-finance.md
+++ b/src/content/ecosystem-explorer/projects/filet-finance.md
@@ -16,7 +16,6 @@ tech:
   - filecoin
 year-joined: 2024-03-29T21:28:51.053Z
 seo:
-  title: Filet Finance
   description: Filet Finance offers decentralized finance solutions on the Filecoin network.
 ---
 

--- a/src/content/ecosystem-explorer/projects/fileverse.md
+++ b/src/content/ecosystem-explorer/projects/fileverse.md
@@ -19,7 +19,6 @@ twitter: https://twitter.com/fileverse
 subcategories:
   - data-storage-management
 seo:
-  title: Fileverse
   description: Fileverse provides decentralized storage solutions for the metaverse.
 email: encrypted::U2FsdGVkX19VhJszfn2ttbAeReEqdZeEksZoFEPcSq6a73O6iJ2txOd0iR/HuBWj
 full-name: encrypted::U2FsdGVkX1+yZ5c+Mvufu5oj9Jn4R8XnERcBzBRiJng=

--- a/src/content/ecosystem-explorer/projects/filezilla.md
+++ b/src/content/ecosystem-explorer/projects/filezilla.md
@@ -18,7 +18,6 @@ year-joined: 2024-02-21T15:20:11.125000Z
 subcategories:
   - data-storage-management
 seo:
-  title: Filezilla
   description: Filezilla offers decentralized file storage and management solutions.
 email: encrypted::U2FsdGVkX1+g8an3PSXetYjodZ0459ma9Rzwz1HjJ8b9kGVLA4/MVu50XOx8X0UG
 full-name: encrypted::U2FsdGVkX18wwfhu3wGAYT8eDq+daob2Jsr59JcbLyc=

--- a/src/content/ecosystem-explorer/projects/filfi.md
+++ b/src/content/ecosystem-explorer/projects/filfi.md
@@ -20,7 +20,6 @@ twitter: https://twitter.com/filfi_io
 video-url: https://www.youtube.com/embed/oaaLTpKSbYU
 year-joined: 2023-05-30T20:57:35.326Z
 seo:
-  title: FilFi
   description: FilFi provides decentralized finance solutions for the Filecoin network.
 ---
 

--- a/src/content/ecosystem-explorer/projects/filliquid.md
+++ b/src/content/ecosystem-explorer/projects/filliquid.md
@@ -21,7 +21,6 @@ twitter: https://twitter.com/FILLiquid
 video-url: https://www.youtube.com/embed/wYYGW7Rxc0E
 year-joined: 2024-01-24T13:45:47.646Z
 seo:
-  title: FilLiquid
   description: FilLiquid offers decentralized liquidity solutions for the Filecoin network.
 ---
 

--- a/src/content/ecosystem-explorer/projects/filscan.md
+++ b/src/content/ecosystem-explorer/projects/filscan.md
@@ -18,6 +18,5 @@ tech:
   - ipfs
 twitter: https://twitter.com/filscanio
 seo:
-  title: FilScan
   description: FilScan provides blockchain explorer services for the Filecoin network.
 ---

--- a/src/content/ecosystem-explorer/projects/filscriptions.md
+++ b/src/content/ecosystem-explorer/projects/filscriptions.md
@@ -16,7 +16,6 @@ year-joined: 2024-01-18T17:56:20.324000Z
 subcategories:
   - data-storage-management
 seo:
-  title: FilScriptions
   description: FilScriptions offers decentralized subscription management solutions.
 email: encrypted::U2FsdGVkX19jGBUJe+UqqCtN6NKVOksfiSZ4bAM/mKSjSnVY7GHzFujS5HJbneWq
 full-name: encrypted::U2FsdGVkX1/F9XdNv2Uv/iTEO50suveQ+tEURS3OxGY=

--- a/src/content/ecosystem-explorer/projects/fission.md
+++ b/src/content/ecosystem-explorer/projects/fission.md
@@ -18,7 +18,6 @@ twitter: https://twitter.com/FISSIONcodes
 subcategories:
   - data-storage-management
 seo:
-  title: Fission
   description: Fission provides decentralized storage and application hosting solutions.
 email: encrypted::U2FsdGVkX1+X69CsepI1J7d6qauqnoUBbqIFNPpq9AbpaxDpwiz2lGjqnSugDH5i
 full-name: encrypted::U2FsdGVkX1+ufPGmpW7IizFe4XEifgJntaOGqdf7HB0=

--- a/src/content/ecosystem-explorer/projects/flame-launch.md
+++ b/src/content/ecosystem-explorer/projects/flame-launch.md
@@ -15,7 +15,6 @@ year-joined: 2022-12-01T17:27:13.497000Z
 subcategories:
   - dapp
 seo:
-  title: Flame Launch
   description:
     Flame Launch provides decentralized solutions for project launches
     and token sales.

--- a/src/content/ecosystem-explorer/projects/flare-api-portal.md
+++ b/src/content/ecosystem-explorer/projects/flare-api-portal.md
@@ -18,7 +18,6 @@ twitter: https://twitter.com/APIPortal
 video-url: https://www.youtube.com/embed/mBTyTwh-Wzo
 year-joined: 2024-04-05T13:18:56.264Z
 seo:
-  title: Flare API Portal
   description:
     Flare API Portal offers decentralized API solutions for blockchain
     applications.

--- a/src/content/ecosystem-explorer/projects/fleek.md
+++ b/src/content/ecosystem-explorer/projects/fleek.md
@@ -20,7 +20,6 @@ year-joined: 2024-01-19T18:50:41.292000Z
 subcategories:
   - dapp
 seo:
-  title: Fleek
   description:
     Fleek provides decentralized solutions for hosting and deploying web
     applications.

--- a/src/content/ecosystem-explorer/projects/fluence.md
+++ b/src/content/ecosystem-explorer/projects/fluence.md
@@ -17,7 +17,6 @@ featured-content: "https://www.youtube.com/watch?v=uFhPJ1wR1GQ"
 subcategories:
   - infrastructure
 seo:
-  title: Fluence
   description: Fluence offers decentralized computing solutions for peer-to-peer applications.
 email: encrypted::U2FsdGVkX1/ciPJHiovcbSZdh2/Yz592T0WGVTWvf1HF34AhUfU+JLh5xfT43Wnj
 full-name: encrypted::U2FsdGVkX1/17/Yh5rUjXOVSUxR/qvnOkkHuvjbyMtI=

--- a/src/content/ecosystem-explorer/projects/fog-works-inc.md
+++ b/src/content/ecosystem-explorer/projects/fog-works-inc.md
@@ -16,9 +16,7 @@ year-joined: 2022-11-22T19:44:10.444000Z
 subcategories:
   - infrastructure
 seo:
-  title: Fog Works Inc
-  description:
-    Fog Works Inc provides decentralized solutions for edge computing and
+  description: Fog Works provides decentralized solutions for edge computing and
     data storage.
 email: encrypted::U2FsdGVkX18O8WVEsV6BmzTK7FtJ8FaqIY3VWo7ExH3nrNF5X4fFyCIRZpSkimj0
 full-name: encrypted::U2FsdGVkX1/NwVviSV5ER7Zi+SiKko/1WoyhygJiksw=

--- a/src/content/ecosystem-explorer/projects/force-community.md
+++ b/src/content/ecosystem-explorer/projects/force-community.md
@@ -17,7 +17,6 @@ tech:
 twitter: https://twitter.com/force_ipfs
 year-joined: 2024-03-29T21:28:50.711Z
 seo:
-  title: Force Community
   description: Force Community offers decentralized solutions for community
     management and governance.
 ---

--- a/src/content/ecosystem-explorer/projects/foxwallet.md
+++ b/src/content/ecosystem-explorer/projects/foxwallet.md
@@ -18,7 +18,6 @@ year-joined: 2024-02-27T20:36:33.551000Z
 subcategories:
   - wallets-identity-authentication
 seo:
-  title: FoxWallet
   description:
     FoxWallet provides decentralized wallet solutions for managing digital
     assets.

--- a/src/content/ecosystem-explorer/projects/froghub.md
+++ b/src/content/ecosystem-explorer/projects/froghub.md
@@ -15,7 +15,6 @@ year-joined: 2024-04-05T23:10:27.396000Z
 subcategories:
   - dapp
 seo:
-  title: FrogHub
   description: FrogHub offers decentralized solutions for project management and collaboration.
 email: encrypted::U2FsdGVkX18WALd/e0jqbdNj7f/qZ78ItzQyv7m40D7lyGru2uiXoLcoUddWMP1C
 full-name: encrypted::U2FsdGVkX185bOl9uf/9KhNY0Du9d0SM2/n4QqHru98=

--- a/src/content/ecosystem-explorer/projects/functionland-fula.md
+++ b/src/content/ecosystem-explorer/projects/functionland-fula.md
@@ -19,7 +19,6 @@ year-joined: 2021-03-03T16:17:36.608000Z
 subcategories:
   - data-storage-management
 seo:
-  title: Functionland Fula
   description:
     Functionland Fula provides decentralized storage solutions for personal
     data management.

--- a/src/content/ecosystem-explorer/projects/fvm-dapp.md
+++ b/src/content/ecosystem-explorer/projects/fvm-dapp.md
@@ -16,7 +16,6 @@ year-joined: 2024-04-04T20:33:26.476000Z
 subcategories:
   - dapp
 seo:
-  title: FVM Dapp
   description:
     FVM Dapp offers decentralized applications built on the Filecoin Virtual
     Machine.

--- a/src/content/ecosystem-explorer/projects/gainforest.md
+++ b/src/content/ecosystem-explorer/projects/gainforest.md
@@ -19,7 +19,6 @@ twitter: https://twitter.com/GainForestNow
 subcategories:
   - climate
 seo:
-  title: Gainforest
   description:
     Gainforest provides decentralized solutions for climate impact monitoring
     and reporting.

--- a/src/content/ecosystem-explorer/projects/genrait.md
+++ b/src/content/ecosystem-explorer/projects/genrait.md
@@ -17,7 +17,6 @@ featured-content: "https://fil.org/blog/case-study-genrait-leverages-filecoin-ne
 subcategories:
   - health
 seo:
-  title: GenRAIT
   description:
     GenRAIT offers decentralized solutions for genomic data storage and
     analysis.

--- a/src/content/ecosystem-explorer/projects/ghostdrive-global.md
+++ b/src/content/ecosystem-explorer/projects/ghostdrive-global.md
@@ -18,8 +18,7 @@ twitter: https://twitter.com/GhostDrive_Web3
 video-url: https://www.youtube.com/embed/D0Mh3ZDA-3Y
 year-joined: 2024-05-16T14:59:06.611Z
 seo:
-  title: GhostDrive Global
-  description: GhostDrive Global provides decentralized storage solutions for
+  description: GhostDrive provides decentralized storage solutions for
     secure data management.
 email: encrypted::U2FsdGVkX1+2AHTFVnvLjWw1INsldiPMMUU5NqKj9bQblQpfPrrHnh1XOSmApCkr
 full-name: encrypted::U2FsdGVkX199HDy/+WXtvCmhAimq9SpRYfA1ieemFHc=

--- a/src/content/ecosystem-explorer/projects/glif.md
+++ b/src/content/ecosystem-explorer/projects/glif.md
@@ -18,7 +18,6 @@ year-joined: 2024-02-07T20:17:14.469000Z
 subcategories:
   - developer-tools
 seo:
-  title: Glif
   description:
     Glif offers decentralized tools and infrastructure for the Filecoin
     network.

--- a/src/content/ecosystem-explorer/projects/glitter-protocol.md
+++ b/src/content/ecosystem-explorer/projects/glitter-protocol.md
@@ -15,7 +15,6 @@ website: https://glitterprotocol.io/
 twitter: https://twitter.com/GlitterProtocol
 year-joined: 2024-03-29T21:28:51.837000Z
 seo:
-  title: Glitter Protocol
   description:
     Glitter Protocol provides decentralized finance solutions for the Filecoin
     network.

--- a/src/content/ecosystem-explorer/projects/hamster.md
+++ b/src/content/ecosystem-explorer/projects/hamster.md
@@ -15,7 +15,6 @@ year-joined: 2024-03-29T21:28:51.960000Z
 subcategories:
   - data-storage-management
 seo:
-  title: Hamster
   description:
     Hamster offers decentralized storage solutions for personal and enterprise
     use.

--- a/src/content/ecosystem-explorer/projects/hashguard.md
+++ b/src/content/ecosystem-explorer/projects/hashguard.md
@@ -17,7 +17,6 @@ year-joined: 2022-09-07T14:14:44.368000Z
 subcategories:
   - infrastructure
 seo:
-  title: HashGuard
   description:
     HashGuard provides decentralized security solutions for blockchain
     applications.

--- a/src/content/ecosystem-explorer/projects/hashmix.md
+++ b/src/content/ecosystem-explorer/projects/hashmix.md
@@ -15,7 +15,6 @@ website: https://fvm.hashmix.org/
 twitter: https://twitter.com/HashMixOfficial
 year-joined: 2020-12-31T15:00:00Z
 seo:
-  title: HashMix
   description:
     HashMix offers decentralized finance solutions for cross-chain asset
     management.

--- a/src/content/ecosystem-explorer/projects/hauska-ai.md
+++ b/src/content/ecosystem-explorer/projects/hauska-ai.md
@@ -17,7 +17,6 @@ year-joined: 2023-12-27T20:42:42.062000Z
 subcategories:
   - artificial-productivity-utilities
 seo:
-  title: Hauska AI
   description:
     Hauska AI provides AI-driven solutions for decentralized data analysis
     and management.

--- a/src/content/ecosystem-explorer/projects/haven.md
+++ b/src/content/ecosystem-explorer/projects/haven.md
@@ -17,7 +17,6 @@ year-joined: 2024-03-29T21:28:52.020000Z
 subcategories:
   - data-storage-management
 seo:
-  title: Haven
   description:
     Haven offers decentralized storage solutions for digital documents
     and assets.

--- a/src/content/ecosystem-explorer/projects/huddle01.md
+++ b/src/content/ecosystem-explorer/projects/huddle01.md
@@ -20,7 +20,6 @@ tech:
 repo: https://github.com/Huddle01
 twitter: https://twitter.com/huddle01com
 seo:
-  title: Huddle01
   description: Huddle01 provides decentralized solutions for video conferencing
     and collaboration.
 ---

--- a/src/content/ecosystem-explorer/projects/human-rights-data-analysis-group-hrdag.md
+++ b/src/content/ecosystem-explorer/projects/human-rights-data-analysis-group-hrdag.md
@@ -19,7 +19,6 @@ twitter: https://twitter.com/hrdag
 subcategories:
   - social-impact
 seo:
-  title: Human Rights Data Analysis Group (HRDAG)
   description:
     HRDAG offers decentralized solutions for human rights data collection
     and analysis.

--- a/src/content/ecosystem-explorer/projects/internet-development-studio-company.md
+++ b/src/content/ecosystem-explorer/projects/internet-development-studio-company.md
@@ -19,7 +19,6 @@ year-joined: 2024-01-12T20:15:45.807000Z
 subcategories:
   - developer-tools
 seo:
-  title: Internet Development Studio Company
   description:
     Internet Development Studio Company provides decentralized solutions
     for web development.

--- a/src/content/ecosystem-explorer/projects/jackrabbit-finance.md
+++ b/src/content/ecosystem-explorer/projects/jackrabbit-finance.md
@@ -16,7 +16,6 @@ tech:
   - filecoin
 year-joined: 2024-04-05T00:02:55.839Z
 seo:
-  title: Jackrabbit Finance
   description: Jackrabbit Finance offers decentralized finance solutions on the
     Filecoin network.
 ---

--- a/src/content/ecosystem-explorer/projects/kabat.md
+++ b/src/content/ecosystem-explorer/projects/kabat.md
@@ -16,7 +16,6 @@ tech:
   - filecoin
 year-joined: 2020-12-31T23:00:00.000Z
 seo:
-  title: Kabat
   description: "Unleash your data’s potential with Kabat! We offer decentralized storage and compute solutions for speed, security, and scalability. Empower your business and take control of the cloud today."
 ---
 

--- a/src/content/ecosystem-explorer/projects/kamu.md
+++ b/src/content/ecosystem-explorer/projects/kamu.md
@@ -16,7 +16,6 @@ year-joined: 2024-04-04T02:05:42.624000Z
 subcategories:
   - data-storage-management
 seo:
-  title: Kamu
   description: Kamu provides decentralized data management and collaboration tools.
 email: encrypted::U2FsdGVkX1+Ik/KXt1It8KHPX6z0L/PN2dAu1K6OknmchIF/m3axlsjBCV0FUPxW
 full-name: encrypted::U2FsdGVkX18n0VHkzzB3Slb9RvavGNSkjrJyAsmTmFw=

--- a/src/content/ecosystem-explorer/projects/ken-labs.md
+++ b/src/content/ecosystem-explorer/projects/ken-labs.md
@@ -14,7 +14,6 @@ tech:
   - ipfs
 year-joined: 2024-04-04T01:31:54.160Z
 seo:
-  title: Ken Labs
   description: Ken Labs offers decentralized solutions for blockchain
     infrastructure and services.
 email: encrypted::U2FsdGVkX18JbLgvvGne4VnNDJyu5+xj2wk76wIJtc3EZG7oKE0LzcxDwYQ56Pqi

--- a/src/content/ecosystem-explorer/projects/labdao.md
+++ b/src/content/ecosystem-explorer/projects/labdao.md
@@ -15,7 +15,6 @@ year-joined: 2024-03-29T21:28:53.071000Z
 subcategories:
   - decentralized-science
 seo:
-  title: LabDAO
   description:
     LabDAO provides decentralized science solutions for data management
     and collaboration.

--- a/src/content/ecosystem-explorer/projects/lagrange-dao.md
+++ b/src/content/ecosystem-explorer/projects/lagrange-dao.md
@@ -18,7 +18,6 @@ twitter: "https://twitter.com/lagrangedao"
 subcategories:
   - governance-daos-public-goods
 seo:
-  title: Lagrange DAO
   description:
     Lagrange DAO offers decentralized solutions for community management
     and governance.

--- a/src/content/ecosystem-explorer/projects/ledgermail.md
+++ b/src/content/ecosystem-explorer/projects/ledgermail.md
@@ -15,7 +15,6 @@ year-joined: 2024-03-29T21:28:53.257000Z
 subcategories:
   - wallets-identity-authentication
 seo:
-  title: LedgerMail
   description: LedgerMail provides decentralized email solutions for secure communication.
 email: encrypted::U2FsdGVkX18iOadodUmQTwBo3polIk4GmSp32kDDwIAPqQBZck15sx89IPPNzH/W
 full-name: encrypted::U2FsdGVkX19TrcL6isZ+zuUzL42c8EMZkHTm5aqnrkg=

--- a/src/content/ecosystem-explorer/projects/leto.md
+++ b/src/content/ecosystem-explorer/projects/leto.md
@@ -15,7 +15,6 @@ year-joined: 2024-04-05T23:01:19.950000Z
 subcategories:
   - data-storage-management
 seo:
-  title: Leto
   description: Leto offers decentralized solutions for data storage and management.
 email: encrypted::U2FsdGVkX18QGOOEY3JHr+/PSBmxUNnXl1zFTGdGW2K2NRqqEsJCKNZsGuYPcnRf
 full-name: encrypted::U2FsdGVkX1+hd/xy/g0wTtPVB1N1WRZT1yVgHDi/Glc=

--- a/src/content/ecosystem-explorer/projects/lighthouse.md
+++ b/src/content/ecosystem-explorer/projects/lighthouse.md
@@ -19,7 +19,6 @@ twitter: https://twitter.com/LighthouseWeb3
 subcategories:
   - data-storage-management
 seo:
-  title: Lighthouse
   description:
     Lighthouse provides decentralized storage solutions for personal and
     enterprise use.

--- a/src/content/ecosystem-explorer/projects/liquicert.md
+++ b/src/content/ecosystem-explorer/projects/liquicert.md
@@ -16,7 +16,6 @@ tech:
   - ipfs
 year-joined: 2024-03-22T16:24:25.092Z
 seo:
-  title: LiquiCert
   description: LiquiCert offers decentralized certification solutions for digital assets.
 email: encrypted::U2FsdGVkX1/J7h9OZWIEDNCBbmmLA8beq59PttsHOGJ6WyNMJCr5NplSfuQn4XbO
 full-name: encrypted::U2FsdGVkX1/DSh27t1E4U37QFncnm/6hhYfZpAOzl8Y=

--- a/src/content/ecosystem-explorer/projects/livepeer.md
+++ b/src/content/ecosystem-explorer/projects/livepeer.md
@@ -20,7 +20,6 @@ year-joined: 2024-01-19T18:26:58.022Z
 subcategories:
   - photo-video
 seo:
-  title: Livepeer
   description: Livepeer provides decentralized video streaming and transcoding services.
 email: encrypted::U2FsdGVkX1+7C08nY4YK4u/a3fURsuxiOoQoFXGv1Ba+1hYOa/YD1aMoViMg4Q/A
 full-name: encrypted::U2FsdGVkX1/HvNoHz+IX5eOXAO02Tlt3OcWfOVn1cDI=

--- a/src/content/ecosystem-explorer/projects/lotus.md
+++ b/src/content/ecosystem-explorer/projects/lotus.md
@@ -16,7 +16,6 @@ year-joined: 2020-10-15T19:36:51.302Z
 subcategories:
   - data-storage-management
 seo:
-  title: Lotus
   description: Lotus offers decentralized storage solutions for the Filecoin network.
 email: encrypted::U2FsdGVkX1+0nFRrm0E/HRSHmjCPB+ut+IUggsSmmWn5QlVhfyo6Oor9ifgbFfcU
 full-name: encrypted::U2FsdGVkX1+5Eq20D2NRXL4AwKBPPNqLdOMrNvdAOwA=

--- a/src/content/ecosystem-explorer/projects/lurk-lab.md
+++ b/src/content/ecosystem-explorer/projects/lurk-lab.md
@@ -19,7 +19,6 @@ tech:
 twitter: https://twitter.com/LurkLab
 year-joined: 2024-03-29T21:28:53.087Z
 seo:
-  title: Lurk Lab
   description: Lurk Lab provides decentralized solutions for data analysis and management.
 email: encrypted::U2FsdGVkX1+xuA6ZPpDARGzzk9jFFPpCCc2Alnhx0TwOC3clxY00qWWLI5aOt22U
 full-name: encrypted::U2FsdGVkX1+Tdtx7Jm8kDHk8onLIGPFnzmMcb2oZPkk=

--- a/src/content/ecosystem-explorer/projects/marlin-protocol.md
+++ b/src/content/ecosystem-explorer/projects/marlin-protocol.md
@@ -21,7 +21,6 @@ year-joined: 2023-12-01T15:08:38.544000Z
 subcategories:
   - infrastructure
 seo:
-  title: Marlin Protocol
   description: Marlin Protocol offers decentralized network infrastructure solutions.
 email: encrypted::U2FsdGVkX19cvqpd6PMdbZoCQpEBR4hKGVCU9Il9D2x9MouX0WKzhJFkcLSp2Rpd
 full-name: encrypted::U2FsdGVkX1+JB5xQJNnUo6/hwiOGRxm4g8Uzbe86sqw=

--- a/src/content/ecosystem-explorer/projects/merklebot.md
+++ b/src/content/ecosystem-explorer/projects/merklebot.md
@@ -19,7 +19,6 @@ year-joined: 2024-04-03T18:37:09.314000Z
 subcategories:
   - data-storage-management
 seo:
-  title: MerkleBot
   description: MerkleBot provides decentralized automation and data management solutions.
 email: encrypted::U2FsdGVkX18wMR0BisqthYUADNti5mCZK7bJXFPc1lRE3SQNrevI+FOo5tPiU/Bi
 full-name: encrypted::U2FsdGVkX1/GTa9gvOyRXXsigyn62kAbqe6LsswnxLo=

--- a/src/content/ecosystem-explorer/projects/metapals.md
+++ b/src/content/ecosystem-explorer/projects/metapals.md
@@ -17,7 +17,6 @@ year-joined: 2024-03-29T21:28:53.034000Z
 subcategories:
   - dapp
 seo:
-  title: MetaPals
   description: MetaPals offers decentralized solutions for social networking and collaboration.
 email: encrypted::U2FsdGVkX18wp4ly7Gm4cBQk9+0iAt96/fuFy/IjPcA62lvqUlEf8WdvgNcgivI+
 full-name: encrypted::U2FsdGVkX1+BcLuGvjcS1OYaoWUARwTFoRVj+loQKrc=

--- a/src/content/ecosystem-explorer/projects/mona.md
+++ b/src/content/ecosystem-explorer/projects/mona.md
@@ -16,7 +16,6 @@ tech:
 twitter: https://twitter.com/monaverse
 year-joined: 2024-03-29T21:28:53.652Z
 seo:
-  title: Mona
   description: Mona provides decentralized solutions for virtual worlds and digital assets.
 email: encrypted::U2FsdGVkX199/QcVuMBxGxIdJW23r8uSXehn4qu/nL76IB5eBSCgrZTVie4+aeWc
 full-name: encrypted::U2FsdGVkX1/c9YcWy1H4h1xw0PoxpokLAh44q1CkqZ0=

--- a/src/content/ecosystem-explorer/projects/mosaia.md
+++ b/src/content/ecosystem-explorer/projects/mosaia.md
@@ -15,7 +15,6 @@ year-joined: 2024-01-12T20:30:19.649Z
 subcategories:
   - data-storage-management
 seo:
-  title: Mosaia
   description: Mosaia offers decentralized solutions for data storage and management.
 email: encrypted::U2FsdGVkX18GQJ4innHIUuUL1cTYRb8J+wP6wFuKhX8rSChNVRktj5ZcDVGY9lHb
 full-name: encrypted::U2FsdGVkX18qYCbssakLTKHzLmPp6HY+xmlT6n0a6Bs=

--- a/src/content/ecosystem-explorer/projects/muckrock.md
+++ b/src/content/ecosystem-explorer/projects/muckrock.md
@@ -18,7 +18,6 @@ twitter: "https://twitter.com/MuckRock"
 subcategories:
   - dweb
 seo:
-  title: MuckRock
   description: MuckRock provides decentralized solutions for public records and transparency.
 email: encrypted::U2FsdGVkX1/M4EUDPR7JGFr/tGCgeSpZMG95MfAA3VkNkEX6Ri8f5FxqSBia97v0
 full-name: encrypted::U2FsdGVkX1/5eEJyLhChhwAqF+bzjIR2oGWvsRykquA=

--- a/src/content/ecosystem-explorer/projects/murmuration-labs.md
+++ b/src/content/ecosystem-explorer/projects/murmuration-labs.md
@@ -15,7 +15,6 @@ year-joined: 2024-03-29T21:28:53.260000Z
 subcategories:
   - data-storage-management
 seo:
-  title: Murmuration Labs
   description:
     Murmuration Labs offers decentralized solutions for data analysis and
     management.

--- a/src/content/ecosystem-explorer/projects/museum-of-crypto-art-m-c.md
+++ b/src/content/ecosystem-explorer/projects/museum-of-crypto-art-m-c.md
@@ -17,7 +17,6 @@ twitter: "https://twitter.com/MuseumofCrypto"
 subcategories:
   - arts-collectibles-nfts
 seo:
-  title: Museum of Crypto Art (M○C△)
   description:
     Museum of Crypto Art offers decentralized solutions for digital art
     and collectibles.

--- a/src/content/ecosystem-explorer/projects/nd-labs.md
+++ b/src/content/ecosystem-explorer/projects/nd-labs.md
@@ -17,7 +17,6 @@ year-joined: 2022-03-01T15:02:57.607000Z
 subcategories:
   - data-storage-management
 seo:
-  title: ND Labs
   description: ND Labs provides decentralized solutions for data storage and management.
 email: encrypted::U2FsdGVkX19aF+TR5qU+/vEq7+cSaLdXyZtE5YUqjnsji0cgqfu97Bk5f+fNYULF
 full-name: encrypted::U2FsdGVkX18f44ABIGpWuLd5IYjA63SQngUBa6lqsFc=

--- a/src/content/ecosystem-explorer/projects/nebula-block.md
+++ b/src/content/ecosystem-explorer/projects/nebula-block.md
@@ -19,7 +19,6 @@ year-joined: 2020-06-15T13:58:36.727000Z
 subcategories:
   - data-storage-management
 seo:
-  title: Nebula Block
   description: Nebula Block offers decentralized solutions for data storage and management.
 email: encrypted::U2FsdGVkX1+IMOu3LkLot6qnm2eTDmFl0Cy3Z6LtnD7oMks9nhZHSffG9CxX7ax0
 full-name: encrypted::U2FsdGVkX1+OB44vzZHYCVXI2ZPAFPD0BGrrbErBhmc=

--- a/src/content/ecosystem-explorer/projects/neyra-ai-from-wise-data-pte.md
+++ b/src/content/ecosystem-explorer/projects/neyra-ai-from-wise-data-pte.md
@@ -14,7 +14,6 @@ year-joined: 2023-11-01T18:39:58.216Z
 subcategories:
   - artificial-productivity-utilities
 seo:
-  title: Neyra AI from Wise Data PTE
   description:
     Neyra AI provides AI-driven solutions for decentralized data analysis
     and management.

--- a/src/content/ecosystem-explorer/projects/nft-storage.md
+++ b/src/content/ecosystem-explorer/projects/nft-storage.md
@@ -16,7 +16,6 @@ twitter: "https://twitter.com/nftdotstorage"
 subcategories:
   - data-storage-management
 seo:
-  title: NFT.Storage
   description: NFT.Storage offers decentralized storage solutions for NFT data.
 email: encrypted::U2FsdGVkX1/o50b/tIWu2FHfsZRbN4/CE8mVZmBjaojKOGYLVsafIaWsN5RQQvGv
 full-name: encrypted::U2FsdGVkX1/kb6jw5h7V/l9a/LI6eo1drmcprhIZ9ms=

--- a/src/content/ecosystem-explorer/projects/niftyguilds.md
+++ b/src/content/ecosystem-explorer/projects/niftyguilds.md
@@ -14,7 +14,6 @@ year-joined: 2024-03-29T21:28:53.605000Z
 subcategories:
   - arts-collectibles-nfts
 seo:
-  title: NiftyGuilds
   description:
     NiftyGuilds provides decentralized solutions for NFT communities and
     projects.

--- a/src/content/ecosystem-explorer/projects/ntent.md
+++ b/src/content/ecosystem-explorer/projects/ntent.md
@@ -17,7 +17,6 @@ twitter: "https://twitter.com/fluence_project"
 subcategories:
   - arts-collectibles-nfts
 seo:
-  title: NTENT
   description: NTENT offers decentralized solutions for digital art and collectibles.
 email: encrypted::U2FsdGVkX19YqEdzETvLgLKZftCusT0mK/8q3cYc7plUad71QQl2uiPqFn/sWkrE
 full-name: encrypted::U2FsdGVkX1+Sh5zhlFBzusuEvNOeD6oZOxD4m8ivz+A=

--- a/src/content/ecosystem-explorer/projects/nuklai.md
+++ b/src/content/ecosystem-explorer/projects/nuklai.md
@@ -18,7 +18,6 @@ repo: https://github.com/Nuklai
 twitter: https://x.com/NuklaiData
 year-joined: 2024-07-08T10:11:00.000Z
 seo:
-  title: "Nuklai: Empowering Innovation with Universal Data Access"
   description: Nuklai is a Web3 & AI-driven ecosystem enabling secure,
     collaborative, and monetizable private data networks for innovation and
     informed decision-making.

--- a/src/content/ecosystem-explorer/projects/nulink.md
+++ b/src/content/ecosystem-explorer/projects/nulink.md
@@ -16,7 +16,6 @@ year-joined: 2022-02-01T14:35:36.326000Z
 subcategories:
   - data-storage-management
 seo:
-  title: NuLink
   description: NuLink provides decentralized solutions for data privacy and security.
 email: encrypted::U2FsdGVkX19dyPoBkL5+cRQk45r0pLj+w+AlipnorwoJdLqzJaHw5L74yVokxglP
 full-name: encrypted::U2FsdGVkX18ko/0cR0NQ+BBmCuRuLJBXnCmDlBcxEKA=

--- a/src/content/ecosystem-explorer/projects/numbers-protocol.md
+++ b/src/content/ecosystem-explorer/projects/numbers-protocol.md
@@ -18,7 +18,6 @@ twitter: "https://twitter.com/numbersprotocol"
 subcategories:
   - wallets-identity-authentication
 seo:
-  title: Numbers Protocol
   description:
     Numbers Protocol offers decentralized solutions for digital asset verification
     and management.

--- a/src/content/ecosystem-explorer/projects/ocean-protocol.md
+++ b/src/content/ecosystem-explorer/projects/ocean-protocol.md
@@ -18,7 +18,6 @@ twitter: "https://twitter.com/oceanprotocol"
 subcategories:
   - data-storage-management
 seo:
-  title: Ocean Protocol
   description: Ocean Protocol provides decentralized data exchange solutions.
 email: encrypted::U2FsdGVkX18Crb/AqRAtk/DeYxTNmJu9WblBAyKmVnZ9LEuLIzEXv5pr1grcW5cE
 full-name: encrypted::U2FsdGVkX1/LX/8eGWGA4Dd4WVm1K5A15MbWdNXKhJ8=

--- a/src/content/ecosystem-explorer/projects/okcontract.md
+++ b/src/content/ecosystem-explorer/projects/okcontract.md
@@ -18,6 +18,5 @@ tech:
 repo: https://github.com/okcontract
 year-joined: 2022-09-11T14:47:28.444Z
 seo:
-  title: OkContract
   description: OkContract offers decentralized solutions for smart contract management.
 ---

--- a/src/content/ecosystem-explorer/projects/opengate.md
+++ b/src/content/ecosystem-explorer/projects/opengate.md
@@ -17,7 +17,6 @@ tech:
 twitter: https://twitter.com/OpenGateNFT
 year-joined: 2021-02-01T23:00:00.000Z
 seo:
-  title: OpenGate
   description: OpenGate provides decentralized solutions for data storage and management.
 ---
 

--- a/src/content/ecosystem-explorer/projects/opsci.md
+++ b/src/content/ecosystem-explorer/projects/opsci.md
@@ -20,7 +20,6 @@ tech:
 repo: https://github.com/opscientia
 twitter: https://twitter.com/opscientia
 seo:
-  title: Opsci
   description:
     Opsci offers decentralized solutions for scientific data management
     and collaboration.

--- a/src/content/ecosystem-explorer/projects/orbitvault.md
+++ b/src/content/ecosystem-explorer/projects/orbitvault.md
@@ -15,7 +15,6 @@ year-joined: 2024-03-07T14:09:03.780000Z
 subcategories:
   - data-storage-management
 seo:
-  title: OrbitVault
   description: OrbitVault provides decentralized storage solutions for digital assets.
 email: encrypted::U2FsdGVkX18OBtWWabjxXbR5dzDApRXiffrgCJz7OT1HwOib/Gkap0p4dd3ULVOA
 full-name: encrypted::U2FsdGVkX1+9LAqcDVE0lnVZjJ7E0V5mx25AGceIx50=

--- a/src/content/ecosystem-explorer/projects/parasail.md
+++ b/src/content/ecosystem-explorer/projects/parasail.md
@@ -15,7 +15,6 @@ year-joined: 2024-05-15T13:46:37.162000Z
 subcategories:
   - data-storage-management
 seo:
-  title: Parasail
   description: Parasail offers decentralized solutions for data storage and management.
 email: encrypted::U2FsdGVkX18eNzdUFYfmb1TrvmJp8ctt02G7y8EvoDH3lxF9RmT2VBkak4VpQSp5
 full-name: encrypted::U2FsdGVkX19BX2mHaU+8IdkY+XJWJn55k78InKk3Ytk=

--- a/src/content/ecosystem-explorer/projects/piknik.md
+++ b/src/content/ecosystem-explorer/projects/piknik.md
@@ -18,7 +18,6 @@ twitter: "https://twitter.com/PiKNiK_US"
 subcategories:
   - data-storage-management
 seo:
-  title: Piknik
   description: Piknik provides decentralized storage solutions for digital media.
 email: encrypted::U2FsdGVkX18LgQrzHxvVrDpXKmWR3z/HlwVCMavsbTPUAwf6sTd6CCQfLIYFToA6
 full-name: encrypted::U2FsdGVkX19mPGOKdsYEPoFX1TpYbv2mEEjQRrpgTYE=

--- a/src/content/ecosystem-explorer/projects/portrait.md
+++ b/src/content/ecosystem-explorer/projects/portrait.md
@@ -18,7 +18,6 @@ twitter: "https://twitter.com/portrait_gg"
 subcategories:
   - arts-collectibles-nfts
 seo:
-  title: Portrait
   description: Portrait offers decentralized solutions for digital art and collectibles.
 email: encrypted::U2FsdGVkX18vbGYF+gpIkqlHJrTU2svRzzPEssOkpdOD/FLX62+tW9u3VoPp1V1w
 full-name: encrypted::U2FsdGVkX18WztmSEoC4BnaYKXF/7Zh3x3o+3ZRhMjI=

--- a/src/content/ecosystem-explorer/projects/project-dokaz.md
+++ b/src/content/ecosystem-explorer/projects/project-dokaz.md
@@ -17,7 +17,6 @@ featured-content: "https://www.cnn.com/2022/06/10/tech/ukraine-war-crimes-blockc
 subcategories:
   - data-storage-management
 seo:
-  title: Project Dokaz
   description:
     Project Dokaz provides decentralized solutions for data verification
     and management.

--- a/src/content/ecosystem-explorer/projects/proofmode-by-guardian-project.md
+++ b/src/content/ecosystem-explorer/projects/proofmode-by-guardian-project.md
@@ -19,7 +19,6 @@ twitter: "https://twitter.com/guardianproject"
 subcategories:
   - data-storage-management
 seo:
-  title: ProofMode by Guardian Project
   description:
     ProofMode offers decentralized solutions for data verification and
     security.

--- a/src/content/ecosystem-explorer/projects/pyth-network.md
+++ b/src/content/ecosystem-explorer/projects/pyth-network.md
@@ -18,7 +18,6 @@ twitter: https://x.com/PythNetwork
 video-url: https://www.youtube.com/embed/7k5gh-1JT3c
 year-joined: 2024-04-16T20:04:49.437Z
 seo:
-  title: Pyth Network
   description: Pyth Network provides decentralized data oracle solutions for
     blockchain applications.
 email: encrypted::U2FsdGVkX1+U56Forn155XVBt6Jud47gcn77bscLvU+S2sHTxMpjFLPENeGXCW/d

--- a/src/content/ecosystem-explorer/projects/quest-chains.md
+++ b/src/content/ecosystem-explorer/projects/quest-chains.md
@@ -17,7 +17,6 @@ year-joined: 2024-03-29T21:28:54.146000Z
 subcategories:
   - dapp
 seo:
-  title: Quest Chains
   description:
     Quest Chains offers decentralized solutions for task management and
     collaboration.

--- a/src/content/ecosystem-explorer/projects/quicknode.md
+++ b/src/content/ecosystem-explorer/projects/quicknode.md
@@ -15,7 +15,6 @@ year-joined: 2024-03-29T21:28:54.885000Z
 subcategories:
   - infrastructure
 seo:
-  title: QuickNode
   description:
     QuickNode provides decentralized solutions for blockchain infrastructure
     and services.

--- a/src/content/ecosystem-explorer/projects/renderhive.md
+++ b/src/content/ecosystem-explorer/projects/renderhive.md
@@ -18,7 +18,6 @@ tech:
 twitter: https://twitter.com/renderhive
 year-joined: 2024-03-29T21:28:53.783Z
 seo:
-  title: RenderHive
   description: RenderHive offers decentralized solutions for rendering and
     processing digital media.
 ---

--- a/src/content/ecosystem-explorer/projects/repl.md
+++ b/src/content/ecosystem-explorer/projects/repl.md
@@ -17,7 +17,6 @@ twitter: "https://twitter.com/Repl_fi"
 subcategories:
   - data-storage-management
 seo:
-  title: Repl
   description:
     Repl provides decentralized solutions for data replication and storage
     management.

--- a/src/content/ecosystem-explorer/projects/reppo.md
+++ b/src/content/ecosystem-explorer/projects/reppo.md
@@ -17,7 +17,6 @@ repo: https://github.com/ReppoLabs
 twitter: https://twitter.com/Repponetwork
 year-joined: 2024-04-24T19:06:44.078Z
 seo:
-  title: Reppo
   description: Reppo offers decentralized solutions for data storage and management.
 email: encrypted::U2FsdGVkX1+vbZTfSrIjxWGTBcFnO449/B0+E3IqDJfPenTlZZJr0GoNKnJ6BCA9
 full-name: encrypted::U2FsdGVkX1/j1FtObc+tG5Hkmc02Vh3nItmF/du+6hE=

--- a/src/content/ecosystem-explorer/projects/seal-storage.md
+++ b/src/content/ecosystem-explorer/projects/seal-storage.md
@@ -18,7 +18,6 @@ featured-content: "https://fil.org/blog/case-study-seal-storage-making-web3-acce
 subcategories:
   - data-storage-management
 seo:
-  title: Seal Storage
   description: Seal Storage provides decentralized storage solutions for enterprises.
 email: encrypted::U2FsdGVkX1/QGWr0qycz70IjHfApBCTG/G6f78FuKNWuBo4viqOHamBCTlHX+sp9
 full-name: encrypted::U2FsdGVkX1+AxhJEj4cMJa8Le5xKd83qMwDHtZAXZx4=

--- a/src/content/ecosystem-explorer/projects/secured-finance.md
+++ b/src/content/ecosystem-explorer/projects/secured-finance.md
@@ -17,7 +17,6 @@ tech:
 twitter: https://twitter.com/Secured_Fi
 year-joined: 2024-03-29T21:28:54.282Z
 seo:
-  title: Secured Finance
   description: Secured Finance offers decentralized finance solutions for secure
     transactions.
 ---

--- a/src/content/ecosystem-explorer/projects/seti-institute.md
+++ b/src/content/ecosystem-explorer/projects/seti-institute.md
@@ -19,7 +19,6 @@ featured-content: "https://destor.com/seti"
 subcategories:
   - decentralized-science
 seo:
-  title: SETI Institute
   description:
     SETI Institute provides decentralized solutions for scientific data
     management and analysis.

--- a/src/content/ecosystem-explorer/projects/sft-chain.md
+++ b/src/content/ecosystem-explorer/projects/sft-chain.md
@@ -19,7 +19,6 @@ year-joined:
 subcategories:
   - infrastructure
 seo:
-  title: SFT Chain
   description:
     SFT Chain offers decentralized solutions for supply chain management
     and tracking.

--- a/src/content/ecosystem-explorer/projects/sinso.md
+++ b/src/content/ecosystem-explorer/projects/sinso.md
@@ -18,7 +18,6 @@ twitter: "https://twitter.com/sinsonetwork"
 subcategories:
   - health
 seo:
-  title: Sinso
   description:
     Sinso provides decentralized storage solutions for healthcare data
     management.

--- a/src/content/ecosystem-explorer/projects/solmedia.md
+++ b/src/content/ecosystem-explorer/projects/solmedia.md
@@ -16,7 +16,6 @@ tech:
 twitter: https://x.com/SolMediaTech
 year-joined: 2024-04-25T17:21:06.512Z
 seo:
-  title: SolMedia
   description:
     SolMedia provides decentralized solutions for digital media storage
     and management.

--- a/src/content/ecosystem-explorer/projects/spex.md
+++ b/src/content/ecosystem-explorer/projects/spex.md
@@ -15,7 +15,6 @@ year-joined: 2024-03-29T21:28:54.676000Z
 subcategories:
   - data-storage-management
 seo:
-  title: Spex
   description: Spex offers decentralized solutions for data storage and management.
 email: encrypted::U2FsdGVkX19BXykXtHf3mfwwPo+lHlbDy+NKwEa2CAq9ueZkiKhYKhGjyt8fzTF6
 full-name: encrypted::U2FsdGVkX1+ellAe4XyTs8uE3U2NPcjYPo2yRhi2jl4=

--- a/src/content/ecosystem-explorer/projects/starboard.md
+++ b/src/content/ecosystem-explorer/projects/starboard.md
@@ -18,7 +18,6 @@ twitter: "https://twitter.com/starboard_v"
 subcategories:
   - data-storage-management
 seo:
-  title: Starboard
   description: Starboard provides decentralized solutions for data analysis and management.
 email: encrypted::U2FsdGVkX18olSZoHycfv3kh6mZO/Wi7j01HF3kc27W69epSa4hSQyr/9BAWMhvH
 full-name: encrypted::U2FsdGVkX1+yUtcJnEcIhMk53OCq3FEFnDC8sAqWrqU=

--- a/src/content/ecosystem-explorer/projects/starchain.md
+++ b/src/content/ecosystem-explorer/projects/starchain.md
@@ -18,7 +18,6 @@ tech:
 year-joined: 2020-12-31T23:00:00.000Z
 twitter: https://twitter.com/starchaindev
 seo:
-  title: StarChain
   description: StarChain leverages Filecoin and IPFS to build a decentralized repository of scientific data where every researcher can freely share their datasets.
 ---
 

--- a/src/content/ecosystem-explorer/projects/starling-lab.md
+++ b/src/content/ecosystem-explorer/projects/starling-lab.md
@@ -19,7 +19,6 @@ repo: "https://github.com/filecoin-project/starling"
 subcategories:
   - data-storage-management
 seo:
-  title: Starling Lab
   description:
     Starling Lab offers decentralized solutions for digital archiving and
     preservation.

--- a/src/content/ecosystem-explorer/projects/stfil.md
+++ b/src/content/ecosystem-explorer/projects/stfil.md
@@ -17,7 +17,6 @@ repo: "https://github.com/stfil-io"
 twitter: "https://twitter.com/stfil_io"
 year-joined: 2024-01-17T14:55:43.749Z
 seo:
-  title: StFIL
   description:
     StFIL provides decentralized finance solutions for staking and yield
     generation.

--- a/src/content/ecosystem-explorer/projects/supranational.md
+++ b/src/content/ecosystem-explorer/projects/supranational.md
@@ -21,7 +21,6 @@ year-joined: 2024-01-11T13:26:59.787Z
 subcategories:
   - data-storage-management
 seo:
-  title: Supranational
   description:
     Supranational offers decentralized solutions for data security and
     cryptography.

--- a/src/content/ecosystem-explorer/projects/swan.md
+++ b/src/content/ecosystem-explorer/projects/swan.md
@@ -16,7 +16,6 @@ year-joined: 2024-01-11T13:26:59.787Z
 subcategories:
   - data-storage-management
 seo:
-  title: Swan
   description: Swan provides decentralized storage solutions for digital assets.
 email: encrypted::U2FsdGVkX1+nd+tkEgibXUU5gK4xyn+f/AcM/GgJToJG4sXesUUFrJc+GuiO5wg8
 full-name: encrypted::U2FsdGVkX1+BhJbsirg0bs3FYJWI+igkfph70tUWOLQ=

--- a/src/content/ecosystem-explorer/projects/tableland.md
+++ b/src/content/ecosystem-explorer/projects/tableland.md
@@ -19,7 +19,6 @@ twitter: "https://twitter.com/tableland"
 subcategories:
   - developer-tools
 seo:
-  title: Tableland
   description: Tableland offers decentralized database solutions for web3 applications.
 email: encrypted::U2FsdGVkX1/DeOaPm+YW7ukLKG8kFNlbgKOXob8Dtwx5MDmvJJw0OpOIUEtRHFbR
 full-name: encrypted::U2FsdGVkX1/KK8cFJO4UrIZ25f3tJnYp+LJioSgmxuM=

--- a/src/content/ecosystem-explorer/projects/tellor.md
+++ b/src/content/ecosystem-explorer/projects/tellor.md
@@ -15,7 +15,6 @@ year-joined: 2024-03-29T21:28:55.457000Z
 subcategories:
   - bridges-oracles
 seo:
-  title: Tellor
   description:
     Tellor provides decentralized data oracle solutions for blockchain
     applications.

--- a/src/content/ecosystem-explorer/projects/third-storage.md
+++ b/src/content/ecosystem-explorer/projects/third-storage.md
@@ -17,7 +17,6 @@ year-joined: 2024-03-29T21:28:55.910000Z
 subcategories:
   - data-storage-management
 seo:
-  title: Third Storage
   description:
     Third Storage provides decentralized storage solutions for digital
     data.

--- a/src/content/ecosystem-explorer/projects/titan-network.md
+++ b/src/content/ecosystem-explorer/projects/titan-network.md
@@ -20,7 +20,6 @@ year-joined: 2024-01-11T13:26:59.787Z
 subcategories:
   - infrastructure
 seo:
-  title: Titan Network
   description: Titan Network offers decentralized solutions for blockchain infrastructure.
 email: encrypted::U2FsdGVkX19sf+hxz6eg44v03StOEchjqiUonXPGpP7iLIzY5lIqXsmMdBSDOJoW
 full-name: encrypted::U2FsdGVkX1+UIXHL7nrSIX2MMgl0/SUDQzRBMU0AVAs=

--- a/src/content/ecosystem-explorer/projects/titan-storage.md
+++ b/src/content/ecosystem-explorer/projects/titan-storage.md
@@ -18,7 +18,6 @@ year-joined: 2023-04-01T13:04:49.683000Z
 subcategories:
   - data-storage-management
 seo:
-  title: Titan Storage
   description: Titan Storage provides decentralized storage solutions for enterprises.
 email: encrypted::U2FsdGVkX18mBGoTqKE0ibTQqDFTjVyE3Zo5Sv7GBqymDcIiKguyaaBn6rK6rcwO
 full-name: encrypted::U2FsdGVkX18pmF5P9gAtexmyRtnQclIVpiHOn43ilNY=

--- a/src/content/ecosystem-explorer/projects/transfer-data-trust.md
+++ b/src/content/ecosystem-explorer/projects/transfer-data-trust.md
@@ -20,7 +20,6 @@ featured-content: "https://fil.org/blog/ecosystem-spotlight-transfer-q-a-on-pres
 subcategories:
   - data-storage-management
 seo:
-  title: Transfer Data Trust
   description:
     Transfer Data Trust offers decentralized solutions for data transfer
     and security.

--- a/src/content/ecosystem-explorer/projects/tres-finance.md
+++ b/src/content/ecosystem-explorer/projects/tres-finance.md
@@ -19,7 +19,6 @@ twitter: https://twitter.com/TresDotFinance
 video-url: https://www.youtube.com/embed/4YHdkICYvJc
 year-joined: 2024-01-12T20:09:29.935Z
 seo:
-  title: Tres Finance
   description: Tres Finance provides decentralized finance solutions for secure
     transactions.
 ---

--- a/src/content/ecosystem-explorer/projects/twin-quasar.md
+++ b/src/content/ecosystem-explorer/projects/twin-quasar.md
@@ -18,7 +18,6 @@ tech:
   - ipfs
 featured-content: https://fil.org/blog/storage-spotlight-how-twin-quasar-and-celeste-are-bringing-green-data-hosting-to-european-data-storage-clients/
 seo:
-  title: Twin Quasar
   description:
     Twin Quasar offers decentralized storage solutions for data hosting
     and management.

--- a/src/content/ecosystem-explorer/projects/uc-berkeley-underground-physics-group.md
+++ b/src/content/ecosystem-explorer/projects/uc-berkeley-underground-physics-group.md
@@ -18,7 +18,6 @@ tech:
   - ipfs
 featured-content: https://physics.berkeley.edu/news-events/news/seal-storage-technology-partners-with-orebi-gann-group
 seo:
-  title: UC Berkeley Underground Physics Group
   description: UC Berkeley Underground Physics Group provides decentralized
     solutions for scientific data management.
 ---

--- a/src/content/ecosystem-explorer/projects/university-of-utah.md
+++ b/src/content/ecosystem-explorer/projects/university-of-utah.md
@@ -19,7 +19,6 @@ tech:
   - ipfs
 featured-content: https://www.sealstorage.io/blog/utah#:~:text=The%20University%20of%20Utah%20is,of%20Seal's%20underlying%20network%2C%20Filecoin
 seo:
-  title: University of Utah
   description:
     University of Utah offers decentralized solutions for academic data
     management and research.

--- a/src/content/ecosystem-explorer/projects/victor-chang-research-institute.md
+++ b/src/content/ecosystem-explorer/projects/victor-chang-research-institute.md
@@ -20,7 +20,6 @@ twitter: "https://twitter.com/VictorChangInst"
 subcategories:
   - health
 seo:
-  title: Victor Chang Research Institute
   description:
     Victor Chang Research Institute provides decentralized solutions for
     healthcare data management.

--- a/src/content/ecosystem-explorer/projects/vsharecloud.md
+++ b/src/content/ecosystem-explorer/projects/vsharecloud.md
@@ -16,7 +16,6 @@ tech:
 repo: https://github.com/vshareCloud-Project/
 year-joined: 2024-04-05T14:14:29.953Z
 seo:
-  title: VshareCloud
   description: VshareCloud offers decentralized storage solutions for digital data.
 email: encrypted::U2FsdGVkX1/SgKq2RNa3F0b3RtGj9CJUNrSazEHq9vrsmbzzc++SHrimTTpUxQxD
 full-name: encrypted::U2FsdGVkX1/qS71FFS7mIt8hPxj2JGv56UXzizkeYR0=

--- a/src/content/ecosystem-explorer/projects/waterlily-ai.md
+++ b/src/content/ecosystem-explorer/projects/waterlily-ai.md
@@ -22,7 +22,6 @@ year-joined: 2023-04-25T22:00:00.000Z
 subcategories:
   - artificial-productivity-utilities
 seo:
-  title: Waterlily AI
   description:
     Waterlily AI provides AI-driven solutions for decentralized data analysis
     and management.

--- a/src/content/ecosystem-explorer/projects/weatherxm.md
+++ b/src/content/ecosystem-explorer/projects/weatherxm.md
@@ -16,7 +16,6 @@ video-url: "https://www.youtube.com/embed/w7_wLlA6n8I"
 subcategories:
   - data-storage-management
 seo:
-  title: WeatherXM
   description:
     WeatherXM offers decentralized solutions for weather data collection
     and analysis.

--- a/src/content/ecosystem-explorer/projects/web3-storage.md
+++ b/src/content/ecosystem-explorer/projects/web3-storage.md
@@ -18,7 +18,6 @@ twitter: "https://twitter.com/Web3Storage"
 subcategories:
   - data-storage-management
 seo:
-  title: Web3.Storage
   description: Web3.Storage provides decentralized storage solutions for web3 applications.
 email: encrypted::U2FsdGVkX19wPgEdr3NkCBu9nXZWlRzKaz5JV6XV2SyNhQc2D35WehvlPwT1RLQ2
 full-name: encrypted::U2FsdGVkX1+NhbJ2THSirApAikiAqrmZ0Doi9RHik/E=

--- a/src/content/ecosystem-explorer/projects/web3mine.md
+++ b/src/content/ecosystem-explorer/projects/web3mine.md
@@ -15,7 +15,6 @@ year-joined: 2024-03-29T21:28:55.160000Z
 subcategories:
   - data-storage-management
 seo:
-  title: Web3Mine
   description: Web3Mine offers decentralized solutions for data storage and management.
 email: encrypted::U2FsdGVkX18fsr3rAmo2KFBvNvkGxQZKcKWdiE+u75dkpveFxwoVbCbq2m/ARduI
 full-name: encrypted::U2FsdGVkX190md8mih0cBULIYgCJmdI0L6dN1E6bn6Q=

--- a/src/content/ecosystem-explorer/projects/xbanking.md
+++ b/src/content/ecosystem-explorer/projects/xbanking.md
@@ -20,7 +20,6 @@ twitter: https://twitter.com/TresDotFinance
 video-url: https://www.youtube.com/embed/4YHdkICYvJc
 year-joined: 2024-01-12T20:27:39.394Z
 seo:
-  title: XBanking
   description: XBanking provides decentralized finance solutions for secure transactions.
 ---
 

--- a/src/content/ecosystem-explorer/projects/zondax.md
+++ b/src/content/ecosystem-explorer/projects/zondax.md
@@ -18,7 +18,6 @@ twitter: "https://twitter.com/_zondax_"
 subcategories:
   - infrastructure
 seo:
-  title: Zondax
   description:
     Zondax provides decentralized solutions for blockchain infrastructure
     and services.

--- a/src/content/events/agi-cryptography-security-multipolar-scenarios-workshop.md
+++ b/src/content/events/agi-cryptography-security-multipolar-scenarios-workshop.md
@@ -12,7 +12,6 @@ end-date: 2024-05-15T15:48:19.530Z
 image:
   src: /assets/images/foresight.svg
 seo:
-  title: AGI Cryptography Security Multipolar Scenarios Workshop
   description: Join the AGI Cryptography Security Workshop to explore multipolar
     scenarios in cryptography and security.
 ---

--- a/src/content/events/april-2021-notary-governance-meeting.md
+++ b/src/content/events/april-2021-notary-governance-meeting.md
@@ -11,7 +11,6 @@ start-date: 2021-04-12T22:00:00.000Z
 image:
   src: /assets/images/governance-logo.jpg
 seo:
-  title: April 2021 Notary Governance Meeting
   description:
     Participate in the April 2021 Notary Governance Meeting to discuss
     Filecoin governance issues.

--- a/src/content/events/asia-hackathon-season-2021.md
+++ b/src/content/events/asia-hackathon-season-2021.md
@@ -8,7 +8,6 @@ location: Virtual
 start-date: 2021-07-31T22:00:00.000Z
 end-date: 2021-10-30T22:00:00.000Z
 seo:
-  title: Asia Hackathon Season 2021
   description: Join the Asia Hackathon Season 2021 to showcase your skills and
     innovations in blockchain technology.
 ---

--- a/src/content/events/consensus-filecoin-orbit-event.md
+++ b/src/content/events/consensus-filecoin-orbit-event.md
@@ -14,7 +14,6 @@ end-date: 2024-05-30T17:00:00.000Z
 image:
   src: /assets/images/consensus-2024.png
 seo:
-  title: Consensus Filecoin Orbit Event
   description: Attend the Consensus Filecoin Orbit Event to connect with the
     Filecoin community and learn the latest updates.
 ---

--- a/src/content/events/decentralized-web-gateway-davos.md
+++ b/src/content/events/decentralized-web-gateway-davos.md
@@ -14,7 +14,6 @@ start-date: 2022-05-22T12:00:00.000Z
 image:
   src: /assets/images/64521829e09e4e566257e24c_dweb-gateway-davos.jpg
 seo:
-  title: Decentralized Web Gateway Davos
   description: Explore the Decentralized Web Gateway at Davos and discover the
     future of decentralized technologies.
 ---

--- a/src/content/events/decentralized-web-gateway-sxsw.md
+++ b/src/content/events/decentralized-web-gateway-sxsw.md
@@ -15,7 +15,6 @@ start-date: 2022-03-15T07:23:50.000Z
 image:
   src: /assets/images/64521857e09e4edc0d57e6df_dweb-gateway-sxsw.jpg
 seo:
-  title: Decentralized Web Gateway SXSW
   description: Join the Decentralized Web Gateway at SXSW to explore the
     innovations in decentralized web technologies.
 ---

--- a/src/content/events/destorhk.md
+++ b/src/content/events/destorhk.md
@@ -19,7 +19,6 @@ start-date: 2023-04-15T15:30:53.222Z
 image:
   src: /assets/images/destore-hk-2023.png
 seo:
-  title: DeStorHK
   description:
     Participate in DeStorHK to explore decentralized storage solutions
     and network with industry experts.

--- a/src/content/events/dweb-camp-1.md
+++ b/src/content/events/dweb-camp-1.md
@@ -12,7 +12,6 @@ end-date: 2023-06-25T15:30:55.996Z
 image:
   src: /assets/images/dweb-camp.png
 seo:
-  title: DWeb Camp 2023
   description: Join DWeb Camp 2023 to learn about the decentralized web and
     collaborate with like-minded individuals.
 ---

--- a/src/content/events/dweb-camp-2024.md
+++ b/src/content/events/dweb-camp-2024.md
@@ -12,7 +12,6 @@ end-date: 2024-08-11T14:55:19.882Z
 image:
   src: /assets/images/dweb-camp24.png
 seo:
-  title: DWeb Camp 2024
   description:
     Attend DWeb Camp 2024 to engage in workshops, talks, and activities
     focused on the decentralized web.

--- a/src/content/events/dweb-camp.md
+++ b/src/content/events/dweb-camp.md
@@ -12,7 +12,6 @@ end-date: 2022-08-22T11:30:00.000Z
 image:
   src: /assets/images/dweb-camp.png
 seo:
-  title: DWeb Camp 2022
   description:
     Explore the decentralized web at DWeb Camp 2022 through workshops,
     discussions, and collaborative activities.

--- a/src/content/events/espa-bootcamp-cohort-4.md
+++ b/src/content/events/espa-bootcamp-cohort-4.md
@@ -1,5 +1,5 @@
 ---
-title: "ESPA Bootcamp Cohort #4"
+title: "ESPA Bootcamp Cohort 4"
 created-on: 2023-05-03T08:05:59.380Z
 updated-on: 2023-05-03T08:05:59.380Z
 published-on: 2023-05-03T08:22:38.798Z
@@ -12,7 +12,6 @@ end-date: 2022-10-13T00:00:00.000Z
 image:
   src: /assets/images/645215e7b97133359d88d3a0_177648477-ed976b8e-ae0d-4f18-8d91-2d8512d3fb54_hua7fa79449114663eebf6af324bdad7a2_1514667_1333x0_resize_q90_linear_2.png
 seo:
-  title: ESPA Bootcamp Cohort 4
   description: Participate in ESPA Bootcamp Cohort 4 to develop your skills in
     blockchain technology and entrepreneurship.
 ---

--- a/src/content/events/eth-denver-filecoin-booth-filecoin-orbit-event.md
+++ b/src/content/events/eth-denver-filecoin-booth-filecoin-orbit-event.md
@@ -12,7 +12,6 @@ end-date: 2024-03-03T15:38:54.840Z
 image:
   src: /assets/images/ethdenver24.png
 seo:
-  title: ETH Denver Filecoin Booth & Filecoin Orbit Event
   description: Join us at ETH Denver for the Filecoin Booth and Filecoin Orbit
     Event to connect with the community.
 ---

--- a/src/content/events/ethcc-5.md
+++ b/src/content/events/ethcc-5.md
@@ -12,7 +12,6 @@ end-date: 2022-07-21T00:00:00.000Z
 image:
   src: /assets/images/645215ed18e20de7428046f6_ethcc.png
 seo:
-  title: ETHCC 5
   description: Join us at ETHCC 5 to learn about the latest advancements in
     Ethereum and connect with the blockchain community.
 ---

--- a/src/content/events/ethcc-filecoin-booth.md
+++ b/src/content/events/ethcc-filecoin-booth.md
@@ -10,7 +10,6 @@ end-date: 2024-07-11T14:51:57.409Z
 image:
   src: /assets/images/ethcc-24.png
 seo:
-  title: ETHCC Filecoin Booth
   description: Visit the Filecoin Booth at ETHCC to discover the latest updates
     and innovations in Filecoin.
 ---

--- a/src/content/events/ethdenver.md
+++ b/src/content/events/ethdenver.md
@@ -9,7 +9,6 @@ start-date: 2022-02-11T06:57:49.000Z
 image:
   src: /assets/images/645215f9a2b74616855546de_ethdenver.png
 seo:
-  title: ETHDenver
   description:
     Participate in ETHDenver to engage with the Ethereum community and
     explore the latest blockchain innovations.

--- a/src/content/events/ethereal-2021.md
+++ b/src/content/events/ethereal-2021.md
@@ -11,7 +11,6 @@ start-date: 2021-05-05T22:00:00.000Z
 image:
   src: /assets/images/64521600a359ff88f536ffc5_ethereal-2021.png
 seo:
-  title: Ethereal 2021
   description:
     Join Ethereal 2021 to explore the intersection of blockchain, art,
     and technology.

--- a/src/content/events/ethereal-2022.md
+++ b/src/content/events/ethereal-2022.md
@@ -11,7 +11,6 @@ start-date: 2022-02-26T16:00:00.000Z
 image:
   src: /assets/images/645215f7455b5b63d0f5b5e8_marta-snowden.png
 seo:
-  title: Ethereal 2022
   description: Attend Ethereal 2022 to engage with the blockchain community and
     explore innovative technologies.
 ---

--- a/src/content/events/fil-austin.md
+++ b/src/content/events/fil-austin.md
@@ -11,7 +11,6 @@ start-date: 2022-06-08T18:35:00.000Z
 image:
   src: /assets/images/645218c34b08773d70df834b_fil-austin.jpg
 seo:
-  title: FIL Austin
   description: Join FIL Austin to connect with the Filecoin community and learn
     about the latest developments.
 ---

--- a/src/content/events/fil-bangalore.md
+++ b/src/content/events/fil-bangalore.md
@@ -12,7 +12,6 @@ end-date: 2022-11-30T16:50:00.000Z
 image:
   src: /assets/images/fil-bangalore-2022.png
 seo:
-  title: FIL Bangalore
   description:
     Participate in FIL Bangalore to network with the Filecoin community
     and explore new opportunities.

--- a/src/content/events/fil-bangkok-2024.md
+++ b/src/content/events/fil-bangkok-2024.md
@@ -311,7 +311,6 @@ sponsors:
       image:
         src: /assets/images/long_white.webp
 seo:
-  title: FIL Bangkok 2024
   description: Join the Filecoin Community in Bangkok for discussions on
     decentralized AI, DePIN, and the data economy. Network, hear major
     announcements, and shape the future of Filecoin ahead of Devcon.

--- a/src/content/events/fil-brussels.md
+++ b/src/content/events/fil-brussels.md
@@ -18,7 +18,6 @@ external-link:
 image:
   src: /assets/images/filbrussels.webp
 seo:
-  title: FIL Brussels
   description: Join FIL Brussels to connect with the Filecoin community and
     explore new developments.
 ---

--- a/src/content/events/fil-capetown.md
+++ b/src/content/events/fil-capetown.md
@@ -11,7 +11,6 @@ start-date: 2023-11-21T13:58:58.117Z
 image:
   src: /assets/images/filcapetown.png
 seo:
-  title: FIL Capetown
   description:
     Participate in FIL Capetown to network with the Filecoin community
     and learn about the latest updates.

--- a/src/content/events/fil-dev-summit-1.md
+++ b/src/content/events/fil-dev-summit-1.md
@@ -12,7 +12,6 @@ end-date: 2023-09-14T15:46:33.644Z
 image:
   src: /assets/images/fil-dev-summit.png
 seo:
-  title: FIL Dev Summit Singapore
   description: Join the FIL Dev Summit Singapore to collaborate with developers
     and explore the latest in Filecoin technology.
 ---

--- a/src/content/events/fil-dev-summit-singapore.md
+++ b/src/content/events/fil-dev-summit-singapore.md
@@ -11,7 +11,6 @@ start-date: 2023-09-25T14:00:04.428Z
 image:
   src: /assets/images/fil-dev-summit.png
 seo:
-  title: FIL Dev Summit Iceland
   description:
     Join the FIL Dev Summit Iceland to collaborate with developers and
     explore the latest in Filecoin technology.

--- a/src/content/events/fil-hong-kong-hosted-by-ndlabs.md
+++ b/src/content/events/fil-hong-kong-hosted-by-ndlabs.md
@@ -10,7 +10,6 @@ end-date: 2024-04-08T14:42:24.941Z
 image:
   src: /assets/images/filhk24.png
 seo:
-  title: FIL Hong Kong Hosted by NDLabs
   description: Attend FIL Hong Kong hosted by NDLabs to engage with the Filecoin
     community and discover new developments.
 ---

--- a/src/content/events/fil-hong-kong.md
+++ b/src/content/events/fil-hong-kong.md
@@ -11,7 +11,6 @@ end-date: 2023-04-15T15:30:53.477Z
 image:
   src: /assets/images/fil-hong-kong.png
 seo:
-  title: FIL Hong Kong 2023
   description:
     Join FIL Hong Kong 2023 to connect with the Filecoin community and
     explore the latest innovations.

--- a/src/content/events/fil-jakarta.md
+++ b/src/content/events/fil-jakarta.md
@@ -9,7 +9,6 @@ start-date: 2023-09-02T11:00:23.071Z
 image:
   src: /assets/images/fil-jakarta.png
 seo:
-  title: "FIL Jakarta"
   description: Participate in FIL Jakarta to network with the Filecoin community
     and discover new opportunities.
 ---

--- a/src/content/events/fil-lisbon.md
+++ b/src/content/events/fil-lisbon.md
@@ -12,7 +12,6 @@ end-date: 2022-11-04T00:00:00.000Z
 image:
   src: /assets/images/645217c53763d71fa57e55a0_fil-lisbon.jpg
 seo:
-  title: FIL Lisbon
   description: Attend FIL Lisbon to engage with the Filecoin community and learn
     about the latest developments.
 ---

--- a/src/content/events/fil-paris.md
+++ b/src/content/events/fil-paris.md
@@ -10,7 +10,6 @@ end-date: 2023-07-22T15:38:00.000Z
 image:
   src: /assets/images/fil-paris-pic.png
 seo:
-  title: FIL Paris
   description: Join FIL Paris to connect with the Filecoin community and explore
     the latest innovations.
 ---

--- a/src/content/events/fil-seoul-network-base-1.md
+++ b/src/content/events/fil-seoul-network-base-1.md
@@ -10,7 +10,6 @@ end-date: 2023-09-07T07:06:47.832Z
 image:
   src: /assets/images/fil-seoul-bg.png
 seo:
-  title: "FIL Seoul Network Base"
   description:
     Participate in FIL Seoul Network Base to network with the Filecoin
     community and discover new opportunities.

--- a/src/content/events/fil-singapore-alongside-token2049-2024.md
+++ b/src/content/events/fil-singapore-alongside-token2049-2024.md
@@ -14,7 +14,6 @@ external-link:
 image:
   src: /assets/images/fil-singapore-24.webp
 seo:
-  title: FIL Singapore 2024
   description: "Join FILSG: Web3 Wonderland at 1-Arden with stunning Singapore
     views. Discover top Web3 and AI innovations alongside TOKEN2049."
 ---

--- a/src/content/events/fil-singapore.md
+++ b/src/content/events/fil-singapore.md
@@ -10,7 +10,6 @@ end-date: 2022-09-26T00:00:00.000Z
 image:
   src: /assets/images/645218e87f5430741f6d9bd6_fil-singapore.jpg
 seo:
-  title: FIL Singapore
   description:
     Participate in FIL Singapore to network with the Filecoin community
     and discover new opportunities.

--- a/src/content/events/fil-vegas.md
+++ b/src/content/events/fil-vegas.md
@@ -12,7 +12,6 @@ end-date: 2023-10-05T17:09:07.051Z
 image:
   src: /assets/images/fil-vegas-event-header.png
 seo:
-  title: FIL Vegas
   description: Attend FIL Vegas to engage with the Filecoin community and learn
     about the latest developments.
 ---

--- a/src/content/events/filecoin-club.md
+++ b/src/content/events/filecoin-club.md
@@ -14,7 +14,6 @@ image:
   src: /assets/images/64521608455b5bc68cf5c6fa_filecoin-club.png
 category: supported-sponsored
 seo:
-  title: Filecoin Club
   description:
     Join the Filecoin Club to connect with enthusiasts and explore the
     latest in Filecoin.

--- a/src/content/events/filecoin-day.md
+++ b/src/content/events/filecoin-day.md
@@ -12,7 +12,6 @@ end-date: 2023-11-14T18:30:36.580Z
 image:
   src: /assets/images/signal-2023-11-12-145615_002.jpeg
 seo:
-  title: Filecoin Day
   description: Celebrate Filecoin Day and learn about the latest updates and
     innovations in the Filecoin ecosystem.
 ---

--- a/src/content/events/filecoin-grant-global-online-hackathon.md
+++ b/src/content/events/filecoin-grant-global-online-hackathon.md
@@ -10,7 +10,6 @@ external-link:
 start-date: 2021-04-30T22:00:00.000Z
 end-date: 2021-07-17T22:00:00.000Z
 seo:
-  title: Filecoin Grant Global Online Hackathon
   description: Participate in the Filecoin Grant Global Online Hackathon to
     showcase your skills and win grants.
 ---

--- a/src/content/events/filecoin-network-base.md
+++ b/src/content/events/filecoin-network-base.md
@@ -10,7 +10,6 @@ end-date: 2023-04-26T15:46:15.151Z
 image:
   src: /assets/images/network-base-austin-2023-pic.png
 seo:
-  title: Filecoin Network Base
   description: Join the Filecoin Network Base to connect with the community and
     explore the latest innovations.
 ---

--- a/src/content/events/filecoin-network-day-south-korea.md
+++ b/src/content/events/filecoin-network-day-south-korea.md
@@ -9,7 +9,6 @@ image:
   src: /assets/images/network-day-korea-2022.png
 category: hosted
 seo:
-  title: Filecoin Network Day South Korea
   description:
     Participate in Filecoin Network Day in South Korea to network with
     the community and learn about the latest updates.

--- a/src/content/events/filecoin-orbit-lounge-at-dc-fintech-week.md
+++ b/src/content/events/filecoin-orbit-lounge-at-dc-fintech-week.md
@@ -14,7 +14,6 @@ image:
   src: /assets/images/645215fc18e20d1c30805b6c_2021-filecoin-orbit-lounge-event.png
 category: supported-sponsored
 seo:
-  title: Filecoin Orbit Lounge at DC Fintech Week
   description:
     Join the Filecoin Orbit Lounge at DC Fintech Week to connect with the
     community and explore the latest innovations.

--- a/src/content/events/filecoin-plus-day-1.md
+++ b/src/content/events/filecoin-plus-day-1.md
@@ -12,7 +12,6 @@ end-date: 2023-11-14T22:00:00.270Z
 image:
   src: /assets/images/03292023-filplusmission.png
 seo:
-  title: "Filecoin Plus Day"
   description:
     Celebrate Filecoin Plus Day and learn about the latest updates and
     innovations in the Filecoin ecosystem.

--- a/src/content/events/filecoin-plus-day-5.md
+++ b/src/content/events/filecoin-plus-day-5.md
@@ -11,7 +11,6 @@ start-date: 2021-05-10T22:00:00.000Z
 image:
   src: /assets/images/6452191a0250ed07cbd15415_luma-_-fil-day.jpg
 seo:
-  title: "Filecoin Plus Day"
   description: Join Filecoin Plus Day to connect with the community and explore
     the latest innovations in the Filecoin ecosystem.
 ---

--- a/src/content/events/filecoin-plus-day.md
+++ b/src/content/events/filecoin-plus-day.md
@@ -7,7 +7,6 @@ category: hosted
 location: Virtual
 start-date: 2022-05-11T06:00:24.000Z
 seo:
-  title: Filecoin Plus Day
   description:
     Celebrate Filecoin Plus Day and learn about the latest updates and
     innovations in the Filecoin ecosystem.

--- a/src/content/events/filecoin-station-at-web-summit.md
+++ b/src/content/events/filecoin-station-at-web-summit.md
@@ -10,7 +10,6 @@ image:
   src: /assets/images/websummit-2023.png
 category: supported-sponsored
 seo:
-  title: Filecoin Station at Web Summit
   description:
     Visit the Filecoin Station at Web Summit to discover the latest updates
     and innovations in Filecoin.

--- a/src/content/events/filecoin-virtual-machine-hacker-base-1.md
+++ b/src/content/events/filecoin-virtual-machine-hacker-base-1.md
@@ -10,7 +10,6 @@ end-date: 2023-03-01T16:39:25.716Z
 image:
   src: /assets/images/fvm-hackerbase-2023.png
 seo:
-  title: Filecoin Virtual Machine Hacker Base
   description: Join the Filecoin Virtual Machine Hacker Base to collaborate and
     innovate with the Filecoin community.
 ---

--- a/src/content/events/funding-the-commons.md
+++ b/src/content/events/funding-the-commons.md
@@ -10,7 +10,6 @@ end-date: 2024-04-14T14:47:33.405Z
 image:
   src: /assets/images/funding-the-commons24.png
 seo:
-  title: Funding the Commons
   description: Participate in Funding the Commons to explore opportunities for
     funding and supporting the commons.
 ---

--- a/src/content/events/gbbc-virtual-members-forum-with-marta-belcher-board-chair-at-the-filecoin-foundation.md
+++ b/src/content/events/gbbc-virtual-members-forum-with-marta-belcher-board-chair-at-the-filecoin-foundation.md
@@ -10,7 +10,6 @@ external-link:
   url: https://www.youtube.com/watch?v=LU_WjU0mUuM
 start-date: 2021-03-04T23:00:00.000Z
 seo:
-  title: GBBC Virtual Members Forum with Marta Belcher
   description: Join the GBBC Virtual Members Forum with Marta Belcher to learn
     about the latest in blockchain and decentralized technologies.
 ---

--- a/src/content/events/hackathon-browsers-3000.md
+++ b/src/content/events/hackathon-browsers-3000.md
@@ -8,7 +8,6 @@ location: Virtual
 start-date: 2021-07-07T22:00:00.000Z
 end-date: 2021-08-19T22:00:00.000Z
 seo:
-  title: "Hackathon: Browsers 3000"
   description: "Participate in the Hackathon: Browsers 3000 to innovate and
     showcase your skills in web development."
 ---

--- a/src/content/events/hackfs.md
+++ b/src/content/events/hackfs.md
@@ -10,7 +10,6 @@ external-link:
 start-date: 2021-07-29T22:00:00.000Z
 end-date: 2021-08-19T22:00:00.000Z
 seo:
-  title: HackFS
   description: Participate in HackFS to innovate and build decentralized
     applications using Filecoin and IPFS.
 ---

--- a/src/content/events/hyperledger-global-forum.md
+++ b/src/content/events/hyperledger-global-forum.md
@@ -12,7 +12,6 @@ image:
   src: /assets/images/645215feaee26f3101cebc4b_hyperledger-global-forum.jpeg
 category: supported-sponsored
 seo:
-  title: Hyperledger Global Forum
   description:
     Join the Hyperledger Global Forum to connect with the blockchain community
     and explore enterprise solutions.

--- a/src/content/events/metaverse-hackathon.md
+++ b/src/content/events/metaverse-hackathon.md
@@ -11,7 +11,6 @@ start-date: 2022-04-19T16:00:45.000Z
 image:
   src: /assets/images/645215fba2b7469c5c5546ea_image_ldbpld.png
 seo:
-  title: Metaverse Hackathon
   description: Participate in the Metaverse Hackathon to innovate and build
     applications for the metaverse.
 ---

--- a/src/content/events/nft-gallery-at-consensus-2022.md
+++ b/src/content/events/nft-gallery-at-consensus-2022.md
@@ -12,7 +12,6 @@ start-date: 2022-06-08T16:00:10.000Z
 image:
   src: /assets/images/645215f075d57ed1e4d02693_nft-gallery-at-consensus.png
 seo:
-  title: NFT Gallery at Consensus 2022
   description: Visit the NFT Gallery at Consensus 2022 to explore the latest in
     NFT art and technology.
 ---

--- a/src/content/events/nft-vision-hack.md
+++ b/src/content/events/nft-vision-hack.md
@@ -10,6 +10,5 @@ external-link:
 start-date: 2021-06-30T22:00:00.000Z
 end-date: 2021-08-30T22:00:00.000Z
 seo:
-  title: NFT Vision Hack
   description: Join the NFT Vision Hack to innovate and create the future of NFTs.
 ---

--- a/src/content/events/protocol-village-at-consensus-2023.md
+++ b/src/content/events/protocol-village-at-consensus-2023.md
@@ -12,7 +12,6 @@ image:
   src: /assets/images/protocol-village-2023.png
 category: supported-sponsored
 seo:
-  title: Protocol Village at Consensus 2023
   description:
     Visit the Protocol Village at Consensus 2023 to connect with blockchain
     protocol developers.

--- a/src/content/events/puerto-rico-blockchain-week.md
+++ b/src/content/events/puerto-rico-blockchain-week.md
@@ -12,7 +12,6 @@ end-date: 2022-12-10T18:15:00.000Z
 image:
   src: /assets/images/pr-blockchain-2022.png
 seo:
-  title: Puerto Rico Blockchain Week
   description: Attend Puerto Rico Blockchain Week to explore the latest in
     blockchain technology and network with industry leaders.
 ---

--- a/src/content/events/sbs-boston.md
+++ b/src/content/events/sbs-boston.md
@@ -10,7 +10,6 @@ end-date: 2023-04-13T15:36:00.000Z
 image:
   src: /assets/images/sbs-boston-2023.png
 seo:
-  title: SBS Boston
   description:
     Join SBS Boston to engage with the blockchain community and explore
     sustainable blockchain solutions.

--- a/src/content/events/singapore-storage-provider-meetup.md
+++ b/src/content/events/singapore-storage-provider-meetup.md
@@ -12,7 +12,6 @@ image:
   src: /assets/images/6452194af82dbf21df953f96_singapore-sp.jpg
 category: hosted
 seo:
-  title: Singapore Storage Provider Meetup
   description:
     Participate in the Singapore Storage Provider Meetup to network and
     learn about Filecoin storage solutions.

--- a/src/content/events/social-impact-summit-2024-cohosted-by-blockchain-law-for-social-good-center-ffdw.md
+++ b/src/content/events/social-impact-summit-2024-cohosted-by-blockchain-law-for-social-good-center-ffdw.md
@@ -14,7 +14,6 @@ image:
   src: /assets/images/sis24.png
 category: co-hosted
 seo:
-  title: Social Impact Summit 2024
   description:
     Join the Social Impact Summit 2024 to explore the intersection of blockchain
     and social good.

--- a/src/content/events/south-korea-storage-provider-meetup.md
+++ b/src/content/events/south-korea-storage-provider-meetup.md
@@ -11,7 +11,6 @@ image:
   src: /assets/images/6452196b59d1f8a352664f3b_korea-sp.jpg
 category: hosted
 seo:
-  title: South Korea Storage Provider Meetup
   description:
     Attend the South Korea Storage Provider Meetup to network and learn
     about Filecoin storage solutions.

--- a/src/content/events/storage-provider-working-group-meeting.md
+++ b/src/content/events/storage-provider-working-group-meeting.md
@@ -11,7 +11,6 @@ start-date: 2021-08-24T22:00:00.000Z
 image:
   src: /assets/images/64521604a359ff699f3705ec_storage-provider-working-group.png
 seo:
-  title: Storage Provider Working Group Meeting
   description:
     Join the Storage Provider Working Group Meeting to collaborate and
     discuss Filecoin storage solutions.

--- a/src/content/events/sustainable-blockchain-summit.md
+++ b/src/content/events/sustainable-blockchain-summit.md
@@ -10,7 +10,6 @@ end-date: 2022-07-23T00:00:00.000Z
 image:
   src: /assets/images/645215eb05e191292b09744d_sbs.png
 seo:
-  title: Sustainable Blockchain Summit
   description: Participate in the Sustainable Blockchain Summit to explore
     sustainable solutions in blockchain technology.
 ---

--- a/src/content/events/synbiobeta.md
+++ b/src/content/events/synbiobeta.md
@@ -9,7 +9,6 @@ image:
   src: /assets/images/synbiobeta-2023.png
 category: supported-sponsored
 seo:
-  title: SynBioBeta
   description:
     Join SynBioBeta to connect with the synthetic biology community and
     explore innovations in the field.

--- a/src/content/events/taipei-blockchain-week.md
+++ b/src/content/events/taipei-blockchain-week.md
@@ -12,7 +12,6 @@ end-date: 2022-12-17T18:19:00.000Z
 image:
   src: /assets/images/tapei-blockchain-2022.png
 seo:
-  title: Taipei Blockchain Week
   description: Attend Taipei Blockchain Week to engage with the blockchain
     community and explore the latest developments.
 ---

--- a/src/content/events/teamz-web3-ai-summit-conference-2024.md
+++ b/src/content/events/teamz-web3-ai-summit-conference-2024.md
@@ -10,7 +10,6 @@ image:
   src: /assets/images/teamz-conference.webp
 category: supported-sponsored
 seo:
-  title: TEAMZ Web3 AI Summit Conference 2024
   description:
     Join the TEAMZ Web3 AI Summit Conference 2024 to explore the intersection
     of Web3 and AI technologies.

--- a/src/content/events/the-crypties.md
+++ b/src/content/events/the-crypties.md
@@ -9,6 +9,5 @@ start-date: 2022-11-30T18:24:48.715Z
 image:
   src: /assets/images/crypties-2022.png
 seo:
-  title: The Crypties
   description: Attend The Crypties to celebrate achievements in the cryptocurrency industry.
 ---

--- a/src/content/events/the-filecoin-sanctuary-davos-2024.md
+++ b/src/content/events/the-filecoin-sanctuary-davos-2024.md
@@ -10,7 +10,6 @@ image:
   src: /assets/images/davos-2023-pic.png
 category: hosted
 seo:
-  title: The Filecoin Sanctuary Davos 2024
   description:
     Join The Filecoin Sanctuary at Davos 2024 to connect with the Filecoin
     community and explore new innovations.

--- a/src/content/events/the-filecoin-sanctuary-davos.md
+++ b/src/content/events/the-filecoin-sanctuary-davos.md
@@ -10,7 +10,6 @@ image:
   src: /assets/images/davos-2023-pic.png
 category: hosted
 seo:
-  title: The Filecoin Sanctuary Davos
   description:
     Participate in The Filecoin Sanctuary at Davos to engage with the Filecoin
     community and learn about the latest developments.

--- a/src/content/events/token2049-dubai-filecoin-orbit-event.md
+++ b/src/content/events/token2049-dubai-filecoin-orbit-event.md
@@ -10,7 +10,6 @@ end-date: 2024-04-19T14:45:39.332Z
 image:
   src: /assets/images/token2049_dubai24.png
 seo:
-  title: Token2049 Dubai Filecoin Orbit Event
   description: Attend the Token2049 Dubai Filecoin Orbit Event to network and
     explore the latest in Filecoin.
 ---

--- a/src/content/events/unfinished-live.md
+++ b/src/content/events/unfinished-live.md
@@ -12,6 +12,5 @@ end-date: 2022-08-24T00:00:00.000Z
 image:
   src: /assets/images/645215e44977982552923065_unfinished-live.png
 seo:
-  title: Unfinished Live
   description: Join Unfinished Live to explore the future of democracy and technology.
 ---

--- a/src/content/events/vision-weekend-us.md
+++ b/src/content/events/vision-weekend-us.md
@@ -12,7 +12,6 @@ end-date: 2022-12-04T18:27:00.000Z
 image:
   src: /assets/images/vision-sf-2022.png
 seo:
-  title: Vision Weekend US
   description:
     Attend Vision Weekend US to connect with the visionary leaders and
     explore future innovations.

--- a/src/content/events/vision-weekend-usa-2023.md
+++ b/src/content/events/vision-weekend-usa-2023.md
@@ -12,7 +12,6 @@ image:
   src: /assets/images/vision-weekend.jpeg
 category: supported-sponsored
 seo:
-  title: Vision Weekend USA 2023
   description:
     Join Vision Weekend USA 2023 to engage with visionary leaders and explore
     future technologies.

--- a/src/content/events/web3-hacker-house-at-sxsw.md
+++ b/src/content/events/web3-hacker-house-at-sxsw.md
@@ -13,7 +13,6 @@ image:
   src: /assets/images/645215f691cf5c91a16146aa_https___cdn-evbuc-com_images_239998219_264947572824_1_original.jpeg
 category: supported-sponsored
 seo:
-  title: Web3 Hacker House at SXSW
   description:
     Participate in the Web3 Hacker House at SXSW to innovate and build
     decentralized applications.

--- a/src/content/events/web3-infrastructure-summit-2023.md
+++ b/src/content/events/web3-infrastructure-summit-2023.md
@@ -9,7 +9,6 @@ image:
   src: /assets/images/web3-infra-2023.png
 category: supported-sponsored
 seo:
-  title: Web3 Infrastructure Summit 2023
   description:
     Join the Web3 Infrastructure Summit 2023 to explore the latest in decentralized
     infrastructure.


### PR DESCRIPTION
## 📝 Description

This PR includes refactor in order to include an optional SEO title for dynamic pages - events, ecosystem project, digest articles and blog posts. If left empty, it defaults to page title. For events, we add a suffix "- Event", and for ecosystem project, we add "- Ecosystem Project".

**Note**: in `createMetadata` file, I encountered some type errors for the `title`- if you have a better idea, probably there's a better workaround than using `as string`?

```
    title: overrideDefaultTitle
      ? { absolute: parsedEnrichedSEO.title **as string** }
      : (parsedEnrichedSEO.title **as string**),
```

- **Type:** Refactor

## 🛠️ Key Changes

- `meta_config` and `SeoMetadataSchema` are broken down in smaller parts

## 📌 To-Do Before Merging

- [x] Check with David 


## 🧪 How to Test

  1. open decap cms
  2. check if static pages have mandatory SEO title and dynamic page an optional SEO title
  3. delete SEO title in dynamic page
  4. check (either console or dev tools) if the SEO title matches the title (It should not be empty). For events, it should have a suffix `"- Events"`, and for ecosystem projects` "- Ecosystem Project"`. Example. 'Acasia - Ecosystem Project'


