### PR TITLE
[UXIT-1538] Event Page · Integrate Luma events via API

### DIFF
--- a/src/app/events/[slug]/components/EventsSection.tsx
+++ b/src/app/events/[slug]/components/EventsSection.tsx
@@ -1,18 +1,47 @@
+import { z } from 'zod'
+
+import { Card } from '@/components/Card'
+import { CardGrid } from '@/components/CardGrid'
 import { PageSection } from '@/components/PageSection'
 
 import type { Event } from '../../types/eventType'
+import { getMetaData } from '../../utils/getMetaData'
+import { getLumaEvents } from '../services/lumaService'
+import { mapLumaEventToMetadata } from '../utils/mapLumaEventToMetadata'
 
 type EventsSectionProps = NonNullable<Event['lumaEventsSection']>
 
-export function EventsSection({ title, embedLink }: EventsSectionProps) {
+export async function EventsSection({ title, embedLink }: EventsSectionProps) {
+  const events = await getLumaEvents()
+
   return (
     <PageSection kicker="Explore" title={title || 'Events'}>
-      <iframe
-        src={embedLink}
-        width="100%"
-        height="720"
-        className="rounded-lg"
-      ></iframe>
+      {events.length > 0 ? (
+        <CardGrid cols="smTwo">
+          {events.map(({ event }) => (
+            <Card
+              key={event.api_id}
+              title={event.name}
+              description={event.description}
+              metaData={getMetaData(mapLumaEventToMetadata(event))}
+              textIsClamped={true}
+              cta={{
+                text: 'View Event Details',
+                href: event.url,
+              }}
+            />
+          ))}
+        </CardGrid>
+      ) : embedLink ? (
+        <iframe
+          src={embedLink}
+          width="100%"
+          height="720"
+          className="rounded-lg"
+        />
+      ) : (
+        <p>No events are currently available. Please check back later.</p>
+      )}
     </PageSection>
   )
 }

--- a/src/app/events/[slug]/components/EventsSection.tsx
+++ b/src/app/events/[slug]/components/EventsSection.tsx
@@ -1,47 +1,15 @@
-import { z } from 'zod'
-
-import { Card } from '@/components/Card'
-import { CardGrid } from '@/components/CardGrid'
 import { PageSection } from '@/components/PageSection'
 
 import type { Event } from '../../types/eventType'
-import { getMetaData } from '../../utils/getMetaData'
-import { getLumaEvents } from '../services/lumaService'
-import { mapLumaEventToMetadata } from '../utils/mapLumaEventToMetadata'
+
+import { LumaEvents } from './LumaEvents'
 
 type EventsSectionProps = NonNullable<Event['lumaEventsSection']>
 
-export async function EventsSection({ title, embedLink }: EventsSectionProps) {
-  const events = await getLumaEvents()
-
+export function EventsSection({ title, embedLink }: EventsSectionProps) {
   return (
     <PageSection kicker="Explore" title={title || 'Events'}>
-      {events.length > 0 ? (
-        <CardGrid cols="smTwo">
-          {events.map(({ event }) => (
-            <Card
-              key={event.api_id}
-              title={event.name}
-              description={event.description}
-              metaData={getMetaData(mapLumaEventToMetadata(event))}
-              textIsClamped={true}
-              cta={{
-                text: 'View Event Details',
-                href: event.url,
-              }}
-            />
-          ))}
-        </CardGrid>
-      ) : embedLink ? (
-        <iframe
-          src={embedLink}
-          width="100%"
-          height="720"
-          className="rounded-lg"
-        />
-      ) : (
-        <p>No events are currently available. Please check back later.</p>
-      )}
+      <LumaEvents embedLink={embedLink} />
     </PageSection>
   )
 }

--- a/src/app/events/[slug]/components/LumaEvents.tsx
+++ b/src/app/events/[slug]/components/LumaEvents.tsx
@@ -1,0 +1,61 @@
+import * as Sentry from '@sentry/nextjs'
+import { ZodError } from 'zod'
+
+import { logZodError } from '@/utils/zodUtils'
+
+import { Card } from '@/components/Card'
+import { CardGrid } from '@/components/CardGrid'
+
+import type { Event } from '../../types/eventType'
+import { getMetaData } from '../../utils/getMetaData'
+import { fetchAndParseLumaEvents } from '../services/lumaService'
+import { mapLumaEventToMetadata } from '../utils/mapLumaEventToMetadata'
+
+type EventsSectionProps = NonNullable<Event['lumaEventsSection']>
+
+export async function LumaEvents({ embedLink }: EventsSectionProps) {
+  try {
+    const events = await fetchAndParseLumaEvents()
+
+    if (events.length === 0) {
+      return <p>There are currently no upcoming events.</p>
+    }
+
+    return (
+      <CardGrid cols="smTwo">
+        {events.map(({ event }) => (
+          <Card
+            key={event.api_id}
+            title={event.name}
+            description={event.description}
+            metaData={getMetaData(mapLumaEventToMetadata(event))}
+            textIsClamped={true}
+            cta={{
+              text: 'View Event Details',
+              href: event.url,
+            }}
+          />
+        ))}
+      </CardGrid>
+    )
+  } catch (error) {
+    Sentry.captureException(error)
+
+    if (error instanceof ZodError) {
+      logZodError(error, { location: 'Luma Events' })
+    }
+
+    if (embedLink) {
+      return (
+        <iframe
+          src={embedLink}
+          width="100%"
+          height="720"
+          className="rounded-lg"
+        />
+      )
+    }
+
+    return <p>No events are currently available. Please check back later.</p>
+  }
+}

--- a/src/app/events/[slug]/schemas/LumaSchema.ts
+++ b/src/app/events/[slug]/schemas/LumaSchema.ts
@@ -1,0 +1,28 @@
+import { z } from 'zod'
+
+export const GeoAddressSchema = z.object({
+  address: z.string(),
+})
+
+const LumaEventSchema = z.object({
+  api_id: z.string(),
+  name: z.string(),
+  description: z.string().optional().default(''),
+  start_at: z.coerce.date(),
+  end_at: z.coerce.date().optional(),
+  url: z.string(),
+  geo_address_json: GeoAddressSchema.optional(),
+})
+
+export const LumaResponseSchema = z.object({
+  entries: z.array(
+    z.object({
+      event: LumaEventSchema,
+    }),
+  ),
+})
+
+export type LumaEvent = z.infer<typeof LumaEventSchema>
+export type LumaEventEntry = {
+  event: LumaEvent
+}

--- a/src/app/events/[slug]/services/lumaService.ts
+++ b/src/app/events/[slug]/services/lumaService.ts
@@ -1,40 +1,20 @@
-import { z } from 'zod'
+import { LumaResponseSchema } from '../schemas/LumaSchema'
 
-import { type LumaEventEntry, LumaResponseSchema } from '../schemas/LumaSchema'
+const apiKey = process.env.LUMA_FILECOIN_API_KEY
 
-export async function getLumaEvents(): Promise<Array<LumaEventEntry>> {
-  const apiKey = process.env.NEXT_LUMA_FILECOIN_API_KEY
+export async function fetchAndParseLumaEvents() {
   if (!apiKey) throw new Error('Luma API key is not configured')
 
-  try {
-    const res = await fetch(
-      'https://api.lu.ma/public/v1/calendar/list-events',
-      {
-        method: 'GET',
-        headers: {
-          accept: 'application/json',
-          authorization: `Bearer ${apiKey}`,
-        },
-        next: { revalidate: 3600 },
-      },
-    )
+  const res = await fetch('https://api.lu.ma/public/v1/calendar/list-events', {
+    method: 'GET',
+    headers: {
+      accept: 'application/json',
+      authorization: `Bearer ${apiKey}`,
+    },
+    next: { revalidate: 3600 },
+  })
 
-    if (!res.ok) {
-      throw new Error(`Failed to fetch events: ${res.status} ${res.statusText}`)
-    }
-
-    const rawData = await res.json()
-
-    const validatedData = LumaResponseSchema.parse(rawData)
-
-    return validatedData.entries
-  } catch (error) {
-    if (error instanceof z.ZodError) {
-      console.error('Invalid API response format:', error.errors)
-    } else {
-      console.error('Error fetching events:', error)
-    }
-
-    return []
-  }
+  const rawData = await res.json()
+  const validatedData = LumaResponseSchema.parse(rawData)
+  return validatedData.entries
 }

--- a/src/app/events/[slug]/services/lumaService.ts
+++ b/src/app/events/[slug]/services/lumaService.ts
@@ -1,0 +1,40 @@
+import { z } from 'zod'
+
+import { type LumaEventEntry, LumaResponseSchema } from '../schemas/LumaSchema'
+
+export async function getLumaEvents(): Promise<Array<LumaEventEntry>> {
+  const apiKey = process.env.NEXT_LUMA_FILECOIN_API_KEY
+  if (!apiKey) throw new Error('Luma API key is not configured')
+
+  try {
+    const res = await fetch(
+      'https://api.lu.ma/public/v1/calendar/list-events',
+      {
+        method: 'GET',
+        headers: {
+          accept: 'application/json',
+          authorization: `Bearer ${apiKey}`,
+        },
+        next: { revalidate: 3600 },
+      },
+    )
+
+    if (!res.ok) {
+      throw new Error(`Failed to fetch events: ${res.status} ${res.statusText}`)
+    }
+
+    const rawData = await res.json()
+
+    const validatedData = LumaResponseSchema.parse(rawData)
+
+    return validatedData.entries
+  } catch (error) {
+    if (error instanceof z.ZodError) {
+      console.error('Invalid API response format:', error.errors)
+    } else {
+      console.error('Error fetching events:', error)
+    }
+
+    return []
+  }
+}

--- a/src/app/events/[slug]/utils/mapLumaEventToMetadata.ts
+++ b/src/app/events/[slug]/utils/mapLumaEventToMetadata.ts
@@ -1,0 +1,13 @@
+import type { LumaEvent } from '../schemas/LumaSchema'
+
+export function mapLumaEventToMetadata({
+  start_at,
+  end_at,
+  geo_address_json,
+}: LumaEvent) {
+  return {
+    startDate: start_at,
+    endDate: end_at,
+    location: geo_address_json?.address || '',
+  }
+}

--- a/src/app/events/utils/getMetaData.ts
+++ b/src/app/events/utils/getMetaData.ts
@@ -1,0 +1,13 @@
+import { formatDate } from '@/utils/dateUtils'
+
+import type { Event } from '../types/eventType'
+
+type EventMetaData = Pick<Event, 'startDate' | 'endDate' | 'location'>
+
+export function getMetaData({ startDate, endDate, location }: EventMetaData) {
+  const formattedStartDate = formatDate(startDate)
+  const formattedEndDate = endDate ? ` - ${formatDate(endDate)}` : ''
+  const formattedDate = `${formattedStartDate}${formattedEndDate}`
+
+  return location ? [formattedDate, location] : [formattedDate]
+}


### PR DESCRIPTION
## 📝 Description
This PR replaces the static Luma iframe embed with a dynamic card-based events display that fetches data directly from the Luma API. This provides a more integrated and customizable event display experience while maintaining fallback to the iframe when no events are available.

- **Type:** New feature

## 🛠️ Key Changes
- Created new Luma API integration service to fetch events data
- Added Zod schema validation for Luma API responses
- Implemented new card-based UI for displaying events
- Added fallback to iframe when no events are available
- Created utility functions for date formatting and metadata mapping

## 📌 To-Do Before Merging
- [ ] Verify `NEXT_LUMA_FILECOIN_API_KEY` is configured in environment
- [ ] Test error handling scenarios
- [ ] Verify fallback to iframe works correctly
- [ ] Review caching strategy (currently set to 1 hour revalidation)
- [ ] Refactor `getEventMetaData` from `src/app/_utils/getMetaData.ts` (in a different PR?)

## 🧪 How to Test
- **Setup:** 
  - Ensure `NEXT_LUMA_FILECOIN_API_KEY` environment variable is set
  - Run the development server

- **Steps to Test:**
  1. Navigate to an events page with Luma integration
  2. Verify events are displayed in card format with correct metadata
  3. Test with API key removed to verify error handling
  4. Test with empty events response to verify iframe fallback
  
- **Expected Results:** 
  - Events should display in a responsive card grid
  - Each card should show event name, description, date, and location
  - Clicking "View Event Details" should link to the Luma event page
  - When no events are available, should fallback to iframe or "No events" message

## 🔖 Resources
- [Luma API Documentation](https://lu.ma/api)
- [Zod Documentation](https://zod.dev/)
- [Next.js Data Fetching Documentation](https://nextjs.org/docs/basic-features/data-fetching)

![CleanShot 2024-11-01 at 11 46 18@2x](https://github.com/user-attachments/assets/89e4dd54-37de-434e-b24c-8f8cb3955b19)
