### PR TITLE
[UXIT-1699] - Save Event Schedule Tabs’ State in URL

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -34,6 +34,7 @@
         "netlify-identity-widget": "^1.9.2",
         "next": "^14.2.5",
         "next-plausible": "^3.12.1",
+        "nuqs": "^2.1.1",
         "pluralize": "^8.0.0",
         "react": "^18",
         "react-dom": "^18",
@@ -4615,6 +4616,17 @@
         }
       }
     },
+    "node_modules/@remix-run/router": {
+      "version": "1.20.0",
+      "resolved": "https://registry.npmjs.org/@remix-run/router/-/router-1.20.0.tgz",
+      "integrity": "sha512-mUnk8rPJBI9loFDZ+YzPGdeniYK+FTmRD1TMCz7ev2SNIozyKKpnGgsxO34u6Z4z/t0ITuu7voi/AshfsGsgFg==",
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
     "node_modules/@rollup/plugin-commonjs": {
       "version": "26.0.1",
       "resolved": "https://registry.npmjs.org/@rollup/plugin-commonjs/-/plugin-commonjs-26.0.1.tgz",
@@ -8766,6 +8778,12 @@
         "node": ">=8"
       }
     },
+    "node_modules/decap-cms-app/node_modules/isarray": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+      "integrity": "sha512-D2S+3GLxWH+uhrNEcoh/fnmYeP8E8/zHl644d/jdA0g2uyXvy3sb0qxotE+ne0LtccHknQzWwZEzhak7oJ0COQ==",
+      "license": "MIT"
+    },
     "node_modules/decap-cms-app/node_modules/longest-streak": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/longest-streak/-/longest-streak-2.0.4.tgz",
@@ -9084,6 +9102,15 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
+    "node_modules/decap-cms-app/node_modules/path-to-regexp": {
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-1.9.0.tgz",
+      "integrity": "sha512-xIp7/apCFJuUHdDLWe8O1HIkb0kQrOMb/0u6FXQjemHn/ii5LrIzU6bdECnsiTF/GjZkMEKg1xdiZwNqDYlZ6g==",
+      "license": "MIT",
+      "dependencies": {
+        "isarray": "0.0.1"
+      }
+    },
     "node_modules/decap-cms-app/node_modules/property-information": {
       "version": "5.6.0",
       "resolved": "https://registry.npmjs.org/property-information/-/property-information-5.6.0.tgz",
@@ -9131,6 +9158,44 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
       "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
       "license": "MIT"
+    },
+    "node_modules/decap-cms-app/node_modules/react-router": {
+      "version": "5.3.4",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-5.3.4.tgz",
+      "integrity": "sha512-Ys9K+ppnJah3QuaRiLxk+jDWOR1MekYQrlytiXxC1RyfbdsZkS5pvKAzCCr031xHixZwpnsYNT5xysdFHQaYsA==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.12.13",
+        "history": "^4.9.0",
+        "hoist-non-react-statics": "^3.1.0",
+        "loose-envify": "^1.3.1",
+        "path-to-regexp": "^1.7.0",
+        "prop-types": "^15.6.2",
+        "react-is": "^16.6.0",
+        "tiny-invariant": "^1.0.2",
+        "tiny-warning": "^1.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=15"
+      }
+    },
+    "node_modules/decap-cms-app/node_modules/react-router-dom": {
+      "version": "5.3.4",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-5.3.4.tgz",
+      "integrity": "sha512-m4EqFMHv/Ih4kpcBCONHbkT68KoAeHN4p3lAGoNryfHi0dMy0kCzEZakiKRsvg5wHZ/JLrLW8o8KomWiz/qbYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.12.13",
+        "history": "^4.9.0",
+        "loose-envify": "^1.3.1",
+        "prop-types": "^15.6.2",
+        "react-router": "5.3.4",
+        "tiny-invariant": "^1.0.2",
+        "tiny-warning": "^1.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=15"
+      }
     },
     "node_modules/decap-cms-app/node_modules/remark-gfm": {
       "version": "1.0.0",
@@ -15292,6 +15357,12 @@
         "node": ">=16 || 14 >=14.17"
       }
     },
+    "node_modules/mitt": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/mitt/-/mitt-3.0.1.tgz",
+      "integrity": "sha512-vKivATfr97l2/QBCYAkXYDbrIWPM2IIKEl7YPhjCvKlG3kE2gm+uBo6nEXK3M5/Ffh/FLpKExzOQ3JJoJGFKBw==",
+      "license": "MIT"
+    },
     "node_modules/module-details-from-path": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/module-details-from-path/-/module-details-from-path-1.0.3.tgz",
@@ -15530,6 +15601,32 @@
       },
       "funding": {
         "url": "https://github.com/fb55/nth-check?sponsor=1"
+      }
+    },
+    "node_modules/nuqs": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/nuqs/-/nuqs-2.1.1.tgz",
+      "integrity": "sha512-iM2H8lMmhvk9bxupUs2oRle9usRNEAqppOkTMXOxD/uK85gOKAubU7T2zmPo8fnYQS4n5e/XswTiq+gLYGpy3w==",
+      "license": "MIT",
+      "dependencies": {
+        "mitt": "^3.0.1"
+      },
+      "peerDependencies": {
+        "@remix-run/react": ">= 2",
+        "next": ">= 14.2.0",
+        "react": ">= 18.2.0",
+        "react-router-dom": ">= 6"
+      },
+      "peerDependenciesMeta": {
+        "@remix-run/react": {
+          "optional": true
+        },
+        "next": {
+          "optional": true
+        },
+        "react-router-dom": {
+          "optional": true
+        }
       }
     },
     "node_modules/object-assign": {
@@ -16906,56 +17003,39 @@
       }
     },
     "node_modules/react-router": {
-      "version": "5.3.4",
-      "resolved": "https://registry.npmjs.org/react-router/-/react-router-5.3.4.tgz",
-      "integrity": "sha512-Ys9K+ppnJah3QuaRiLxk+jDWOR1MekYQrlytiXxC1RyfbdsZkS5pvKAzCCr031xHixZwpnsYNT5xysdFHQaYsA==",
+      "version": "6.27.0",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-6.27.0.tgz",
+      "integrity": "sha512-YA+HGZXz4jaAkVoYBE98VQl+nVzI+cVI2Oj/06F5ZM+0u3TgedN9Y9kmMRo2mnkSK2nCpNQn0DVob4HCsY/WLw==",
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "dependencies": {
-        "@babel/runtime": "^7.12.13",
-        "history": "^4.9.0",
-        "hoist-non-react-statics": "^3.1.0",
-        "loose-envify": "^1.3.1",
-        "path-to-regexp": "^1.7.0",
-        "prop-types": "^15.6.2",
-        "react-is": "^16.6.0",
-        "tiny-invariant": "^1.0.2",
-        "tiny-warning": "^1.0.0"
+        "@remix-run/router": "1.20.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
       },
       "peerDependencies": {
-        "react": ">=15"
+        "react": ">=16.8"
       }
     },
     "node_modules/react-router-dom": {
-      "version": "5.3.4",
-      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-5.3.4.tgz",
-      "integrity": "sha512-m4EqFMHv/Ih4kpcBCONHbkT68KoAeHN4p3lAGoNryfHi0dMy0kCzEZakiKRsvg5wHZ/JLrLW8o8KomWiz/qbYQ==",
+      "version": "6.27.0",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-6.27.0.tgz",
+      "integrity": "sha512-+bvtFWMC0DgAFrfKXKG9Fc+BcXWRUO1aJIihbB79xaeq0v5UzfvnM5houGUm1Y461WVRcgAQ+Clh5rdb1eCx4g==",
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "dependencies": {
-        "@babel/runtime": "^7.12.13",
-        "history": "^4.9.0",
-        "loose-envify": "^1.3.1",
-        "prop-types": "^15.6.2",
-        "react-router": "5.3.4",
-        "tiny-invariant": "^1.0.2",
-        "tiny-warning": "^1.0.0"
+        "@remix-run/router": "1.20.0",
+        "react-router": "6.27.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
       },
       "peerDependencies": {
-        "react": ">=15"
-      }
-    },
-    "node_modules/react-router/node_modules/isarray": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-      "integrity": "sha512-D2S+3GLxWH+uhrNEcoh/fnmYeP8E8/zHl644d/jdA0g2uyXvy3sb0qxotE+ne0LtccHknQzWwZEzhak7oJ0COQ==",
-      "license": "MIT"
-    },
-    "node_modules/react-router/node_modules/path-to-regexp": {
-      "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-1.8.0.tgz",
-      "integrity": "sha512-n43JRhlUKUAlibEJhPeir1ncUID16QnEjNpwzNdO3Lm4ywrBpBZ5oLD0I6br9evr1Y9JTqwRtAh7JLoOzAQdVA==",
-      "license": "MIT",
-      "dependencies": {
-        "isarray": "0.0.1"
+        "react": ">=16.8",
+        "react-dom": ">=16.8"
       }
     },
     "node_modules/react-scroll-sync": {

--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "netlify-identity-widget": "^1.9.2",
     "next": "^14.2.5",
     "next-plausible": "^3.12.1",
+    "nuqs": "^2.1.1",
     "pluralize": "^8.0.0",
     "react": "^18",
     "react-dom": "^18",

--- a/src/app/events/[slug]/components/ScheduleSection/Tabs.tsx
+++ b/src/app/events/[slug]/components/ScheduleSection/Tabs.tsx
@@ -10,7 +10,7 @@ import { useIsMounted, useMediaQuery } from 'usehooks-ts'
 import type { Event } from '../../../types/eventType'
 import { formatDate } from '../../utils/dateUtils'
 import { filterAndSortScheduleDays } from '../../utils/filterAndSortScheduleDays'
-import { scrollRefIntoView } from '../../utils/scrollRefIntoView'
+import { scrollTabContentIntoView } from '../../utils/scrollTabContentIntoView'
 
 import { EventDetails } from './EventDetails'
 
@@ -43,7 +43,7 @@ export function Tabs({ schedule }: TabsProps) {
     setActiveTabIndex(index)
 
     if (isMounted() && isScreenBelowLg) {
-      scrollRefIntoView(tabGroupRef)
+      scrollTabContentIntoView(tabGroupRef)
     }
   }
 

--- a/src/app/events/[slug]/components/ScheduleSection/Tabs.tsx
+++ b/src/app/events/[slug]/components/ScheduleSection/Tabs.tsx
@@ -10,6 +10,7 @@ import { useIsMounted, useMediaQuery } from 'usehooks-ts'
 import type { Event } from '../../../types/eventType'
 import { formatDate } from '../../utils/dateUtils'
 import { filterAndSortScheduleDays } from '../../utils/filterAndSortScheduleDays'
+import { scrollRefIntoView } from '../../utils/scrollRefIntoView'
 
 import { EventDetails } from './EventDetails'
 
@@ -41,11 +42,8 @@ export function Tabs({ schedule }: TabsProps) {
   function handleIndexChange(index: number) {
     setActiveTabIndex(index)
 
-    if (isMounted() && isScreenBelowLg && tabGroupRef.current) {
-      tabGroupRef.current.scrollIntoView({
-        behavior: 'smooth',
-        block: 'start',
-      })
+    if (isMounted() && isScreenBelowLg) {
+      scrollRefIntoView(tabGroupRef)
     }
   }
 

--- a/src/app/events/[slug]/components/ScheduleSection/Tabs.tsx
+++ b/src/app/events/[slug]/components/ScheduleSection/Tabs.tsx
@@ -42,8 +42,8 @@ export function Tabs({ schedule }: TabsProps) {
   function handleTabIndexChange(index: number) {
     setActiveTabIndex(index)
 
-    if (isMounted() && isScreenBelowLg) {
-      scrollTabContentIntoView(tabGroupRef)
+    if (isMounted() && isScreenBelowLg && tabGroupRef.current) {
+      scrollTabContentIntoView(tabGroupRef.current)
     }
   }
 

--- a/src/app/events/[slug]/components/ScheduleSection/Tabs.tsx
+++ b/src/app/events/[slug]/components/ScheduleSection/Tabs.tsx
@@ -39,7 +39,7 @@ export function Tabs({ schedule }: TabsProps) {
     `(max-width: ${parseInt(screens.md, 10) - 1}px)`,
   )
 
-  function handleIndexChange(index: number) {
+  function handleTabIndexChange(index: number) {
     setActiveTabIndex(index)
 
     if (isMounted() && isScreenBelowLg) {
@@ -52,7 +52,7 @@ export function Tabs({ schedule }: TabsProps) {
       ref={tabGroupRef}
       className="relative grid gap-6"
       selectedIndex={activeTabIndex}
-      onChange={handleIndexChange}
+      onChange={handleTabIndexChange}
     >
       <TabList className="sticky top-0 -m-2 flex gap-4 overflow-auto bg-brand-800 p-2 lg:static">
         {sortedDays.map((day) => (

--- a/src/app/events/[slug]/components/ScheduleSection/Tabs.tsx
+++ b/src/app/events/[slug]/components/ScheduleSection/Tabs.tsx
@@ -3,6 +3,7 @@
 import { useRef } from 'react'
 
 import { Tab, TabGroup, TabList, TabPanel, TabPanels } from '@headlessui/react'
+import { useQueryState, parseAsInteger } from 'nuqs'
 import theme from 'tailwindcss/defaultTheme'
 import { useIsMounted, useMediaQuery } from 'usehooks-ts'
 
@@ -18,8 +19,18 @@ type TabsProps = {
 
 const { screens } = theme
 
+const QUERY_KEY = 'tab'
+const DEFAULT_TAB_INDEX = 0
+
 export function Tabs({ schedule }: TabsProps) {
   const sortedDays = filterAndSortScheduleDays(schedule)
+
+  const [activeTabIndex, setActiveTabIndex] = useQueryState(
+    QUERY_KEY,
+    parseAsInteger.withDefault(DEFAULT_TAB_INDEX).withOptions({
+      clearOnDefault: false,
+    }),
+  )
 
   const tabGroupRef = useRef<HTMLDivElement>(null)
   const isMounted = useIsMounted()
@@ -27,7 +38,9 @@ export function Tabs({ schedule }: TabsProps) {
     `(max-width: ${parseInt(screens.md, 10) - 1}px)`,
   )
 
-  function scrollToTabGroup() {
+  function handleIndexChange(index: number) {
+    setActiveTabIndex(index)
+
     if (isMounted() && isScreenBelowLg && tabGroupRef.current) {
       tabGroupRef.current.scrollIntoView({
         behavior: 'smooth',
@@ -40,7 +53,8 @@ export function Tabs({ schedule }: TabsProps) {
     <TabGroup
       ref={tabGroupRef}
       className="relative grid gap-6"
-      onChange={scrollToTabGroup}
+      selectedIndex={activeTabIndex}
+      onChange={handleIndexChange}
     >
       <TabList className="sticky top-0 -m-2 flex gap-4 overflow-auto bg-brand-800 p-2 lg:static">
         {sortedDays.map((day) => (

--- a/src/app/events/[slug]/utils/scrollRefIntoView.ts
+++ b/src/app/events/[slug]/utils/scrollRefIntoView.ts
@@ -1,3 +1,0 @@
-export function scrollRefIntoView(ref: React.RefObject<HTMLElement>) {
-  ref.current?.scrollIntoView({ behavior: 'smooth', block: 'start' })
-}

--- a/src/app/events/[slug]/utils/scrollRefIntoView.ts
+++ b/src/app/events/[slug]/utils/scrollRefIntoView.ts
@@ -1,0 +1,3 @@
+export function scrollRefIntoView(ref: React.RefObject<HTMLElement>) {
+  ref.current?.scrollIntoView({ behavior: 'smooth', block: 'start' })
+}

--- a/src/app/events/[slug]/utils/scrollTabContentIntoView.ts
+++ b/src/app/events/[slug]/utils/scrollTabContentIntoView.ts
@@ -1,3 +1,5 @@
-export function scrollTabContentIntoView(ref: React.RefObject<HTMLElement>) {
-  ref.current?.scrollIntoView({ behavior: 'smooth', block: 'start' })
+export function scrollTabContentIntoView(
+  refCurrent: NonNullable<React.RefObject<HTMLElement>['current']>,
+) {
+  refCurrent.scrollIntoView({ behavior: 'smooth', block: 'start' })
 }

--- a/src/app/events/[slug]/utils/scrollTabContentIntoView.ts
+++ b/src/app/events/[slug]/utils/scrollTabContentIntoView.ts
@@ -1,0 +1,3 @@
+export function scrollTabContentIntoView(ref: React.RefObject<HTMLElement>) {
+  ref.current?.scrollIntoView({ behavior: 'smooth', block: 'start' })
+}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,6 +1,7 @@
 import { SpeedInsights } from '@vercel/speed-insights/next'
 import type { Metadata } from 'next'
 import PlausibleProvider from 'next-plausible'
+import { NuqsAdapter } from 'nuqs/adapters/next/app'
 
 import '@/styles/globals.scss'
 
@@ -24,11 +25,13 @@ export type LayoutProps = {
 
 export default function RootLayout({ children }: LayoutProps) {
   return (
-    <PlausibleProvider domain="fil.org">
-      <SiteLayout>
-        {children}
-        <SpeedInsights />
-      </SiteLayout>
-    </PlausibleProvider>
+    <NuqsAdapter>
+      <PlausibleProvider domain="fil.org">
+        <SiteLayout>
+          {children}
+          <SpeedInsights />
+        </SiteLayout>
+      </PlausibleProvider>
+    </NuqsAdapter>
   )
 }


### PR DESCRIPTION
## 📝 Description

This PR syncs the state of `Tabs` (on the event's individual page) with the URL query: `/events/fil-bangkok-2024?tab=1`

This will persist the active schedule tab, so when users click on “View Details” and then return to the page, they land on the same tab.

## 🛠️ Key Changes

- Installs `nuqs` and uses `useQueryState` to sync the state with the URL query

## 🧪 How to Test

- Go to `/events/fil-bangkok-2024`
- Select a day in the schedule -> the URL should update
- Click on `View Details` on one of the events and then go back -> you should land on the same tab

⚠️ One limitation is that, on `xs` devices, the last tab can be active and out of the viewport simultaneously.

## 📸 Screenshots

![CleanShot 2024-11-05 at 12 04 33](https://github.com/user-attachments/assets/4a3d5b0f-5b9c-477a-94a5-fe08fcb4a83e)

## 🔖 Resources

- https://nuqs.47ng.com/docs/adapters#nextjs-app-router
- https://nuqs.47ng.com/docs/basic-usage
- https://headlessui.com/react/tabs#controlling-the-selected-tab
