### PR TITLE
[UXIT-1710] Fix speaker images on events page

### DIFF
--- a/src/app/_components/KeyMemberCard.tsx
+++ b/src/app/_components/KeyMemberCard.tsx
@@ -1,6 +1,7 @@
 import Image from 'next/image'
 
 import { LinkedinLogo } from '@phosphor-icons/react/dist/ssr'
+import { clsx } from 'clsx'
 
 import type { StaticImageProps, ImageProps } from '@/types/imageType'
 
@@ -54,13 +55,20 @@ function KeyMemberImage({
 }: Pick<KeyMemberCardProps, 'image' | 'name'>) {
   const isStaticImage = typeof image === 'object'
 
+  const commonProps = {
+    alt: `Photo of ${name}`,
+    quality: 100,
+    sizes: '150px',
+    className: 'rounded object-cover',
+  }
+
   if (isStaticImage) {
     return (
       <Image
+        {...commonProps}
+        className={clsx(commonProps.className, 'aspect-[3/4] w-32 shrink-0')}
         src={image}
-        alt={`Photo of ${name}`}
-        sizes="150px"
-        className="aspect-[3/4] w-32 shrink-0 rounded object-cover"
+        alt={commonProps.alt}
       />
     )
   }
@@ -69,10 +77,10 @@ function KeyMemberImage({
     <div className="relative aspect-[3/4] w-32 shrink-0">
       <Image
         fill
+        {...commonProps}
+        className={commonProps.className}
         src={image}
-        alt={`Photo of ${name}`}
-        sizes="150px"
-        className="rounded object-cover"
+        alt={commonProps.alt}
       />
     </div>
   )

--- a/src/app/_components/KeyMemberCard.tsx
+++ b/src/app/_components/KeyMemberCard.tsx
@@ -60,13 +60,13 @@ function KeyMemberImage({
         src={image}
         alt={`Photo of ${name}`}
         sizes="150px"
-        className="aspect-[3/4] w-32 rounded object-cover"
+        className="aspect-[3/4] w-32 shrink-0 rounded object-cover"
       />
     )
   }
 
   return (
-    <div className="relative aspect-[3/4] w-32">
+    <div className="relative aspect-[3/4] w-32 shrink-0">
       <Image
         fill
         src={image}

--- a/src/app/_components/KeyMemberCard.tsx
+++ b/src/app/_components/KeyMemberCard.tsx
@@ -5,8 +5,9 @@ import { clsx } from 'clsx'
 
 import type { StaticImageProps, ImageProps } from '@/types/imageType'
 
-import { Card } from '@/components/Card'
+import { CustomLink } from '@/components/CustomLink'
 import { Heading } from '@/components/Heading'
+import { Icon } from '@/components/Icon'
 
 type KeyMemberCardProps = {
   name: string
@@ -32,18 +33,21 @@ export function KeyMemberCard({
           {name}
         </Heading>
 
-        <p className="mt-1 text-brand-300">
+        <p className="mb-10 mt-1 text-brand-300">
           {title}
           {company && `, ${company}`}
         </p>
 
-        <Card.Link
+        <CustomLink
           href={linkedin}
-          icon={LinkedinLogo}
-          text="LinkedIn"
-          ariaLabel={`Visit ${name}'s LinkedIn profile.`}
-          left="left-36"
-        />
+          aria-label={`Visit ${name}'s LinkedIn profile.`}
+          className="absolute inset-0 rounded-lg pb-10 focus:brand-outline"
+        >
+          <span className="absolute bottom-4 left-36 inline-flex items-center gap-2 text-brand-300">
+            <Icon component={LinkedinLogo} />
+            LinkedIn
+          </span>
+        </CustomLink>
       </div>
     </li>
   )
@@ -53,35 +57,30 @@ function KeyMemberImage({
   image,
   name,
 }: Pick<KeyMemberCardProps, 'image' | 'name'>) {
-  const isStaticImage = typeof image === 'object'
-
   const commonProps = {
+    src: image,
     alt: `Photo of ${name}`,
     quality: 100,
     sizes: '150px',
     className: 'rounded object-cover',
   }
 
+  const containerClass = 'aspect-[3/4] w-32 shrink-0'
+  const isStaticImage = typeof image === 'object'
+
   if (isStaticImage) {
     return (
       <Image
         {...commonProps}
-        className={clsx(commonProps.className, 'aspect-[3/4] w-32 shrink-0')}
-        src={image}
+        className={clsx(commonProps.className, containerClass)}
         alt={commonProps.alt}
       />
     )
   }
 
   return (
-    <div className="relative aspect-[3/4] w-32 shrink-0">
-      <Image
-        fill
-        {...commonProps}
-        className={commonProps.className}
-        src={image}
-        alt={commonProps.alt}
-      />
+    <div className={clsx('relative', containerClass)}>
+      <Image fill {...commonProps} alt={commonProps.alt} />
     </div>
   )
 }

--- a/src/app/_components/KeyMemberCard.tsx
+++ b/src/app/_components/KeyMemberCard.tsx
@@ -2,30 +2,29 @@ import Image from 'next/image'
 
 import { LinkedinLogo } from '@phosphor-icons/react/dist/ssr'
 
-import type { MemberData } from '@/types/memberType'
+import type { StaticImageProps, ImageProps } from '@/types/imageType'
 
 import { Card } from '@/components/Card'
 import { Heading } from '@/components/Heading'
 
-import type { Speaker } from '@/events/schemas/SpeakerSchema'
+type KeyMemberCardProps = {
+  name: string
+  title: string
+  company?: string
+  linkedin: string
+  image: StaticImageProps['data'] | ImageProps['src']
+}
 
-type KeyMemberCardProps = MemberData | Speaker
-
-export function KeyMemberCard(props: KeyMemberCardProps) {
-  const { name, title, linkedin, image } = props
-  const isStaticImage = typeof image.src === 'object'
-
+export function KeyMemberCard({
+  name,
+  title,
+  company,
+  linkedin,
+  image,
+}: KeyMemberCardProps) {
   return (
     <li className="relative flex rounded-lg border border-brand-500 p-1">
-      <Image
-        src={image.src}
-        alt={`Photo of ${name}`}
-        sizes="150px"
-        className="aspect-[3/4] w-32 rounded object-cover"
-        {...(isStaticImage
-          ? { placeholder: 'blur' }
-          : { width: 150, height: 200 })}
-      />
+      <KeyMemberImage image={image} name={name} />
 
       <div className="m-3 grow">
         <Heading tag="h3" variant="lg">
@@ -34,7 +33,7 @@ export function KeyMemberCard(props: KeyMemberCardProps) {
 
         <p className="mt-1 text-brand-300">
           {title}
-          {'company' in props && props.company && `, ${props.company}`}
+          {company && `, ${company}`}
         </p>
 
         <Card.Link
@@ -46,5 +45,35 @@ export function KeyMemberCard(props: KeyMemberCardProps) {
         />
       </div>
     </li>
+  )
+}
+
+function KeyMemberImage({
+  image,
+  name,
+}: Pick<KeyMemberCardProps, 'image' | 'name'>) {
+  const isStaticImage = typeof image === 'object'
+
+  if (isStaticImage) {
+    return (
+      <Image
+        src={image}
+        alt={`Photo of ${name}`}
+        sizes="150px"
+        className="aspect-[3/4] w-32 rounded object-cover"
+      />
+    )
+  }
+
+  return (
+    <div className="relative aspect-[3/4] w-32">
+      <Image
+        fill
+        src={image}
+        alt={`Photo of ${name}`}
+        sizes="150px"
+        className="rounded object-cover"
+      />
+    </div>
   )
 }

--- a/src/app/about/page.tsx
+++ b/src/app/about/page.tsx
@@ -59,21 +59,26 @@ export default function About() {
 
       <PageSection kicker="What We Do" title="Focus Areas">
         <CardGrid cols="lgThree">
-          {focusAreasData.map((area, i) => (
-            <FocusAreaCard key={i} {...area} />
+          {focusAreasData.map(({ title, description, image }) => (
+            <FocusAreaCard
+              key={title}
+              title={title}
+              description={description}
+              image={image}
+            />
           ))}
         </CardGrid>
       </PageSection>
 
       <PageSection kicker="Board" title="Board of Directors">
         <CardGrid cols="mdTwo">
-          {boardMembersData.map((boardMember) => (
+          {boardMembersData.map(({ name, title, linkedin, image }) => (
             <KeyMemberCard
-              key={boardMember.name}
-              name={boardMember.name}
-              title={boardMember.title}
-              linkedin={boardMember.linkedin}
-              image={boardMember.image}
+              key={name}
+              name={name}
+              title={title}
+              linkedin={linkedin}
+              image={image}
             />
           ))}
         </CardGrid>
@@ -85,13 +90,13 @@ export default function About() {
         description="Leaders from across web3 and the open-source technology communities have come together to foster the Filecoin ecosystem."
       >
         <CardGrid cols="mdTwo">
-          {advisorsData.map((advisor) => (
+          {advisorsData.map(({ name, title, linkedin, image }) => (
             <KeyMemberCard
-              key={advisor.name}
-              name={advisor.name}
-              title={advisor.title}
-              linkedin={advisor.linkedin}
-              image={advisor.image}
+              key={name}
+              name={name}
+              title={title}
+              linkedin={linkedin}
+              image={image}
             />
           ))}
         </CardGrid>

--- a/src/app/about/page.tsx
+++ b/src/app/about/page.tsx
@@ -67,9 +67,9 @@ export default function About() {
 
       <PageSection kicker="Board" title="Board of Directors">
         <CardGrid cols="mdTwo">
-          {boardMembersData.map((boardMember, i) => (
+          {boardMembersData.map((boardMember) => (
             <KeyMemberCard
-              key={i}
+              key={boardMember.name}
               name={boardMember.name}
               title={boardMember.title}
               linkedin={boardMember.linkedin}
@@ -85,9 +85,9 @@ export default function About() {
         description="Leaders from across web3 and the open-source technology communities have come together to foster the Filecoin ecosystem."
       >
         <CardGrid cols="mdTwo">
-          {advisorsData.map((advisor, i) => (
+          {advisorsData.map((advisor) => (
             <KeyMemberCard
-              key={i}
+              key={advisor.name}
               name={advisor.name}
               title={advisor.title}
               linkedin={advisor.linkedin}

--- a/src/app/about/page.tsx
+++ b/src/app/about/page.tsx
@@ -68,7 +68,13 @@ export default function About() {
       <PageSection kicker="Board" title="Board of Directors">
         <CardGrid cols="mdTwo">
           {boardMembersData.map((boardMember, i) => (
-            <KeyMemberCard key={i} {...boardMember} />
+            <KeyMemberCard
+              key={i}
+              name={boardMember.name}
+              title={boardMember.title}
+              linkedin={boardMember.linkedin}
+              image={boardMember.image}
+            />
           ))}
         </CardGrid>
       </PageSection>
@@ -80,7 +86,13 @@ export default function About() {
       >
         <CardGrid cols="mdTwo">
           {advisorsData.map((advisor, i) => (
-            <KeyMemberCard key={i} {...advisor} />
+            <KeyMemberCard
+              key={i}
+              name={advisor.name}
+              title={advisor.title}
+              linkedin={advisor.linkedin}
+              image={advisor.image}
+            />
           ))}
         </CardGrid>
       </PageSection>

--- a/src/app/events/[slug]/components/SpeakersSection.tsx
+++ b/src/app/events/[slug]/components/SpeakersSection.tsx
@@ -12,14 +12,14 @@ export function SpeakersSection({ speakers }: SpeakersSectionProps) {
   return (
     <PageSection kicker="speakers" title="Speakers">
       <CardGrid cols="mdTwo">
-        {speakers.map((speaker) => (
+        {speakers.map(({ name, title, company, linkedin, image }) => (
           <KeyMemberCard
-            key={speaker.name}
-            name={speaker.name}
-            title={speaker.title}
-            company={speaker.company}
-            linkedin={speaker.linkedin}
-            image={speaker.image.src}
+            key={name}
+            name={name}
+            title={title}
+            company={company}
+            linkedin={linkedin}
+            image={image.src}
           />
         ))}
       </CardGrid>

--- a/src/app/events/[slug]/components/SpeakersSection.tsx
+++ b/src/app/events/[slug]/components/SpeakersSection.tsx
@@ -15,11 +15,11 @@ export function SpeakersSection({ speakers }: SpeakersSectionProps) {
         {speakers.map((speaker) => (
           <KeyMemberCard
             key={speaker.name}
-            {...speaker}
-            image={{
-              ...speaker.image,
-              alt: `Photo of ${speaker.name}`,
-            }}
+            name={speaker.name}
+            title={speaker.title}
+            company={speaker.company}
+            linkedin={speaker.linkedin}
+            image={speaker.image.src}
           />
         ))}
       </CardGrid>


### PR DESCRIPTION
## 📝 Description

This PR fixes the speaker images on the FIL Bangkok event page. Currently not all images have the same width on mobile devices.

## 🛠️ Key Changes

- Reworks `KeyMemberCard` to treat dynamic and static images differently


## 🧪 How to Test

- Inspect the About and FIL Bangkok event page on a mobile device and make sure image sizes are consistent
