### PR TITLE
UXIT-1720 - Add Percy Skip for CMS Branches

### DIFF
--- a/.github/workflows/cypress-percy.yml
+++ b/.github/workflows/cypress-percy.yml
@@ -46,7 +46,7 @@ jobs:
             COMMIT_MESSAGE="${{ github.event.head_commit.message }}"
           fi
 
-          if [[ "$COMMIT_MESSAGE" == *"[skip percy]"* ]]; then
+          if [[ "$BRANCH_NAME" == cms/* ]] || [[ "$COMMIT_MESSAGE" == *"[skip percy]"* ]]; then
             echo "skip_percy=true" >> $GITHUB_OUTPUT
           else
             echo "skip_percy=false" >> $GITHUB_OUTPUT


### PR DESCRIPTION
This update modifies the GitHub Actions workflow to automatically skip Percy tests for branches prefixed with `cms/`. By implementing this change, we aim to conserve Percy screenshot resources and streamline the content team’s workflow by eliminating the need to approve visual changes for purely content-related updates.