### PR TITLE
[UXIT-1719] Don’t trigger Sentry in development mode [skip percy]

### DIFF
--- a/sentry.client.config.ts
+++ b/sentry.client.config.ts
@@ -4,15 +4,11 @@
 
 import * as Sentry from '@sentry/nextjs'
 
-if (process.env.NEXT_PUBLIC_DISABLE_SENTRY !== 'true') {
-  Sentry.init({
-    dsn: process.env.NEXT_PUBLIC_SENTRY_DSN,
-    tracesSampleRate: 0.05,
-    debug: false,
-    replaysOnErrorSampleRate: 1.0,
-    replaysSessionSampleRate: 0.01,
-    environment: process.env.NODE_ENV || 'production',
-  })
-} else {
-  console.log('Sentry is disabled on the client.')
-}
+Sentry.init({
+  dsn: process.env.NEXT_PUBLIC_SENTRY_DSN,
+  tracesSampleRate: 0.05,
+  debug: false,
+  replaysOnErrorSampleRate: 1.0,
+  replaysSessionSampleRate: 0.01,
+  environment: process.env.NODE_ENV,
+})

--- a/sentry.edge.config.ts
+++ b/sentry.edge.config.ts
@@ -5,12 +5,8 @@
 
 import * as Sentry from '@sentry/nextjs'
 
-if (process.env.NEXT_PUBLIC_DISABLE_SENTRY !== 'true') {
-  Sentry.init({
-    dsn: process.env.NEXT_PUBLIC_SENTRY_DSN,
-    tracesSampleRate: 0.05,
-    debug: false,
-  })
-} else {
-  console.log('Sentry is disabled on the edge.')
-}
+Sentry.init({
+  dsn: process.env.NEXT_PUBLIC_SENTRY_DSN,
+  tracesSampleRate: 0.05,
+  debug: false,
+})

--- a/sentry.server.config.ts
+++ b/sentry.server.config.ts
@@ -4,13 +4,21 @@
 
 import * as Sentry from '@sentry/nextjs'
 
-if (process.env.NEXT_PUBLIC_DISABLE_SENTRY !== 'true') {
-  Sentry.init({
-    dsn: process.env.NEXT_PUBLIC_SENTRY_DSN,
-    tracesSampleRate: 0.05,
-    debug: false,
-    environment: process.env.NODE_ENV || 'production',
-  })
+const dsn = process.env.NEXT_PUBLIC_SENTRY_DSN
+const environment = process.env.NODE_ENV
+
+// If dsn is undefined, Sentry SDK will be disabled
+Sentry.init({
+  dsn,
+  tracesSampleRate: 0.05,
+  debug: false,
+  environment,
+})
+
+if (dsn) {
+  console.log(`✅ Sentry is enabled in ${environment}`)
 } else {
-  console.log('Sentry is disabled on the server.')
+  console.log(
+    `ℹ️ Sentry is disabled in ${environment}: To enable it, set NEXT_PUBLIC_SENTRY_DSN in the associated .env for this environment`,
+  )
 }

--- a/src/app/global-error.tsx
+++ b/src/app/global-error.tsx
@@ -11,7 +11,11 @@ import { FILECOIN_FOUNDATION_URLS } from '@/constants/siteMetadata'
 import ErrorMessage from '@/components/ErrorMessage'
 import { SiteLayout } from '@/components/SiteLayout'
 
-export default function GlobalError({ error }: { error: Error }) {
+type GlobalErrorProps = {
+  error: Error
+}
+
+export default function GlobalError({ error }: GlobalErrorProps) {
   useEffect(() => {
     Sentry.captureException(error)
   }, [error])


### PR DESCRIPTION
## 📝 Description

This PR updates our Sentry config to only trigger in production.

Right now, many development bugs pollute our [Sentry dashboard](https://filecoin-foundation-qk.sentry.io/issues/?statsPeriod=90d&utc=true), and the real bugs get lost there.

## 🛠️ Key Changes

1. The Sentry config now relies on `process.env.NEXT_PUBLIC_SENTRY_DSN` to enable/disable tracking, as suggested by [one of the maintainers](https://github.com/getsentry/sentry-javascript/discussions/7760#discussioncomment-5533016) of the Sentry JS SDK. If set, bugs are reported. If not set, they are not.
2. On [Vercel](https://vercel.com/filecoin-foundations-projects/filecoin-foundation-site/settings/environment-variables), I deleted `NEXT_PUBLIC_DISABLE_SENTRY` from our Environment Variables as it didn't seem to work, and updated `NEXT_PUBLIC_SENTRY_DSN` to only apply to production.

## 📌 To-Do Before Merging

- Make sure all teammates sync their `.env` with Vercel
- Go to the Sentry dashboard and delete all development bugs

## 🧪 How to Test

1. Pull the latest Vercel env variable using `vercel env pull` in the terminal. It should delete `NEXT_PUBLIC_SENTRY_DSN` and `NEXT_PUBLIC_DISABLE_SENTRY` from your `.env`
2. Trigger a manual error anywhere in the app
```ts
export default function Home() {
  setTimeout(() => {
    throw new Error('A custom error message...')
  }, 3000)

  return (
```
3. Go to Sentry and make sure the error is NOT there.
