### PR TITLE
[UXIT-1720] Fix - Percy CMS Branch Detection [skip percy]

### DIFF
--- a/.github/workflows/cypress-percy.yml
+++ b/.github/workflows/cypress-percy.yml
@@ -41,8 +41,10 @@ jobs:
         id: test-type
         run: |
           if [[ "${{ github.event_name }}" == "pull_request" ]]; then
+            BRANCH_NAME="${{ github.head_ref }}"
             COMMIT_MESSAGE="${{ github.event.pull_request.title }}"
           else
+            BRANCH_NAME="${{ github.ref_name }}"
             COMMIT_MESSAGE="${{ github.event.head_commit.message }}"
           fi
 


### PR DESCRIPTION
## Description

Percy visual tests should be skipped for CMS-related branches to avoid unnecessary visual testing of content-only changes. The previous implementation wasn't correctly identifying these branches, leading to unnecessary Percy test runs.

## Main Changes

_Previously, Percy tests weren't being skipped for CMS branches because the branch name wasn't being set before evaluation_

- Fixed the branch name detection in the GitHub Actions workflow
- Added proper capture of `BRANCH_NAME` using `github.head_ref` for pull requests and `github.ref_name` for direct pushes

## Testing

See screenshots below:

- Verified that PRs from branches starting with `cms/` now correctly skip Percy tests
- Confirmed that regular branches still run Percy tests as expected
- Confirmed that regular branches with `[skip percy]` in the title still skip Percy tests

1. Test PR - #823 - A `cms/` branch

![CleanShot 2024-11-13 at 11 07 30@2x](https://github.com/user-attachments/assets/1485ab49-c2d2-4da0-81d2-16350a7784c9)

2. Test PR - #824 - A regular branch

![CleanShot 2024-11-13 at 11 07 58@2x](https://github.com/user-attachments/assets/9e88901b-4b17-4f75-bd0e-0944e79f9f24)

3. Test PR - #835 - A regular branch with `[skip percy]` in the title
![CleanShot 2024-11-18 at 13 58 02@2x](https://github.com/user-attachments/assets/51e1b8c0-2abb-4149-98cf-c5c0ce783688)
