### PR TITLE
[UXIT-1783] - Rename CMS Project Subcategories

### DIFF
--- a/src/content/ecosystem-explorer/categories/artificial-intelligence.yml
+++ b/src/content/ecosystem-explorer/categories/artificial-intelligence.yml
@@ -1,4 +1,4 @@
 name: Artificial Intelligence
 slug: artificial-intelligence
 subcategories:
-  - artificial-productivity-utilities
+  - ai-productivity-utilities

--- a/src/content/ecosystem-explorer/projects/bagel.md
+++ b/src/content/ecosystem-explorer/projects/bagel.md
@@ -7,7 +7,7 @@ image:
   src: /assets/images/bagel-logo.webp
 category: artificial-intelligence
 subcategories:
-  - artificial-productivity-utilities
+  - ai-productivity-utilities
 description: Bagel is an AI and cryptography research lab, building a credibly
   neutral, peer-to-peer machine learning ecosystem.
 website: https://bagel.net/

--- a/src/content/ecosystem-explorer/projects/hauska-ai.md
+++ b/src/content/ecosystem-explorer/projects/hauska-ai.md
@@ -15,7 +15,7 @@ image:
 website: https://www.hauska.ai/
 year-joined: 2023-12-27T20:42:42.062000Z
 subcategories:
-  - artificial-productivity-utilities
+  - ai-productivity-utilities
 seo:
   description:
     Hauska AI provides AI-driven solutions for decentralized data analysis

--- a/src/content/ecosystem-explorer/projects/neyra-ai-from-wise-data-pte.md
+++ b/src/content/ecosystem-explorer/projects/neyra-ai-from-wise-data-pte.md
@@ -12,7 +12,7 @@ tech:
 website: "https://drive.neyra.ai/"
 year-joined: 2023-11-01T18:39:58.216Z
 subcategories:
-  - artificial-productivity-utilities
+  - ai-productivity-utilities
 seo:
   description:
     Neyra AI provides AI-driven solutions for decentralized data analysis

--- a/src/content/ecosystem-explorer/projects/nuklai.md
+++ b/src/content/ecosystem-explorer/projects/nuklai.md
@@ -9,7 +9,7 @@ image:
   src: /assets/images/nuklai.png
 category: artificial-intelligence
 subcategories:
-  - artificial-productivity-utilities
+  - ai-productivity-utilities
 description: ‍‍Nuklai is a collaborative data ecosystem and infrastructure provider for private data networks.
 website: https://www.nukl.ai/
 tech:

--- a/src/content/ecosystem-explorer/projects/waterlily-ai.md
+++ b/src/content/ecosystem-explorer/projects/waterlily-ai.md
@@ -20,7 +20,7 @@ twitter: "https://twitter.com/Waterlily"
 video-url: "https://www.youtube.com/embed/AhCScfpeN3k"
 year-joined: 2023-04-25T22:00:00.000Z
 subcategories:
-  - artificial-productivity-utilities
+  - ai-productivity-utilities
 seo:
   description:
     Waterlily AI provides AI-driven solutions for decentralized data analysis

--- a/src/content/ecosystem-explorer/subcategories/ai-productivity-utilities.yml
+++ b/src/content/ecosystem-explorer/subcategories/ai-productivity-utilities.yml
@@ -1,0 +1,3 @@
+name: "AI Productivity & Utilities"
+slug: "ai-productivity-utilities"
+"parent_category": "artificial-intelligence"

--- a/src/content/ecosystem-explorer/subcategories/artificial-productivity-utilities.yml
+++ b/src/content/ecosystem-explorer/subcategories/artificial-productivity-utilities.yml
@@ -1,3 +1,0 @@
-name: "Artificial Productivity & Utilities"
-slug: "artificial-productivity-utilities"
-"parent_category": "artificial-intelligence"

--- a/src/content/ecosystem-explorer/subcategories/arts-collectibles-nfts.yml
+++ b/src/content/ecosystem-explorer/subcategories/arts-collectibles-nfts.yml
@@ -1,3 +1,3 @@
-name: "Arts, Collectibles & Non-Fungible Tokens (NFTs)"
+name: "Arts, Collectibles & NFTs"
 slug: "arts-collectibles-nfts"
 "parent_category": "media-entertainment"

--- a/src/content/ecosystem-explorer/subcategories/dapp.yml
+++ b/src/content/ecosystem-explorer/subcategories/dapp.yml
@@ -1,3 +1,3 @@
-name: "Decentralized Application (Dapp)"
+name: "Dapp"
 slug: "dapp"
 "parent_category": "tooling-productivity"

--- a/src/content/ecosystem-explorer/subcategories/governance-daos-public-goods.yml
+++ b/src/content/ecosystem-explorer/subcategories/governance-daos-public-goods.yml
@@ -1,3 +1,3 @@
-name: "Governance & Decentralized Autonomous Organizations (DAOs), Public Goods"
+name: "Governance, DAOs & Public Goods"
 slug: "governance-daos-public-goods"
 "parent_category": "public-goods-dweb"


### PR DESCRIPTION
## 📝 Description

This PR updates the names of some CMS project subcategories to use common acronyms where possible, reducing long text that messes with the UI layout. The updated names align more closely with the [Figma](https://www.figma.com/design/0pBfQs5tKI6bx5ypPIfVRA/FIL.org-V4-Prototypes?node-id=2696-54996&t=mU9Fokr0IeiR4PAS-4) designs.

These changes will benefit two upcoming releases, both of which currently rely on fully spelled-out names:
1. The new category filters - [Preview](https://filecoin-foundation-si-git-87e7be-filecoin-foundations-projects.vercel.app/ecosystem-explorer)
2. The updated select fields in the Ecosystem Project form - [Preview](https://filecoin-foundation-si-git-01a414-filecoin-foundations-projects.vercel.app/ecosystem-explorer/project-form)

## 🛠️ Key Changes

The changes apply to the following subcategories:
- AI Productivity & Utilities
- Arts, Collectibles & NFTs
- Dapp
- Governance, DAOs & Public Goods