### PR TITLE
[UXIT-1730] Refactor scrollToSection.ts

### DIFF
--- a/src/app/security/maturity-model/components/Article.tsx
+++ b/src/app/security/maturity-model/components/Article.tsx
@@ -19,7 +19,7 @@ type ArticleProps = {
 
 function ArticleComponent(
   { title, slug, children }: ArticleProps,
-  ref: React.Ref<HTMLElement>,
+  ref: React.ForwardedRef<HTMLElement>,
 ) {
   const { updateHash, clearHashIfPresent, getHashFromSlug } = useUrlHash()
 
@@ -29,11 +29,11 @@ function ArticleComponent(
     },
   })
 
+  const isRefObject = ref && 'current' in ref
+
   function combinedRef(node: HTMLElement | null) {
-    if (typeof ref === 'function') {
-      ref(node)
-    } else if (ref) {
-      ;(ref as React.MutableRefObject<HTMLElement | null>).current = node
+    if (isRefObject) {
+      ref.current = node
     }
     observerRef(node)
   }
@@ -49,7 +49,7 @@ function ArticleComponent(
           style={{ fontWeight: 'inherit' }}
           onClick={(e: React.MouseEvent<HTMLAnchorElement>) => {
             e.preventDefault()
-            if (ref && 'current' in ref) {
+            if (isRefObject) {
               scrollToSection({ sectionRef: ref })
             }
           }}

--- a/src/app/security/maturity-model/components/Article.tsx
+++ b/src/app/security/maturity-model/components/Article.tsx
@@ -1,3 +1,5 @@
+'use client'
+
 import React, { forwardRef } from 'react'
 
 import Link from 'next/link'

--- a/src/app/security/maturity-model/components/Article.tsx
+++ b/src/app/security/maturity-model/components/Article.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import React, { forwardRef } from 'react'
+import React from 'react'
 
 import Link from 'next/link'
 
@@ -10,40 +10,40 @@ import { useIntersectionObserver } from 'usehooks-ts'
 
 import { Icon } from '@/components/Icon'
 
-import { scrollToSection } from '../utils/scrollToSection'
 import { useUrlHash } from '../utils/useUrlHash'
 
 type ArticleProps = {
   title: string
   slug: string
   children: React.ReactNode
+  setRef: (slug: string, element: HTMLElement | null) => void
+  scrollToSection: (slug: string) => void
 } & React.ComponentPropsWithoutRef<'article'>
 
-function ArticleComponent(
-  { title, slug, children }: ArticleProps,
-  ref: React.ForwardedRef<HTMLElement>,
-) {
+export function Article({
+  title,
+  slug,
+  children,
+  setRef,
+  scrollToSection,
+}: ArticleProps) {
   const { updateHash, clearHashIfPresent, getHashFromSlug } = useUrlHash()
 
-  const { ref: observerRef } = useIntersectionObserver({
+  const { ref: setHookRef } = useIntersectionObserver({
     onChange: (isIntersecting) => {
       isIntersecting ? updateHash(slug) : clearHashIfPresent(slug)
     },
   })
 
-  const isRefObject = ref && 'current' in ref
-
-  function combinedRef(node: HTMLElement | null) {
-    if (isRefObject) {
-      ref.current = node
-    }
-    observerRef(node)
+  function setRefs(node: HTMLElement | null) {
+    setRef(slug, node)
+    setHookRef(node)
   }
 
   const sectionHash = getHashFromSlug(slug)
 
   return (
-    <article ref={combinedRef}>
+    <article ref={setRefs}>
       <h3 id={slug}>
         <Link
           href={sectionHash as Route}
@@ -51,9 +51,7 @@ function ArticleComponent(
           style={{ fontWeight: 'inherit' }}
           onClick={(e: React.MouseEvent<HTMLAnchorElement>) => {
             e.preventDefault()
-            if (isRefObject) {
-              scrollToSection({ sectionRef: ref })
-            }
+            scrollToSection(slug)
           }}
         >
           {title}
@@ -66,5 +64,3 @@ function ArticleComponent(
     </article>
   )
 }
-
-export const Article = forwardRef<HTMLElement, ArticleProps>(ArticleComponent)

--- a/src/app/security/maturity-model/components/CoreFunctions.tsx
+++ b/src/app/security/maturity-model/components/CoreFunctions.tsx
@@ -1,14 +1,15 @@
 import React from 'react'
 
 import { coreFunctionsData } from '../data/coreFunctionsData'
+import type { SectionRefsProps } from '../types/sectionRefsTypes'
 
 import { Article } from './Article'
 
-export function CoreFunctions() {
+export function CoreFunctions({ sectionRefs }: SectionRefsProps) {
   return (
     <div className="prose first:prose-h3:mt-0 prose-h4:text-brand-300 prose-h5:text-brand-300">
       {coreFunctionsData.map(({ title, Content, slug }, index) => (
-        <Article key={slug} title={title} slug={slug}>
+        <Article key={slug} ref={sectionRefs[slug]} title={title} slug={slug}>
           <Content />
           {index < coreFunctionsData.length - 1 && (
             <hr className="border-brand-300" />

--- a/src/app/security/maturity-model/components/CoreFunctions.tsx
+++ b/src/app/security/maturity-model/components/CoreFunctions.tsx
@@ -5,6 +5,7 @@ import type { SectionRefsProps } from '../types/sectionRefsTypes'
 
 import { Article } from './Article'
 
+// This should be deleted
 export function CoreFunctions({ sectionRefs }: SectionRefsProps) {
   return (
     <div className="prose first:prose-h3:mt-0 prose-h4:text-brand-300 prose-h5:text-brand-300">

--- a/src/app/security/maturity-model/components/DesktopTableOfContents.tsx
+++ b/src/app/security/maturity-model/components/DesktopTableOfContents.tsx
@@ -5,10 +5,11 @@ import Link from 'next/link'
 import { clsx } from 'clsx'
 
 import { coreFunctionsData } from '../data/coreFunctionsData'
+import type { SectionRefsProps } from '../types/sectionRefsTypes'
 import { scrollToSection } from '../utils/scrollToSection'
 import { useUrlHash } from '../utils/useUrlHash'
 
-export function DesktopTableOfContents() {
+export function DesktopTableOfContents({ sectionRefs }: SectionRefsProps) {
   const { isSectionActive, getHashFromSlug } = useUrlHash()
 
   return (
@@ -34,7 +35,7 @@ export function DesktopTableOfContents() {
                 )}
                 onClick={(e: React.MouseEvent<HTMLAnchorElement>) => {
                   e.preventDefault()
-                  scrollToSection(sectionHash)
+                  scrollToSection({ sectionRef: sectionRefs[slug] })
                 }}
               >
                 {title}

--- a/src/app/security/maturity-model/components/DesktopTableOfContents.tsx
+++ b/src/app/security/maturity-model/components/DesktopTableOfContents.tsx
@@ -4,12 +4,19 @@ import Link from 'next/link'
 
 import { clsx } from 'clsx'
 
-import { coreFunctionsData } from '../data/coreFunctionsData'
-import type { SectionRefsProps } from '../types/sectionRefsTypes'
-import { scrollToSection } from '../utils/scrollToSection'
 import { useUrlHash } from '../utils/useUrlHash'
 
-export function DesktopTableOfContents({ sectionRefs }: SectionRefsProps) {
+import type { DataWithRef } from './TableOfContents'
+
+type DesktopTableOfContentsProps = {
+  data: Array<DataWithRef>
+  scrollToSection: (slug: string) => void
+}
+
+export function DesktopTableOfContents({
+  data,
+  scrollToSection,
+}: DesktopTableOfContentsProps) {
   const { isSectionActive, getHashFromSlug } = useUrlHash()
 
   return (
@@ -19,7 +26,7 @@ export function DesktopTableOfContents({ sectionRefs }: SectionRefsProps) {
       </p>
 
       <ol>
-        {coreFunctionsData.map(({ slug, title }) => {
+        {data.map(({ slug, title }) => {
           const sectionHash = getHashFromSlug(slug)
           const isCurrentSection = isSectionActive(slug)
 
@@ -35,7 +42,7 @@ export function DesktopTableOfContents({ sectionRefs }: SectionRefsProps) {
                 )}
                 onClick={(e: React.MouseEvent<HTMLAnchorElement>) => {
                   e.preventDefault()
-                  scrollToSection({ sectionRef: sectionRefs[slug] })
+                  scrollToSection(slug)
                 }}
               >
                 {title}

--- a/src/app/security/maturity-model/components/MobileTableOfContents.tsx
+++ b/src/app/security/maturity-model/components/MobileTableOfContents.tsx
@@ -10,6 +10,7 @@ import {
 import { ListboxOptions } from '@/components/Listbox/ListboxOptions'
 
 import { coreFunctionsData } from '../data/coreFunctionsData'
+import type { SectionRefsProps } from '../types/sectionRefsTypes'
 import { scrollToSection } from '../utils/scrollToSection'
 import { useUrlHash } from '../utils/useUrlHash'
 
@@ -17,11 +18,11 @@ const options = coreFunctionsData.map(({ slug, title }) => ({
   id: slug,
   name: title,
 }))
+
 const firstOption = options[0]
 
-export function MobileTableOfContents() {
-  const { updateHash, isSectionActive, getHashFromSlug } = useUrlHash()
-
+export function MobileTableOfContents({ sectionRefs }: SectionRefsProps) {
+  const { isSectionActive, updateHash } = useUrlHash()
   const selectedOption =
     options.find((option) => isSectionActive(option.id)) || firstOption
 
@@ -32,7 +33,6 @@ export function MobileTableOfContents() {
         onChange={scrollToActiveSection}
       >
         <ListboxButton text={selectedOption.name} />
-
         <ListboxOptions matchButtonWidth>
           {options.map((option) => (
             <ListboxOption key={option.id} option={option} />
@@ -45,7 +45,7 @@ export function MobileTableOfContents() {
   function scrollToActiveSection(option: OptionType) {
     updateHash(option.id)
 
-    const sectionHash = getHashFromSlug(option.id)
-    scrollToSection(sectionHash)
+    const sectionRef = sectionRefs[option.id]
+    scrollToSection({ sectionRef })
   }
 }

--- a/src/app/security/maturity-model/components/MobileTableOfContents.tsx
+++ b/src/app/security/maturity-model/components/MobileTableOfContents.tsx
@@ -1,5 +1,7 @@
 'use client'
 
+import { useMemo } from 'react'
+
 import { Listbox as HeadlessUIListbox } from '@headlessui/react'
 
 import { ListboxButton } from '@/components/Listbox/ListboxButton'
@@ -9,22 +11,28 @@ import {
 } from '@/components/Listbox/ListboxOption'
 import { ListboxOptions } from '@/components/Listbox/ListboxOptions'
 
-import { coreFunctionsData } from '../data/coreFunctionsData'
-import type { SectionRefsProps } from '../types/sectionRefsTypes'
-import { scrollToSection } from '../utils/scrollToSection'
 import { useUrlHash } from '../utils/useUrlHash'
 
-const options = coreFunctionsData.map(({ slug, title }) => ({
-  id: slug,
-  name: title,
-}))
+import type { DataWithRef } from './TableOfContents'
 
-const firstOption = options[0]
+type MobileTableOfContentsProps = {
+  data: Array<DataWithRef>
+  scrollToSection: (slug: string) => void
+}
 
-export function MobileTableOfContents({ sectionRefs }: SectionRefsProps) {
+export function MobileTableOfContents({
+  data,
+  scrollToSection,
+}: MobileTableOfContentsProps) {
   const { isSectionActive, updateHash } = useUrlHash()
+
+  const options = useMemo(
+    () => data.map(({ slug, title }) => ({ id: slug, name: title })),
+    [data],
+  )
+
   const selectedOption =
-    options.find((option) => isSectionActive(option.id)) || firstOption
+    options.find((option) => isSectionActive(option.id)) || options[0]
 
   return (
     <nav aria-label="Table of Contents" className="w-full max-w-sm">
@@ -44,8 +52,6 @@ export function MobileTableOfContents({ sectionRefs }: SectionRefsProps) {
 
   function scrollToActiveSection(option: OptionType) {
     updateHash(option.id)
-
-    const sectionRef = sectionRefs[option.id]
-    scrollToSection({ sectionRef })
+    scrollToSection(option.id)
   }
 }

--- a/src/app/security/maturity-model/components/TableOfContents.tsx
+++ b/src/app/security/maturity-model/components/TableOfContents.tsx
@@ -1,0 +1,45 @@
+'use client'
+
+import React, { createRef, useRef } from 'react'
+
+import dynamic from 'next/dynamic'
+
+import { coreFunctionsData } from '../data/coreFunctionsData'
+
+import { CoreFunctions } from './CoreFunctions'
+import { MobileTableOfContents } from './MobileTableOfContents'
+
+const DynamicDesktopTableOfContents = dynamic(
+  () =>
+    import('./DesktopTableOfContents').then(
+      (module) => module.DesktopTableOfContents,
+    ),
+  { ssr: false },
+)
+
+export function TableOfContents() {
+  const sectionRefs = useRef(
+    coreFunctionsData.reduce(
+      (acc, { slug }) => {
+        acc[slug] = createRef<HTMLElement>()
+        return acc
+      },
+
+      {} as Record<string, React.RefObject<HTMLElement>>,
+    ),
+  )
+
+  return (
+    <>
+      <div className="grow">
+        <CoreFunctions sectionRefs={sectionRefs.current} />
+      </div>
+      <div className="hidden lg:sticky lg:top-12 lg:order-last lg:block lg:w-72">
+        <DynamicDesktopTableOfContents sectionRefs={sectionRefs.current} />
+      </div>
+      <div className="sticky top-6 z-10 order-first block lg:hidden">
+        <MobileTableOfContents sectionRefs={sectionRefs.current} />
+      </div>
+    </>
+  )
+}

--- a/src/app/security/maturity-model/components/TableOfContents.tsx
+++ b/src/app/security/maturity-model/components/TableOfContents.tsx
@@ -5,6 +5,7 @@ import React, { createRef, useRef } from 'react'
 import dynamic from 'next/dynamic'
 
 import { coreFunctionsData } from '../data/coreFunctionsData'
+import type { SectionRefsProps } from '../types/sectionRefsTypes'
 
 import { CoreFunctions } from './CoreFunctions'
 import { MobileTableOfContents } from './MobileTableOfContents'
@@ -25,7 +26,7 @@ export function TableOfContents() {
         return acc
       },
 
-      {} as Record<string, React.RefObject<HTMLElement>>,
+      {} as SectionRefsProps['sectionRefs'],
     ),
   )
 

--- a/src/app/security/maturity-model/page.tsx
+++ b/src/app/security/maturity-model/page.tsx
@@ -1,5 +1,3 @@
-import dynamic from 'next/dynamic'
-
 import { PATHS } from '@/constants/paths'
 
 import { graphicsData } from '@/data/graphicsData'
@@ -17,18 +15,10 @@ import { PageLayout } from '@/components/PageLayout'
 import { PageSection } from '@/components/PageSection'
 import { StructuredDataScript } from '@/components/StructuredDataScript'
 
-import { CoreFunctions } from './components/CoreFunctions'
-import { MobileTableOfContents } from './components/MobileTableOfContents'
+import { TableOfContents } from './components/TableOfContents'
 import { applicationAndUseData } from './data/applicationAndUseData'
+import { coreFunctionsData } from './data/coreFunctionsData'
 import { generateStructuredData } from './utils/generateStructuredData'
-
-const DynamicDesktopTableOfContents = dynamic(
-  () =>
-    import('./components/DesktopTableOfContents').then(
-      (module) => module.DesktopTableOfContents,
-    ),
-  { ssr: false },
-)
 
 const { header, seo } = getFrontmatter({
   path: PATHS.MATURITY_MODEL,
@@ -79,15 +69,7 @@ export default function MaturityModel() {
         title="Explore the Core Functions"
       >
         <div className="flex flex-col gap-8 lg:relative lg:flex-row lg:items-start lg:gap-12">
-          <div className="grow">
-            <CoreFunctions />
-          </div>
-          <div className="hidden lg:sticky lg:top-12 lg:order-last lg:block lg:w-72">
-            <DynamicDesktopTableOfContents />
-          </div>
-          <div className="sticky top-6 z-10 order-first block lg:hidden">
-            <MobileTableOfContents />
-          </div>
+          <TableOfContents />
         </div>
       </PageSection>
     </PageLayout>

--- a/src/app/security/maturity-model/page.tsx
+++ b/src/app/security/maturity-model/page.tsx
@@ -17,7 +17,6 @@ import { StructuredDataScript } from '@/components/StructuredDataScript'
 
 import { TableOfContents } from './components/TableOfContents'
 import { applicationAndUseData } from './data/applicationAndUseData'
-import { coreFunctionsData } from './data/coreFunctionsData'
 import { generateStructuredData } from './utils/generateStructuredData'
 
 const { header, seo } = getFrontmatter({

--- a/src/app/security/maturity-model/types/sectionRefsTypes.ts
+++ b/src/app/security/maturity-model/types/sectionRefsTypes.ts
@@ -1,0 +1,5 @@
+export type SectionRefs = Record<string, React.RefObject<HTMLElement>>
+
+export type SectionRefsProps = {
+  sectionRefs: SectionRefs
+}

--- a/src/app/security/maturity-model/utils/scrollToSection.ts
+++ b/src/app/security/maturity-model/utils/scrollToSection.ts
@@ -1,13 +1,14 @@
-'use client'
+type ScrollToSectionProps = {
+  sectionRef: React.RefObject<HTMLElement>
+}
 
-export function scrollToSection(selector: string) {
-  const element = document.querySelector(selector)
-
-  if (!element) {
-    console.error(`Element with selector "${selector}" does not exist`)
+export function scrollToSection({ sectionRef }: ScrollToSectionProps) {
+  if (!sectionRef.current) {
+    console.error(`The referenced element does not exist`)
+    return
   }
 
-  element?.scrollIntoView({
+  sectionRef.current.scrollIntoView({
     block: 'start',
     behavior: 'smooth',
   })

--- a/src/app/security/maturity-model/utils/scrollToSection.ts
+++ b/src/app/security/maturity-model/utils/scrollToSection.ts
@@ -2,6 +2,7 @@ type ScrollToSectionProps = {
   sectionRef: React.RefObject<HTMLElement>
 }
 
+// This should be deleted
 export function scrollToSection({ sectionRef }: ScrollToSectionProps) {
   if (!sectionRef.current) {
     console.error(`The referenced element does not exist`)


### PR DESCRIPTION
## 📝 Description

This PR refactors the `scrollToSection` function by replacing `document.querySelector` with React `refs`. New `TableOfContents` component is responsible for centralizing `sectionRefs` and passing them to parts of the page that use the `scrollToSection` function.

- **Type:** Refactor

## 🧪 How to Test

- Check if scroll to section functionality works as expected on `security/maturity-model`
