### PR TITLE
[UXIT-831] Add 404 tracking code for Plausible.io

### DIFF
--- a/src/app/not-found-analytics.tsx
+++ b/src/app/not-found-analytics.tsx
@@ -1,0 +1,17 @@
+'use client'
+
+import Script from 'next/script'
+
+import { usePlausible } from 'next-plausible'
+
+export default function NotFoundAnalytics() {
+  const plausible = usePlausible()
+
+  return (
+    <Script
+      onReady={() =>
+        plausible('404', { props: { path: window.location.pathname } })
+      }
+    />
+  )
+}

--- a/src/app/not-found.tsx
+++ b/src/app/not-found.tsx
@@ -1,9 +1,14 @@
 import ErrorMessage from '@/components/ErrorMessage'
 
+import NotFoundAnalytics from './not-found-analytics'
+
 export default function NotFound() {
   return (
-    <ErrorMessage kicker="404" title="Page Not Found">
-      We&apos;re sorry, but the page you were looking for is not here.
-    </ErrorMessage>
+    <>
+      <NotFoundAnalytics />
+      <ErrorMessage kicker="404" title="Page Not Found">
+        We&apos;re sorry, but the page you were looking for is not here.
+      </ErrorMessage>
+    </>
   )
 }


### PR DESCRIPTION
## 📝 Description

This PR adds script to track 404 events in plausible.

- **Type:** New feature

## 🧪 How to Test

Plausible only tracks events from domains that are registered in Plausible account, so we can't test from localhost. 

## 🔖 Resources

- [Plausible - error pages tracking 404](https://plausible.io/docs/error-pages-tracking-404)
- [Nextjs - script](https://nextjs.org/docs/pages/api-reference/components/script)
- [NextJS recipe: Tracking 404s with Plausible and NextJS App Router](https://calebfaruki.me/nextjs-plausible-app-router-404)
