### PR TITLE
[UXIT-1823] Fix Layout Shifts for FilterMenu

### DIFF
--- a/src/app/_components/CategorySidebar.tsx
+++ b/src/app/_components/CategorySidebar.tsx
@@ -54,17 +54,7 @@ CategorySidebar.Container = function List({
   children,
   as: Component = 'ul',
 }: CategoryContainerProps) {
-  return (
-    <Component
-      className={clsx(
-        'space-y-4',
-        touchTarget.offsetClassX,
-        touchTarget.offsetClassY,
-      )}
-    >
-      {children}
-    </Component>
-  )
+  return <Component className="space-y-4">{children}</Component>
 }
 
 CategorySidebar.Item = function Item({

--- a/src/app/_components/CategorySidebar.tsx
+++ b/src/app/_components/CategorySidebar.tsx
@@ -6,10 +6,9 @@ import { clsx } from 'clsx'
 
 import type { OptionType } from './Listbox/ListboxOption'
 
-const touchTarget = {
-  class: 'px-4',
-  offsetClassY: '-mt-4',
-  offsetClassX: '-ml-4',
+const TOUCH_TARGET = {
+  touchAreaPaddingX: 'px-4',
+  touchAreaOffsetX: '-ml-4',
 } as const
 
 type CategorySidebarProps = {
@@ -54,7 +53,11 @@ CategorySidebar.Container = function List({
   children,
   as: Component = 'ul',
 }: CategoryContainerProps) {
-  return <Component className="space-y-4">{children}</Component>
+  return (
+    <Component className={clsx('space-y-4', TOUCH_TARGET.touchAreaOffsetX)}>
+      {children}
+    </Component>
+  )
 }
 
 CategorySidebar.Item = function Item({
@@ -89,7 +92,7 @@ CategorySidebar.Button = function Button({
           ? 'bg-brand-700 text-brand-400'
           : 'bg-transparent text-brand-300',
         count !== undefined && 'inline-flex items-baseline gap-2',
-        touchTarget.class,
+        TOUCH_TARGET.touchAreaPaddingX,
       )}
       onClick={handleClick}
     >

--- a/src/app/_components/FilterContainer.tsx
+++ b/src/app/_components/FilterContainer.tsx
@@ -25,7 +25,7 @@ type WrapperProps = {
 
 export function FilterContainer({ children }: LayoutProps) {
   return (
-    <div className="flex flex-col items-baseline gap-6 lg:flex-row">
+    <div className="grid grid-cols-1 gap-6 lg:grid-cols-[280px_1fr]">
       {children}
     </div>
   )


### PR DESCRIPTION
## 📝 Description

Replace flexbox with grid to prevent layout shift.

**Type:** Bug fix

https://github.com/user-attachments/assets/582a104c-fb90-46d5-9d02-637e8d63754f

