### PR TITLE
[Skill Stretch] Use startTransition to improve INP

### DIFF
--- a/src/app/_components/Sort.tsx
+++ b/src/app/_components/Sort.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useState, useEffect } from 'react'
+import { startTransition, useState, useEffect } from 'react'
 
 import { type SortOption, type ValidSortKey } from '@/types/sortTypes'
 
@@ -27,12 +27,16 @@ export function Sort({ query, options, defaultQuery }: SortProps) {
     const sortIsReset = query === defaultQuery
 
     if (sortIsReset) {
-      setSortId(defaultQuery)
+      startTransition(() => {
+        setSortId(defaultQuery)
+      })
     }
   }, [query, defaultQuery])
 
   function handleSortChange(newOption: SortOption) {
-    setSortId(newOption.id)
+    startTransition(() => {
+      setSortId(newOption.id)
+    })
     updateSearchParams({ [SORT_KEY]: newOption.id })
   }
 


### PR DESCRIPTION
## 📝 Description

**Type:** Refactor

This is a part of Skill Stretch, so not a priority at all.

By using `startTransition` for `setState` updates, we can enable concurrent (re)rendering in response to user interactions and improve our INP.

## 🔖 Resources

- [How To Improve INP](https://kurtextrem.de/posts/improve-inp-react?ck_subscriber_id=2303278212)

