### PR TITLE
[UXIT-1859] Remove empty image markup [skip percy]

### DIFF
--- a/src/content/blog/orbiting-ethdenver-perspectives-from-a-filecoin-orbit-ambassador.md
+++ b/src/content/blog/orbiting-ethdenver-perspectives-from-a-filecoin-orbit-ambassador.md
@@ -36,7 +36,7 @@ The Filecoin Orbit program engages with the next generation of builders at top u
 
 And apply to become a [Filecoin Orbit ambassador](https://airtable.com/appAGdqyYrqoFNuPI/shrKrbPOdxGNnMM9C) for your city or university.
 
-![](https://lh7-us.googleusercontent.com/lPGlGnds3qGCC9ZGjFICk93WO83EdB6_zBjGF6Ct-sVcL43NOV0r_OLxEXNcWxgfOE0nzHtJ7rlEMSiUKKAss0ZBtATXmr8oQ-UuSXV-ASuOCHLbwPjhgOO6eNFuk-WgELAvJhzdvrE5NscWbgwgdbM)![]()
+![](https://lh7-us.googleusercontent.com/lPGlGnds3qGCC9ZGjFICk93WO83EdB6_zBjGF6Ct-sVcL43NOV0r_OLxEXNcWxgfOE0nzHtJ7rlEMSiUKKAss0ZBtATXmr8oQ-UuSXV-ASuOCHLbwPjhgOO6eNFuk-WgELAvJhzdvrE5NscWbgwgdbM)
 
 **Upcoming Filecoin Ecosystem Events**
 


### PR DESCRIPTION
This pull request includes a minor change to the blog post content in `src/content/blog/orbiting-ethdenver-perspectives-from-a-filecoin-orbit-ambassador.md`. The change involves the removal of an empty image tag to clean up the markdown.

Content cleanup:

* [`src/content/blog/orbiting-ethdenver-perspectives-from-a-filecoin-orbit-ambassador.md`](diffhunk://#diff-dfe64a9d532fde6f866feb945c8a8b61e67ff17100a921d3ccc238727d117904L39-R39): Removed an empty image tag to improve the readability and cleanliness of the markdown.

Fixes https://github.com/FilecoinFoundationWeb/filecoin-foundation/issues/899