### PR TITLE
[UXIT-1877] - Add Virtual Option to Event Filter

### DIFF
--- a/src/app/_utils/filterUtils.ts
+++ b/src/app/_utils/filterUtils.ts
@@ -1,9 +1,12 @@
+import { VIRTUAL_EVENT_FILTER_OPTION } from '@/events/constants/constants'
+
 type WithCategory = {
   category: string
 }
 
 type WithLocation = {
   location: {
+    primary: string
     region?: string
   }
 }
@@ -19,5 +22,9 @@ export function entryMatchesLocationQuery<Entry extends WithLocation>(
   entry: Entry,
   query?: string,
 ) {
+  if (query === VIRTUAL_EVENT_FILTER_OPTION.id) {
+    return entry.location.primary === VIRTUAL_EVENT_FILTER_OPTION.name
+  }
+
   return entry.location.region === query
 }

--- a/src/app/events/constants/constants.ts
+++ b/src/app/events/constants/constants.ts
@@ -17,3 +17,8 @@ export const FILTERS_CONFIG = {
     defaultOption: DEFAULT_CATEGORY_FILTER_OPTION,
   },
 } as const
+
+export const VIRTUAL_EVENT_FILTER_OPTION = {
+  id: 'virtual',
+  name: 'Virtual',
+} as const

--- a/src/app/events/page.tsx
+++ b/src/app/events/page.tsx
@@ -18,7 +18,6 @@ import {
   entryMatchesCategoryQuery,
   entryMatchesLocationQuery,
 } from '@/utils/filterUtils'
-import { getCMSOptionsWithDefault } from '@/utils/getCMSOptionsWithDefault'
 import { getFrontmatter } from '@/utils/getFrontmatter'
 import { getSortOptions } from '@/utils/getSortOptions'
 
@@ -48,6 +47,7 @@ import { eventsSortConfigs } from './constants/sortConfigs'
 import { getInvolvedData } from './data/getInvolvedData'
 import { generateStructuredData } from './utils/generateStructuredData'
 import { getEventData, getEventsData } from './utils/getEventData'
+import { getLocationListboxOptions } from './utils/getLocationFilterOptions'
 import { getMetaData } from './utils/getMetaData'
 
 const NoSSRPagination = dynamic(
@@ -80,11 +80,7 @@ export const metadata = createMetadata({
   overrideDefaultTitle: true,
 })
 
-const locationOptions = getCMSOptionsWithDefault({
-  collectionName: FILTERS_CONFIG.location.collectionName,
-  fieldName: FILTERS_CONFIG.location.fieldName,
-  defaultOption: FILTERS_CONFIG.location.defaultOption,
-})
+const locationOptions = getLocationListboxOptions()
 
 export default function Events({ searchParams }: Props) {
   if (!featuredEvent) {

--- a/src/app/events/utils/getLocationFilterOptions.ts
+++ b/src/app/events/utils/getLocationFilterOptions.ts
@@ -6,10 +6,14 @@ import {
 } from '../constants/constants'
 
 export function getLocationListboxOptions() {
+  const {
+    location: { collectionName, fieldName, defaultOption },
+  } = FILTERS_CONFIG
+
   const locationOptions = getCMSOptionsWithDefault({
-    collectionName: FILTERS_CONFIG.location.collectionName,
-    fieldName: FILTERS_CONFIG.location.fieldName,
-    defaultOption: FILTERS_CONFIG.location.defaultOption,
+    collectionName,
+    fieldName,
+    defaultOption,
   })
 
   return [...locationOptions, VIRTUAL_EVENT_FILTER_OPTION]

--- a/src/app/events/utils/getLocationFilterOptions.ts
+++ b/src/app/events/utils/getLocationFilterOptions.ts
@@ -1,0 +1,16 @@
+import { getCMSOptionsWithDefault } from '@/utils/getCMSOptionsWithDefault'
+
+import {
+  FILTERS_CONFIG,
+  VIRTUAL_EVENT_FILTER_OPTION,
+} from '../constants/constants'
+
+export function getLocationListboxOptions() {
+  const locationOptions = getCMSOptionsWithDefault({
+    collectionName: FILTERS_CONFIG.location.collectionName,
+    fieldName: FILTERS_CONFIG.location.fieldName,
+    defaultOption: FILTERS_CONFIG.location.defaultOption,
+  })
+
+  return [...locationOptions, VIRTUAL_EVENT_FILTER_OPTION]
+}


### PR DESCRIPTION
## 📝 Description

This PR adds a `Virtual` option to the `LocationFilter` on the events page.

## 🛠️ Key Changes

- Adds `getLocationListboxOptions` to combine all location-related options.
- Updates `entryMatchesLocationQuery` to account for virtual events

## 🧪 How to Test

- Go to `/events` and try filtering by virtual events

## 📸 Screenshots

![CleanShot 2024-12-11 at 14 40 45@2x](https://github.com/user-attachments/assets/d992cfcd-fdd0-46a3-8fb4-a383fde33ffe)

![CleanShot 2024-12-11 at 14 44 31@2x](https://github.com/user-attachments/assets/615d2903-8b7d-4f13-b8b5-dcb872648eae)
