### PR TITLE
[UXIT-1856] Enhance Event Structured Data: Add Address Details and SEO Description Fallback [skip percy]

### DIFF
--- a/src/app/events/[slug]/utils/generateStructuredData.ts
+++ b/src/app/events/[slug]/utils/generateStructuredData.ts
@@ -51,7 +51,7 @@ export function generateStructuredData(data: Event): WithContext<EventSchema> {
     '@type': 'Event',
     eventAttendanceMode,
     name: seo.title,
-    description,
+    description: description || seo.description,
     startDate: startDate.toISOString(),
     endDate: (endDate || startDate)?.toISOString(),
     location: eventLocation,

--- a/src/app/events/[slug]/utils/generateStructuredData.ts
+++ b/src/app/events/[slug]/utils/generateStructuredData.ts
@@ -15,7 +15,7 @@ import {
 
 import type { Event } from '../../types/eventType'
 
-type LocationType = Place | VirtualLocation | undefined
+type LocationType = Place | VirtualLocation
 
 type GetLocationProps = {
   location: Event['location']
@@ -69,6 +69,22 @@ function getLocation({
     return {
       '@type': 'VirtualLocation',
       url: externalLink || `${BASE_URL}${PATHS.EVENTS.path}/${slug}`,
+    }
+  }
+
+  const locationComponents = location.primary.split(', ')
+
+  if (locationComponents.length === 2) {
+    const [city, country] = locationComponents
+    return {
+      '@type': 'Place',
+      name: location.primary,
+      address: {
+        '@type': 'PostalAddress',
+        addressLocality: city,
+        addressCountry: country,
+        addressRegion: location.region,
+      },
     }
   }
 


### PR DESCRIPTION
## 📝 Description

This PR enhances the structured data for events by addressing two key areas:

1. Adds address details to the event’s location structured data, improving the clarity and alignment with Schema.org standards.
2. Provides a fallback to the SEO description when an event-specific description is unavailable, ensuring consistent metadata.

## 🛠️ Key Changes

- Added `address` details (including `addressLocality`, `addressCountry`, and `addressRegion`) to the event’s location structured data.
- Updated the `description` field in structured data to fallback to `seo.description` if the event-specific description is missing.

## 📌 To-Do Before Merging
- [ ] Verify the new address fields render correctly in structured data.
- [ ] Test fallback behavior for the description field when it is `undefined`.

## 🧪 How to Test
- Setup: Ensure you have events with and without descriptions and locations with a primary field.
- Steps to Test:
  1. Build the project and navigate to an event with a defined location and no description.
  2. Check the structured data output using a Schema.org testing tool or browser developer tools.
  3. Verify the fallback to seo.description for events without a description.
  4. Verify that the address details are correctly generated from the location.primary field.
- Expected Results:
  - Events without a description should use the `seo.description` as a fallback.
  - Address details (locality, country, region) should appear in the structured data for events with a valid location.
  - Additional Notes: Make sure there are no validation errors in the structured data.

## 📸 Screenshots

N/A - No UI changes.

## 🔖 Resources
- [Schema.org Event Documentation](https://schema.org/Event)
- [Schema.org PostalAddress Documentation](https://schema.org/PostalAddress)