### PR TITLE
[UXIT-1880] - Rework event filters on XS devices

### DIFF
--- a/src/app/_components/CategoryFilter.tsx
+++ b/src/app/_components/CategoryFilter.tsx
@@ -1,7 +1,5 @@
 'use client'
 
-import { FunnelSimple } from '@phosphor-icons/react'
-
 import { DEFAULT_CATEGORY_FILTER_OPTION } from '@/constants/filterConstants'
 import { CATEGORY_KEY } from '@/constants/searchParams'
 
@@ -35,7 +33,6 @@ export function CategoryFilter({ options }: CategoryProps) {
         <FilterListbox
           selected={categoryOption}
           options={options}
-          icon={FunnelSimple}
           onChange={setCategoryOption}
         />
       </div>

--- a/src/app/_components/CategoryFilter.tsx
+++ b/src/app/_components/CategoryFilter.tsx
@@ -5,7 +5,7 @@ import { FunnelSimple } from '@phosphor-icons/react'
 import { DEFAULT_CATEGORY_FILTER_OPTION } from '@/constants/filterConstants'
 import { CATEGORY_KEY } from '@/constants/searchParams'
 
-import { useFilterListboxState } from '@/hooks/useFilterListboxState'
+import { useListboxQueryState } from '@/hooks/useListboxQueryState'
 
 import { CategorySidebar } from '@/components/CategorySidebar'
 import { FilterListbox } from '@/components/FilterListbox'
@@ -16,7 +16,7 @@ type CategoryProps = {
 }
 
 export function CategoryFilter({ options }: CategoryProps) {
-  const [categoryOption, setCategoryOption] = useFilterListboxState({
+  const [categoryOption, setCategoryOption] = useListboxQueryState({
     key: CATEGORY_KEY,
     options,
     defaultOption: DEFAULT_CATEGORY_FILTER_OPTION,

--- a/src/app/_components/CategoryFilter.tsx
+++ b/src/app/_components/CategoryFilter.tsx
@@ -1,5 +1,7 @@
 'use client'
 
+import { FunnelSimple } from '@phosphor-icons/react'
+
 import { DEFAULT_CATEGORY_FILTER_OPTION } from '@/constants/filterConstants'
 import { CATEGORY_KEY } from '@/constants/searchParams'
 
@@ -33,6 +35,7 @@ export function CategoryFilter({ options }: CategoryProps) {
         <FilterListbox
           selected={categoryOption}
           options={options}
+          icon={FunnelSimple}
           onChange={setCategoryOption}
         />
       </div>

--- a/src/app/_components/FilterContainer.tsx
+++ b/src/app/_components/FilterContainer.tsx
@@ -51,9 +51,9 @@ FilterContainer.MobileFiltersAndResults = function MobileFiltersAndResults({
           <div
             key={index}
             className={clsx(
-              'flex-1',
+              'min-w-0 flex-1',
               filterComponents.length === 1 && 'sm:w-64',
-              filterComponents.length === 2 && 'min-w-0 sm:w-52 md:w-44',
+              filterComponents.length === 2 && 'sm:w-52 md:w-44',
             )}
           >
             {filterComponent}

--- a/src/app/_components/FilterListbox.tsx
+++ b/src/app/_components/FilterListbox.tsx
@@ -3,7 +3,10 @@
 import { Listbox } from '@headlessui/react'
 import { FunnelSimple } from '@phosphor-icons/react'
 
-import { ListboxButton } from '@/components/Listbox/ListboxButton'
+import {
+  ListboxButton,
+  type ListboxButtonProps,
+} from '@/components/Listbox/ListboxButton'
 import {
   ListboxOption,
   type OptionType,
@@ -14,16 +17,18 @@ type FilterListboxProps = {
   selected: OptionType
   options: Array<OptionType>
   onChange: (selected: OptionType) => void
+  icon: ListboxButtonProps['leadingIcon']
 }
 
 export function FilterListbox({
   selected,
   options,
   onChange,
+  icon,
 }: FilterListboxProps) {
   return (
     <Listbox value={selected} onChange={onChange}>
-      <ListboxButton text={selected.name} leadingIcon={FunnelSimple} />
+      <ListboxButton text={selected.name} leadingIcon={icon} />
       <ListboxOptions>
         {options.map((option) => (
           <ListboxOption key={option.id} option={option} />

--- a/src/app/_components/FilterListbox.tsx
+++ b/src/app/_components/FilterListbox.tsx
@@ -17,18 +17,18 @@ type FilterListboxProps = {
   selected: OptionType
   options: Array<OptionType>
   onChange: (selected: OptionType) => void
-  icon: ListboxButtonProps['leadingIcon']
+  buttonIcon?: ListboxButtonProps['leadingIcon']
 }
 
 export function FilterListbox({
   selected,
   options,
   onChange,
-  icon,
+  buttonIcon = FunnelSimple,
 }: FilterListboxProps) {
   return (
     <Listbox value={selected} onChange={onChange}>
-      <ListboxButton text={selected.name} leadingIcon={icon} />
+      <ListboxButton text={selected.name} leadingIcon={buttonIcon} />
       <ListboxOptions>
         {options.map((option) => (
           <ListboxOption key={option.id} option={option} />

--- a/src/app/_components/Listbox/ListboxButton.tsx
+++ b/src/app/_components/Listbox/ListboxButton.tsx
@@ -8,7 +8,7 @@ import { Icon, type IconProps } from '@/components/Icon'
 type TailwindConfig = ReturnType<typeof resolveConfig>
 type Breakpoint = keyof TailwindConfig['theme']['screens']
 
-type ListboxButtonProps = {
+export type ListboxButtonProps = {
   text: string
   leadingIcon?: IconProps['component']
   compactBelow?: Breakpoint

--- a/src/app/_components/LocationFilter.tsx
+++ b/src/app/_components/LocationFilter.tsx
@@ -25,7 +25,7 @@ export function LocationFilter({ options }: LocationFilterProps) {
     <FilterListbox
       selected={locationOption}
       options={options}
-      icon={GlobeSimple}
+      buttonIcon={GlobeSimple}
       onChange={setLocationOption}
     />
   )

--- a/src/app/_components/LocationFilter.tsx
+++ b/src/app/_components/LocationFilter.tsx
@@ -5,7 +5,7 @@ import { GlobeSimple } from '@phosphor-icons/react'
 import { DEFAULT_LOCATION_FILTER_OPTION } from '@/constants/filterConstants'
 import { LOCATION_KEY } from '@/constants/searchParams'
 
-import { useFilterListboxState } from '@/hooks/useFilterListboxState'
+import { useListboxQueryState } from '@/hooks/useListboxQueryState'
 
 import { FilterListbox } from '@/components/FilterListbox'
 import type { OptionType } from '@/components/Listbox/ListboxOption'
@@ -15,7 +15,7 @@ type LocationFilterProps = {
 }
 
 export function LocationFilter({ options }: LocationFilterProps) {
-  const [locationOption, setLocationOption] = useFilterListboxState({
+  const [locationOption, setLocationOption] = useListboxQueryState({
     key: LOCATION_KEY,
     options,
     defaultOption: DEFAULT_LOCATION_FILTER_OPTION,

--- a/src/app/_components/LocationFilter.tsx
+++ b/src/app/_components/LocationFilter.tsx
@@ -1,5 +1,7 @@
 'use client'
 
+import { GlobeSimple } from '@phosphor-icons/react'
+
 import { DEFAULT_LOCATION_FILTER_OPTION } from '@/constants/filterConstants'
 import { LOCATION_KEY } from '@/constants/searchParams'
 
@@ -23,6 +25,7 @@ export function LocationFilter({ options }: LocationFilterProps) {
     <FilterListbox
       selected={locationOption}
       options={options}
+      icon={GlobeSimple}
       onChange={setLocationOption}
     />
   )

--- a/src/app/_components/Sort.tsx
+++ b/src/app/_components/Sort.tsx
@@ -2,26 +2,28 @@
 
 import { useState, useEffect } from 'react'
 
-import { type SortOption, type ValidSortKey } from '@/types/sortTypes'
+import { ArrowsDownUp } from '@phosphor-icons/react'
 
 import { SORT_KEY } from '@/constants/searchParams'
 
 import { useSort } from '@/hooks/useSort'
 import { useUpdateSearchParams } from '@/hooks/useUpdateSearchParams'
 
-import { SortListbox } from '@/components/SortListbox'
+import type { OptionType } from './Listbox/ListboxOption'
+import { SortListbox } from './SortListbox'
 
 type SortProps = {
   query: ReturnType<typeof useSort>['sortQuery']
-  options: ReadonlyArray<SortOption>
+  options: ReadonlyArray<OptionType>
   defaultQuery: ReturnType<typeof useSort>['defaultSortQuery']
 }
 
 export function Sort({ query, options, defaultQuery }: SortProps) {
-  const [sortId, setSortId] = useState<ValidSortKey>(query)
+  const [sortId, setSortId] = useState<OptionType['id']>(query)
   const { updateSearchParams } = useUpdateSearchParams()
 
-  const selectedOption = options.find((option) => option.id === sortId)
+  const selectedOption =
+    options.find((option) => option.id === sortId) || options[0]
 
   useEffect(() => {
     const sortIsReset = query === defaultQuery
@@ -31,7 +33,7 @@ export function Sort({ query, options, defaultQuery }: SortProps) {
     }
   }, [query, defaultQuery])
 
-  function handleSortChange(newOption: SortOption) {
+  function handleSortChange(newOption: OptionType) {
     setSortId(newOption.id)
     updateSearchParams({ [SORT_KEY]: newOption.id })
   }
@@ -40,6 +42,7 @@ export function Sort({ query, options, defaultQuery }: SortProps) {
     <SortListbox
       options={options}
       selected={selectedOption}
+      icon={ArrowsDownUp}
       onChange={handleSortChange}
     />
   )

--- a/src/app/_components/Sort.tsx
+++ b/src/app/_components/Sort.tsx
@@ -2,8 +2,6 @@
 
 import { useState, useEffect } from 'react'
 
-import { ArrowsDownUp } from '@phosphor-icons/react'
-
 import { SORT_KEY } from '@/constants/searchParams'
 
 import { useSort } from '@/hooks/useSort'
@@ -42,7 +40,6 @@ export function Sort({ query, options, defaultQuery }: SortProps) {
     <SortListbox
       options={options}
       selected={selectedOption}
-      icon={ArrowsDownUp}
       onChange={handleSortChange}
     />
   )

--- a/src/app/_components/SortListbox.tsx
+++ b/src/app/_components/SortListbox.tsx
@@ -1,6 +1,7 @@
 'use client'
 
 import { Listbox } from '@headlessui/react'
+import { ArrowsDownUp } from '@phosphor-icons/react'
 
 import {
   ListboxButton,
@@ -14,19 +15,19 @@ export type SortListboxProps = {
   selected: OptionType
   onChange: (newOption: OptionType) => void
   options: ReadonlyArray<OptionType>
-  icon: ListboxButtonProps['leadingIcon']
+  buttonIcon?: ListboxButtonProps['leadingIcon']
 }
 
 export function SortListbox({
   selected,
   onChange,
   options,
-  icon,
+  buttonIcon = ArrowsDownUp,
 }: SortListboxProps) {
   return (
     <Listbox value={selected} onChange={onChange}>
       <ListboxButton
-        leadingIcon={icon}
+        leadingIcon={buttonIcon}
         text={selected.name}
         compactBelow="md"
       />

--- a/src/app/_components/SortListbox.tsx
+++ b/src/app/_components/SortListbox.tsx
@@ -1,28 +1,33 @@
 'use client'
 
 import { Listbox } from '@headlessui/react'
-import { ArrowsDownUp } from '@phosphor-icons/react/dist/ssr'
 
-import { type SortOption } from '@/types/sortTypes'
-
-import { ListboxButton } from '@/components/Listbox/ListboxButton'
+import {
+  ListboxButton,
+  type ListboxButtonProps,
+} from '@/components/Listbox/ListboxButton'
 import { ListboxOption } from '@/components/Listbox/ListboxOption'
+import type { OptionType } from '@/components/Listbox/ListboxOption'
 import { ListboxOptions } from '@/components/Listbox/ListboxOptions'
 
-type SortListboxProps = {
-  selected: SortOption | undefined
-  onChange: (newOption: SortOption) => void
-  options: ReadonlyArray<SortOption>
+export type SortListboxProps = {
+  selected: OptionType
+  onChange: (newOption: OptionType) => void
+  options: ReadonlyArray<OptionType>
+  icon: ListboxButtonProps['leadingIcon']
 }
 
-export function SortListbox({ selected, onChange, options }: SortListboxProps) {
-  const selectedOption = selected || options[0]
-
+export function SortListbox({
+  selected,
+  onChange,
+  options,
+  icon,
+}: SortListboxProps) {
   return (
-    <Listbox value={selectedOption} onChange={onChange}>
+    <Listbox value={selected} onChange={onChange}>
       <ListboxButton
-        leadingIcon={ArrowsDownUp}
-        text={selectedOption.name}
+        leadingIcon={icon}
+        text={selected.name}
         compactBelow="md"
       />
 

--- a/src/app/_hooks/useFilterListboxState.ts
+++ b/src/app/_hooks/useFilterListboxState.ts
@@ -1,7 +1,5 @@
 import { parseAsString, useQueryState } from 'nuqs'
 
-import { DEFAULT_FILTER_ID } from '@/constants/filterConstants'
-
 import type { OptionType } from '@/components/Listbox/ListboxOption'
 
 type FilterListboxStateConfig = {
@@ -17,9 +15,7 @@ export function useFilterListboxState({
 }: FilterListboxStateConfig) {
   const [optionId, setOptionId] = useQueryState<OptionType['id']>(
     key,
-    parseAsString
-      .withDefault(DEFAULT_FILTER_ID)
-      .withOptions({ shallow: false }),
+    parseAsString.withDefault(defaultOption.id).withOptions({ shallow: false }),
   )
 
   const selectedOption =

--- a/src/app/_hooks/useListboxQueryState.ts
+++ b/src/app/_hooks/useListboxQueryState.ts
@@ -2,17 +2,17 @@ import { parseAsString, useQueryState } from 'nuqs'
 
 import type { OptionType } from '@/components/Listbox/ListboxOption'
 
-type FilterListboxStateConfig = {
+type ListboxQueryStateConfig = {
   key: string
   options: Array<OptionType>
   defaultOption: OptionType
 }
 
-export function useFilterListboxState({
+export function useListboxQueryState({
   key,
   options,
   defaultOption,
-}: FilterListboxStateConfig) {
+}: ListboxQueryStateConfig) {
   const [optionId, setOptionId] = useQueryState<OptionType['id']>(
     key,
     parseAsString.withDefault(defaultOption.id).withOptions({ shallow: false }),

--- a/src/app/_types/sortTypes.ts
+++ b/src/app/_types/sortTypes.ts
@@ -7,8 +7,3 @@ export type SortConfig<Entry extends Record<string, any>> = {
   label: string
   sortFn: (entries: Array<Entry>) => Array<Entry>
 }
-
-export type SortOption = {
-  id: ValidSortKey
-  name: string
-}

--- a/src/app/events/components/EventSort.tsx
+++ b/src/app/events/components/EventSort.tsx
@@ -6,7 +6,7 @@ import { SORT_KEY } from '@/constants/searchParams'
 
 import { getSortOptions } from '@/utils/getSortOptions'
 
-import { useFilterListboxState } from '@/hooks/useFilterListboxState'
+import { useListboxQueryState } from '@/hooks/useListboxQueryState'
 
 import { SortListbox } from '@/components/SortListbox'
 
@@ -15,7 +15,7 @@ import { eventsSortConfigs } from '../constants/sortConfigs'
 const options = getSortOptions(eventsSortConfigs)
 
 export function EventSort() {
-  const [selectedSort, setSelectedSort] = useFilterListboxState({
+  const [selectedSort, setSelectedSort] = useListboxQueryState({
     key: SORT_KEY,
     options: options,
     defaultOption: options[0],

--- a/src/app/events/components/EventSort.tsx
+++ b/src/app/events/components/EventSort.tsx
@@ -1,0 +1,32 @@
+'use client'
+
+import { CalendarBlank } from '@phosphor-icons/react'
+
+import { SORT_KEY } from '@/constants/searchParams'
+
+import { getSortOptions } from '@/utils/getSortOptions'
+
+import { useFilterListboxState } from '@/hooks/useFilterListboxState'
+
+import { SortListbox } from '@/components/SortListbox'
+
+import { eventsSortConfigs } from '../constants/sortConfigs'
+
+const options = getSortOptions(eventsSortConfigs)
+
+export function EventSort() {
+  const [selectedSort, setSelectedSort] = useFilterListboxState({
+    key: SORT_KEY,
+    options: options,
+    defaultOption: options[0],
+  })
+
+  return (
+    <SortListbox
+      options={options}
+      selected={selectedSort}
+      icon={CalendarBlank}
+      onChange={setSelectedSort}
+    />
+  )
+}

--- a/src/app/events/components/EventSort.tsx
+++ b/src/app/events/components/EventSort.tsx
@@ -25,7 +25,7 @@ export function EventSort() {
     <SortListbox
       options={options}
       selected={selectedSort}
-      icon={CalendarBlank}
+      buttonIcon={CalendarBlank}
       onChange={setSelectedSort}
     />
   )

--- a/src/app/events/page.tsx
+++ b/src/app/events/page.tsx
@@ -19,7 +19,6 @@ import {
   entryMatchesLocationQuery,
 } from '@/utils/filterUtils'
 import { getFrontmatter } from '@/utils/getFrontmatter'
-import { getSortOptions } from '@/utils/getSortOptions'
 
 import { FeaturedPageFrontmatterSchema } from '@/schemas/FrontmatterSchema'
 
@@ -39,9 +38,9 @@ import { PageHeader } from '@/components/PageHeader'
 import { PageLayout } from '@/components/PageLayout'
 import { PageSection } from '@/components/PageSection'
 import { Search } from '@/components/Search'
-import { Sort } from '@/components/Sort'
 import { StructuredDataScript } from '@/components/StructuredDataScript'
 
+import { EventSort } from './components/EventSort'
 import { DEFAULT_CTA_TEXT, FILTERS_CONFIG } from './constants/constants'
 import { eventsSortConfigs } from './constants/sortConfigs'
 import { getInvolvedData } from './data/getInvolvedData'
@@ -65,8 +64,6 @@ const { featuredEntry: featuredEventPath, seo } = getFrontmatter({
   path: PATHS.EVENTS,
   zodParser: FeaturedPageFrontmatterSchema.parse,
 })
-
-const sortOptions = getSortOptions(eventsSortConfigs)
 
 const featuredEventSlug = extractSlugFromFilename(featuredEventPath)
 const featuredEvent = getEventData(featuredEventSlug)
@@ -93,7 +90,7 @@ export default function Events({ searchParams }: Props) {
     searchBy: ['title', 'location'],
   })
 
-  const { sortQuery, sortedResults, defaultSortQuery } = useSort({
+  const { sortedResults } = useSort({
     searchParams,
     entries: searchResults,
     configs: eventsSortConfigs,
@@ -156,19 +153,14 @@ export default function Events({ searchParams }: Props) {
           <FilterContainer.MainWrapper>
             <FilterContainer.DesktopFilters
               searchComponent={<Search query={searchQuery} />}
+              sortComponent={<EventSort />}
               filterComponents={[
                 <LocationFilter key="location" options={locationOptions} />,
               ]}
-              sortComponent={
-                <Sort
-                  query={sortQuery}
-                  options={sortOptions}
-                  defaultQuery={defaultSortQuery}
-                />
-              }
             />
             <FilterContainer.MobileFiltersAndResults
               searchComponent={<Search query={searchQuery} />}
+              sortComponent={<EventSort />}
               filterComponents={[
                 <CategoryFilter
                   key="category"
@@ -176,13 +168,6 @@ export default function Events({ searchParams }: Props) {
                 />,
                 <LocationFilter key="location" options={locationOptions} />,
               ]}
-              sortComponent={
-                <Sort
-                  query={sortQuery}
-                  options={sortOptions}
-                  defaultQuery={defaultSortQuery}
-                />
-              }
             />
             <FilterContainer.ContentWrapper>
               {filteredEntries.length === 0 ? (


### PR DESCRIPTION
## 📝 Description

This PR updates the sort and filter Listbox `components` to show different icons on the events page, after a discussion with Filipa this morning.

## 🛠️ Key Changes
- Adds an icon prop to `FilterListbox` and `SortListbox`.
- Creates `EventSort` for the events page, which relies on `SortListbox`
- Updates `SortListbox` to use `OptionType` instead of `SortType`, enabling reuse of `useFilterListboxState` (now renamed `useListboxQueryState`).

## 📌 To-Do Before Merging

- [x] Get the greenlight from Filipa - [Slack](https://filecoinfoundation.slack.com/archives/C07UH9HAURX/p1734016268364299?thread_ts=1733743660.737509&cid=C07UH9HAURX)

## 📸 Screenshots

![image](https://github.com/user-attachments/assets/4676b4fa-92cd-44a2-9f31-0087ae810924)
