### PR TITLE
UXIT-1887] Event Page · Remove "co-hosted" category [skip percy]

### DIFF
--- a/public/admin/config.yml
+++ b/public/admin/config.yml
@@ -654,8 +654,6 @@ collections:
         label: "Category"
         widget: "select"
         options:
-          - label: "Co-Hosted"
-            value: "co-hosted"
           - label: "Hosted"
             value: "hosted"
           - label: "Supported & Sponsored"

--- a/src/content/events/social-impact-summit-2024-cohosted-by-blockchain-law-for-social-good-center-ffdw.md
+++ b/src/content/events/social-impact-summit-2024-cohosted-by-blockchain-law-for-social-good-center-ffdw.md
@@ -13,7 +13,7 @@ start-date: 2024-02-27T14:00:51.036Z
 end-date: 2024-02-27T21:00:51.050Z
 image:
   src: /assets/images/sis24.png
-category: co-hosted
+category: hosted
 seo:
   description:
     Join the Social Impact Summit 2024 to explore the intersection of blockchain


### PR DESCRIPTION
## 📝 Description

- Removed the "Co-Hosted" option from the Events categories 
- Updated the category for the Social Impact Summit 2024 event from "co-hosted" to "hosted"

