### PR TITLE
[UXIT-1731] Validate Image Src

### DIFF
--- a/apps/site/src/app/(homepage)/components/FeaturedBlogPosts.tsx
+++ b/apps/site/src/app/(homepage)/components/FeaturedBlogPosts.tsx
@@ -37,16 +37,18 @@ export function FeaturedBlogPosts({
                 href: `${PATHS.BLOG.path}/${slug}`,
                 text: 'Learn More',
               }}
-              image={{
-                ...image,
-                alt: '',
-                objectFit: 'cover',
-                sizes: buildImageSizeProp({
-                  startSize: '100vw',
-                  sm: '350px',
-                  md: '480px',
-                }),
-              }}
+              image={
+                image && {
+                  src: image.src,
+                  alt: image.alt || '',
+                  objectFit: 'cover',
+                  sizes: buildImageSizeProp({
+                    startSize: '100vw',
+                    sm: '350px',
+                    md: '480px',
+                  }),
+                }
+              }
             />
           )
         },

--- a/apps/site/src/app/(homepage)/components/FeaturedBlogPosts.tsx
+++ b/apps/site/src/app/(homepage)/components/FeaturedBlogPosts.tsx
@@ -1,7 +1,5 @@
 import { PATHS } from '@/constants/paths'
 
-import { graphicsData } from '@/data/graphicsData'
-
 import { buildImageSizeProp } from '@/utils/buildImageSizeProp'
 import { getCategoryLabel } from '@/utils/categoryUtils'
 

--- a/apps/site/src/app/(homepage)/components/FeaturedBlogPosts.tsx
+++ b/apps/site/src/app/(homepage)/components/FeaturedBlogPosts.tsx
@@ -40,7 +40,7 @@ export function FeaturedBlogPosts({
                 text: 'Learn More',
               }}
               image={{
-                ...(image || graphicsData.imageFallback.data),
+                ...image,
                 alt: '',
                 objectFit: 'cover',
                 sizes: buildImageSizeProp({

--- a/apps/site/src/app/(homepage)/components/FeaturedEcosystemProjects.tsx
+++ b/apps/site/src/app/(homepage)/components/FeaturedEcosystemProjects.tsx
@@ -30,18 +30,20 @@ export function FeaturedEcosystemProjects({
             text: 'Learn More',
             icon: MagnifyingGlass,
           }}
-          image={{
-            ...image,
-            alt: '',
-            objectFit: 'contain',
-            padding: Boolean(image),
-            sizes: buildImageSizeProp({
-              startSize: '100vw',
-              sm: '320px',
-              md: '440px',
-              lg: '280px',
-            }),
-          }}
+          image={
+            image && {
+              src: image.src,
+              alt: image.alt || '',
+              objectFit: 'contain',
+              padding: Boolean(image),
+              sizes: buildImageSizeProp({
+                startSize: '100vw',
+                sm: '320px',
+                md: '440px',
+                lg: '280px',
+              }),
+            }
+          }
         />
       ))}
     </CardGrid>

--- a/apps/site/src/app/(homepage)/components/FeaturedEcosystemProjects.tsx
+++ b/apps/site/src/app/(homepage)/components/FeaturedEcosystemProjects.tsx
@@ -2,8 +2,6 @@ import { MagnifyingGlass } from '@phosphor-icons/react/dist/ssr'
 
 import { PATHS } from '@/constants/paths'
 
-import { graphicsData } from '@/data/graphicsData'
-
 import { buildImageSizeProp } from '@/utils/buildImageSizeProp'
 
 import { Card } from '@/components/Card'

--- a/apps/site/src/app/(homepage)/components/FeaturedEcosystemProjects.tsx
+++ b/apps/site/src/app/(homepage)/components/FeaturedEcosystemProjects.tsx
@@ -33,7 +33,7 @@ export function FeaturedEcosystemProjects({
             icon: MagnifyingGlass,
           }}
           image={{
-            ...(image || graphicsData.imageFallback.data),
+            ...image,
             alt: '',
             objectFit: 'contain',
             padding: Boolean(image),

--- a/apps/site/src/app/_components/ArticleHeader.tsx
+++ b/apps/site/src/app/_components/ArticleHeader.tsx
@@ -1,8 +1,7 @@
 import { buildImageSizeProp } from '@/utils/buildImageSizeProp'
 
 import { type HeadingProps, Heading } from '@/components/Heading'
-
-import { SmartImage, type SmartImageProps } from './SmartImage'
+import { SmartImage, type SmartImageProps } from '@/components/SmartImage'
 
 type ArticleHeaderProps = {
   image: SmartImageProps

--- a/apps/site/src/app/_components/ArticleHeader.tsx
+++ b/apps/site/src/app/_components/ArticleHeader.tsx
@@ -1,13 +1,11 @@
-import Image from 'next/image'
-
-import type { ImageProps } from '@/types/imageType'
-
 import { buildImageSizeProp } from '@/utils/buildImageSizeProp'
 
 import { type HeadingProps, Heading } from '@/components/Heading'
 
+import { SmartImage, type SmartImageProps } from './SmartImage'
+
 type ArticleHeaderProps = {
-  image: ImageProps
+  image: SmartImageProps
   children?: React.ReactNode
 }
 
@@ -20,7 +18,7 @@ export function ArticleHeader({ image, children }: ArticleHeaderProps) {
     <header className="space-y-6">
       <div className="space-y-6">{children}</div>
       <div className="relative aspect-video">
-        <Image
+        <SmartImage
           fill
           priority
           quality={100}

--- a/apps/site/src/app/_components/Card.tsx
+++ b/apps/site/src/app/_components/Card.tsx
@@ -1,10 +1,11 @@
-import Image, { type StaticImageData } from 'next/image'
+import Image, { type ImageProps } from 'next/image'
 
 import { ArrowUpRight } from '@phosphor-icons/react/dist/ssr'
 import { clsx } from 'clsx'
 import theme from 'tailwindcss/defaultTheme'
 
 import { type CTAProps } from '@/types/ctaType'
+import { type ImageObjectFit } from '@/types/imageType'
 
 import { buildImageSizeProp } from '@/utils/buildImageSizeProp'
 import { isExternalLink } from '@/utils/linkUtils'
@@ -14,11 +15,16 @@ import { BaseLink } from '@/components/BaseLink'
 import { Heading } from '@/components/Heading'
 import { Icon } from '@/components/Icon'
 import { Meta, type MetaDataType } from '@/components/Meta'
-import { SmartImage, type SmartImageProps } from '@/components/SmartImage'
+import { SmartImage } from '@/components/SmartImage'
 import {
   type TagGroupProps,
   TagGroup,
 } from '@/components/TagComponents/TagGroup'
+
+type CardImageProps = ImageProps &
+  ImageObjectFit & {
+    padding?: boolean
+  }
 
 type CardProps = {
   title: string | React.ReactNode
@@ -26,7 +32,7 @@ type CardProps = {
   metaData?: MetaDataType
   description?: string
   cta?: CTAPropsWithSpacing
-  image?: SmartImageProps
+  image?: CardImageProps
   borderColor?: 'brand-300' | 'brand-400' | 'brand-500' | 'brand-600'
   textIsClamped?: boolean
   as?: React.ElementType
@@ -92,10 +98,11 @@ export function Card({
 Card.Image = function ImageComponent({
   image,
 }: Required<Pick<CardProps, 'image'>>) {
-  const isStaticImage = 'data' in image
+  const imageSrc = image.src
+  const isStaticImage = typeof imageSrc === 'object'
 
   const commonProps = {
-    alt: image.alt || '',
+    alt: image.alt,
     priority: image.priority,
     quality: 100,
     sizes:
@@ -113,7 +120,7 @@ Card.Image = function ImageComponent({
       <Image
         {...commonProps}
         className={clsx(commonProps.className, 'aspect-video')}
-        src={image.data as StaticImageData}
+        src={imageSrc}
         alt={commonProps.alt}
       />
     )
@@ -125,7 +132,7 @@ Card.Image = function ImageComponent({
         fill
         {...commonProps}
         className={clsx(commonProps.className, 'h-full w-full')}
-        src={image.src}
+        src={imageSrc}
         alt={commonProps.alt}
       />
     </div>

--- a/apps/site/src/app/_components/Card.tsx
+++ b/apps/site/src/app/_components/Card.tsx
@@ -1,4 +1,4 @@
-import { type StaticImageData } from 'next/image'
+import Image, { type StaticImageData } from 'next/image'
 
 import { ArrowUpRight } from '@phosphor-icons/react/dist/ssr'
 import { clsx } from 'clsx'
@@ -110,7 +110,7 @@ Card.Image = function ImageComponent({
 
   if (isStaticImage) {
     return (
-      <SmartImage
+      <Image
         {...commonProps}
         className={clsx(commonProps.className, 'aspect-video')}
         src={image.data as StaticImageData}

--- a/apps/site/src/app/_components/Card.tsx
+++ b/apps/site/src/app/_components/Card.tsx
@@ -1,11 +1,10 @@
-import Image, { type ImageProps, type StaticImageData } from 'next/image'
+import { type StaticImageData } from 'next/image'
 
 import { ArrowUpRight } from '@phosphor-icons/react/dist/ssr'
 import { clsx } from 'clsx'
 import theme from 'tailwindcss/defaultTheme'
 
 import { type CTAProps } from '@/types/ctaType'
-import type { ImageObjectFit, StaticImageProps } from '@/types/imageType'
 
 import { buildImageSizeProp } from '@/utils/buildImageSizeProp'
 import { isExternalLink } from '@/utils/linkUtils'
@@ -15,20 +14,11 @@ import { BaseLink } from '@/components/BaseLink'
 import { Heading } from '@/components/Heading'
 import { Icon } from '@/components/Icon'
 import { Meta, type MetaDataType } from '@/components/Meta'
+import { SmartImage, type SmartImageProps } from '@/components/SmartImage'
 import {
   type TagGroupProps,
   TagGroup,
 } from '@/components/TagComponents/TagGroup'
-
-import { SmartImage } from './SmartImage'
-import type { SmartImageProps } from './SmartImage'
-
-type CardImageProps = (StaticImageProps | ImageProps) & {
-  objectFit?: ImageObjectFit
-  padding?: boolean
-  priority?: boolean
-  sizes?: string
-}
 
 type CardProps = {
   title: string | React.ReactNode

--- a/apps/site/src/app/_components/Card.tsx
+++ b/apps/site/src/app/_components/Card.tsx
@@ -1,4 +1,4 @@
-import Image, { type ImageProps } from 'next/image'
+import Image, { type ImageProps, type StaticImageData } from 'next/image'
 
 import { ArrowUpRight } from '@phosphor-icons/react/dist/ssr'
 import { clsx } from 'clsx'
@@ -20,6 +20,9 @@ import {
   TagGroup,
 } from '@/components/TagComponents/TagGroup'
 
+import { SmartImage } from './SmartImage'
+import type { SmartImageProps } from './SmartImage'
+
 type CardImageProps = (StaticImageProps | ImageProps) & {
   objectFit?: ImageObjectFit
   padding?: boolean
@@ -33,7 +36,7 @@ type CardProps = {
   metaData?: MetaDataType
   description?: string
   cta?: CTAPropsWithSpacing
-  image?: CardImageProps
+  image?: SmartImageProps
   borderColor?: 'brand-300' | 'brand-400' | 'brand-500' | 'brand-600'
   textIsClamped?: boolean
   as?: React.ElementType
@@ -117,10 +120,10 @@ Card.Image = function ImageComponent({
 
   if (isStaticImage) {
     return (
-      <Image
+      <SmartImage
         {...commonProps}
         className={clsx(commonProps.className, 'aspect-video')}
-        src={image.data}
+        src={(image.data as StaticImageData).src}
         alt={commonProps.alt}
       />
     )
@@ -128,7 +131,7 @@ Card.Image = function ImageComponent({
 
   return (
     <div className="relative aspect-video">
-      <Image
+      <SmartImage
         fill
         {...commonProps}
         className={clsx(commonProps.className, 'h-full w-full')}

--- a/apps/site/src/app/_components/Card.tsx
+++ b/apps/site/src/app/_components/Card.tsx
@@ -113,7 +113,7 @@ Card.Image = function ImageComponent({
       <SmartImage
         {...commonProps}
         className={clsx(commonProps.className, 'aspect-video')}
-        src={(image.data as StaticImageData).src}
+        src={image.data as StaticImageData}
         alt={commonProps.alt}
       />
     )

--- a/apps/site/src/app/_components/Card.tsx
+++ b/apps/site/src/app/_components/Card.tsx
@@ -95,7 +95,7 @@ Card.Image = function ImageComponent({
   const isStaticImage = 'data' in image
 
   const commonProps = {
-    alt: image.alt,
+    alt: image.alt || '',
     priority: image.priority,
     quality: 100,
     sizes:

--- a/apps/site/src/app/_components/PageHeader.tsx
+++ b/apps/site/src/app/_components/PageHeader.tsx
@@ -1,6 +1,12 @@
-import Image, { type StaticImageData } from 'next/image'
+import Image from 'next/image'
 
 import { clsx } from 'clsx'
+
+import type {
+  ImageObjectFit,
+  ImageProps,
+  StaticImageProps,
+} from '@/types/imageType'
 
 import { buildImageSizeProp } from '@/utils/buildImageSizeProp'
 
@@ -15,15 +21,17 @@ import {
 import { Heading } from '@/components/Heading'
 import { Meta, type MetaDataType } from '@/components/Meta'
 import { SectionDivider } from '@/components/SectionDivider'
-import { SmartImage, type SmartImageProps } from '@/components/SmartImage'
+import { SmartImage } from '@/components/SmartImage'
 
 type TitleProps = {
   children: string
 }
 
+type PageHeaderImageProps = (ImageProps | StaticImageProps) & ImageObjectFit
+
 type PageHeaderProps = {
   title: TitleProps['children']
-  image: SmartImageProps
+  image?: PageHeaderImageProps
   isFeatured?: boolean
   metaData?: MetaDataType
   description?: DescriptionTextType
@@ -68,7 +76,7 @@ PageHeader.Title = function Title({ children }: TitleProps) {
 
 PageHeader.Image = function PageHeaderImage({
   image,
-}: Pick<PageHeaderProps, 'image'>) {
+}: Required<Pick<PageHeaderProps, 'image'>>) {
   const isStaticImage = 'data' in image
 
   const commonProps = {
@@ -88,7 +96,7 @@ PageHeader.Image = function PageHeaderImage({
       <Image
         {...commonProps}
         className={clsx(commonProps.className, 'aspect-video')}
-        src={image.data as StaticImageData}
+        src={image.data}
         alt={commonProps.alt}
       />
     )

--- a/apps/site/src/app/_components/PageHeader.tsx
+++ b/apps/site/src/app/_components/PageHeader.tsx
@@ -1,8 +1,6 @@
-import Image, { type ImageProps } from 'next/image'
+import type { StaticImageData } from 'next/image'
 
 import { clsx } from 'clsx'
-
-import type { ImageObjectFit, StaticImageProps } from '@/types/imageType'
 
 import { buildImageSizeProp } from '@/utils/buildImageSizeProp'
 
@@ -18,17 +16,18 @@ import { Heading } from '@/components/Heading'
 import { Meta, type MetaDataType } from '@/components/Meta'
 import { SectionDivider } from '@/components/SectionDivider'
 
+import type { StaticImageProps } from '@/_types/imageType'
+
+import { SmartImage } from './SmartImage'
+import type { SmartImageProps } from './SmartImage'
+
 type TitleProps = {
   children: string
 }
 
-type PageHeaderImageProps = (StaticImageProps | ImageProps) & {
-  objectFit?: ImageObjectFit
-}
-
 type PageHeaderProps = {
   title: TitleProps['children']
-  image: PageHeaderImageProps
+  image: SmartImageProps
   isFeatured?: boolean
   metaData?: MetaDataType
   description?: DescriptionTextType
@@ -90,10 +89,10 @@ PageHeader.Image = function PageHeaderImage({
 
   if (isStaticImage) {
     return (
-      <Image
+      <SmartImage
         {...commonProps}
         className={clsx(commonProps.className, 'aspect-video')}
-        src={image.data}
+        src={image.data as StaticImageData}
         alt={commonProps.alt}
       />
     )
@@ -101,7 +100,7 @@ PageHeader.Image = function PageHeaderImage({
 
   return (
     <div className="relative aspect-video">
-      <Image
+      <SmartImage
         fill
         {...commonProps}
         className={clsx(commonProps.className, 'h-full w-full')}

--- a/apps/site/src/app/_components/PageHeader.tsx
+++ b/apps/site/src/app/_components/PageHeader.tsx
@@ -72,7 +72,7 @@ PageHeader.Image = function PageHeaderImage({
   const isStaticImage = 'data' in image
 
   const commonProps = {
-    alt: image.alt,
+    alt: image.alt || '',
     priority: true,
     quality: 100,
     sizes: buildImageSizeProp({ startSize: '100vw', lg: '490px' }),

--- a/apps/site/src/app/_components/PageHeader.tsx
+++ b/apps/site/src/app/_components/PageHeader.tsx
@@ -15,11 +15,7 @@ import {
 import { Heading } from '@/components/Heading'
 import { Meta, type MetaDataType } from '@/components/Meta'
 import { SectionDivider } from '@/components/SectionDivider'
-
-import type { StaticImageProps } from '@/_types/imageType'
-
-import { SmartImage } from './SmartImage'
-import type { SmartImageProps } from './SmartImage'
+import { SmartImage, type SmartImageProps } from '@/components/SmartImage'
 
 type TitleProps = {
   children: string

--- a/apps/site/src/app/_components/PageHeader.tsx
+++ b/apps/site/src/app/_components/PageHeader.tsx
@@ -1,4 +1,4 @@
-import type { StaticImageData } from 'next/image'
+import Image, { type StaticImageData } from 'next/image'
 
 import { clsx } from 'clsx'
 
@@ -85,7 +85,7 @@ PageHeader.Image = function PageHeaderImage({
 
   if (isStaticImage) {
     return (
-      <SmartImage
+      <Image
         {...commonProps}
         className={clsx(commonProps.className, 'aspect-video')}
         src={image.data as StaticImageData}

--- a/apps/site/src/app/_components/SmartImage.tsx
+++ b/apps/site/src/app/_components/SmartImage.tsx
@@ -14,7 +14,7 @@ const { data: fallbackSrc, alt: fallbackAlt } = graphicsData.imageFallback
 
 export type SmartImageProps = {
   src?: string | StaticImageProps['data']
-  alt: string
+  alt?: string
   className?: string
   objectFit?: ImageObjectFit
   padding?: boolean
@@ -22,7 +22,7 @@ export type SmartImageProps = {
 
 export async function SmartImage({
   src,
-  alt,
+  alt = '',
   className,
   ...props
 }: SmartImageProps) {

--- a/apps/site/src/app/_components/SmartImage.tsx
+++ b/apps/site/src/app/_components/SmartImage.tsx
@@ -13,13 +13,13 @@ const { data: fallbackSrc, alt: fallbackAlt } = graphicsData.imageFallback
 
 export type SmartImageProps = {
   src?: string | StaticImageProps['data']
-  alt: string
+  alt?: string
   className?: string
   objectFit?: ImageObjectFit
   padding?: boolean
 } & Omit<ImageProps, 'src' | 'alt' | 'className'>
 
-export async function SmartImage({ src, alt, ...props }: SmartImageProps) {
+export async function SmartImage({ src, alt = '', ...props }: SmartImageProps) {
   const imageSrc = await getImageSrc(src)
 
   const imageExists = imageSrc !== fallbackSrc

--- a/apps/site/src/app/_components/SmartImage.tsx
+++ b/apps/site/src/app/_components/SmartImage.tsx
@@ -1,3 +1,5 @@
+'use server'
+
 import fs from 'fs/promises'
 import path from 'path'
 

--- a/apps/site/src/app/_components/SmartImage.tsx
+++ b/apps/site/src/app/_components/SmartImage.tsx
@@ -3,8 +3,7 @@
 import fs from 'fs/promises'
 import path from 'path'
 
-import { type ImageProps } from 'next/image'
-import Image from 'next/image'
+import Image, { type ImageProps } from 'next/image'
 
 import type { ImageObjectFit, StaticImageProps } from '@/types/imageType'
 
@@ -14,29 +13,19 @@ const { data: fallbackSrc, alt: fallbackAlt } = graphicsData.imageFallback
 
 export type SmartImageProps = {
   src?: string | StaticImageProps['data']
-  alt?: string
+  alt: string
   className?: string
   objectFit?: ImageObjectFit
   padding?: boolean
 } & Omit<ImageProps, 'src' | 'alt' | 'className'>
 
-export async function SmartImage({
-  src,
-  alt = '',
-  className,
-  ...props
-}: SmartImageProps) {
+export async function SmartImage({ src, alt, ...props }: SmartImageProps) {
   const imageSrc = await getImageSrc(src)
 
   const imageExists = imageSrc !== fallbackSrc
 
   return (
-    <Image
-      className={className}
-      src={imageSrc}
-      alt={imageExists ? alt : fallbackAlt}
-      {...props}
-    />
+    <Image src={imageSrc} alt={imageExists ? alt : fallbackAlt} {...props} />
   )
 }
 
@@ -44,14 +33,9 @@ async function getImageSrc(src: SmartImageProps['src']) {
   if (!src) {
     return fallbackSrc
   }
-  const isStaticImport = typeof src === 'object'
   const isAssetImage = typeof src === 'string' && src.startsWith('/assets')
   const isRemoteImage =
     typeof src === 'string' && (src.startsWith('http') || src.startsWith('//'))
-
-  if (isStaticImport) {
-    return src
-  }
 
   if (isAssetImage) {
     const assetExists = await checkAssetImageExists(src)

--- a/apps/site/src/app/_components/SmartImage.tsx
+++ b/apps/site/src/app/_components/SmartImage.tsx
@@ -1,0 +1,84 @@
+import fs from 'fs/promises'
+import path from 'path'
+
+import { type ImageProps } from 'next/image'
+import Image from 'next/image'
+
+import type { ImageObjectFit, StaticImageProps } from '@/types/imageType'
+
+import { graphicsData } from '@/data/graphicsData'
+
+const { data: fallbackSrc, alt: fallbackAlt } = graphicsData.imageFallback
+
+export type SmartImageProps = {
+  src?: string | StaticImageProps['data']
+  alt: string
+  className?: string
+  objectFit?: ImageObjectFit
+  padding?: boolean
+} & Omit<ImageProps, 'src' | 'alt' | 'className'>
+
+export async function SmartImage({
+  src,
+  alt,
+  className,
+  ...props
+}: SmartImageProps) {
+  const imageSrc = await getImageSrc(src)
+
+  const imageExists = imageSrc !== fallbackSrc
+
+  return (
+    <Image
+      className={className}
+      src={imageSrc}
+      alt={imageExists ? alt : fallbackAlt}
+      {...props}
+    />
+  )
+}
+
+async function getImageSrc(src: SmartImageProps['src']) {
+  if (!src) {
+    return fallbackSrc
+  }
+  const isStaticImport = typeof src === 'object'
+  const isAssetImage = typeof src === 'string' && src.startsWith('/assets')
+  const isRemoteImage =
+    typeof src === 'string' && (src.startsWith('http') || src.startsWith('//'))
+
+  if (isStaticImport) {
+    return src
+  }
+
+  if (isAssetImage) {
+    const assetExists = await checkAssetImageExists(src)
+    return assetExists ? src : fallbackSrc
+  }
+
+  if (isRemoteImage) {
+    const remoteImageExists = await checkRemoteImageExists(src)
+    return remoteImageExists ? src : fallbackSrc
+  }
+
+  return src
+}
+
+async function checkRemoteImageExists(url: string) {
+  try {
+    const response = await fetch(url, { method: 'HEAD' })
+    return response.ok
+  } catch {
+    return false
+  }
+}
+
+async function checkAssetImageExists(src: string): Promise<boolean> {
+  const publicPath = path.join(process.cwd(), 'public', src)
+  try {
+    await fs.access(publicPath, fs.constants.F_OK)
+    return true
+  } catch {
+    return false
+  }
+}

--- a/apps/site/src/app/_components/SmartImage.tsx
+++ b/apps/site/src/app/_components/SmartImage.tsx
@@ -75,7 +75,7 @@ async function checkRemoteImageExists(url: string) {
   }
 }
 
-async function checkAssetImageExists(src: string): Promise<boolean> {
+async function checkAssetImageExists(src: string) {
   const publicPath = path.join(process.cwd(), 'public', src)
   try {
     await fs.access(publicPath, fs.constants.F_OK)

--- a/apps/site/src/app/about/page.tsx
+++ b/apps/site/src/app/about/page.tsx
@@ -120,7 +120,7 @@ export default function About() {
                   description={description}
                   image={
                     image && {
-                      ...image,
+                      src: image.data,
                       alt: '',
                       sizes: buildImageSizeProp({
                         startSize: '100vw',

--- a/apps/site/src/app/about/page.tsx
+++ b/apps/site/src/app/about/page.tsx
@@ -120,7 +120,7 @@ export default function About() {
                   description={description}
                   image={
                     image && {
-                      ...(image || graphicsData.imageFallback.data),
+                      ...image,
                       alt: '',
                       sizes: buildImageSizeProp({
                         startSize: '100vw',

--- a/apps/site/src/app/blog/[slug]/components/BlogPostHeader.tsx
+++ b/apps/site/src/app/blog/[slug]/components/BlogPostHeader.tsx
@@ -22,7 +22,7 @@ export function BlogPostHeader({
   return (
     <ArticleHeader
       image={{
-        src: image?.src || graphicsData.imageFallback.data.src,
+        src: image?.src,
         alt: '',
       }}
     >

--- a/apps/site/src/app/digest/[slug]/components/DigestArticleHeader.tsx
+++ b/apps/site/src/app/digest/[slug]/components/DigestArticleHeader.tsx
@@ -1,5 +1,3 @@
-import { graphicsData } from '@/data/graphicsData'
-
 import { ArticleHeader } from '@/components/ArticleHeader'
 import { AvatarGroup } from '@/components/AvatarGroup'
 import { TagGroup } from '@/components/TagComponents/TagGroup'
@@ -21,7 +19,7 @@ export function DigestArticleHeader({
   return (
     <ArticleHeader
       image={{
-        src: image?.src || graphicsData.imageFallback.data.src,
+        src: image?.src,
         alt: '',
       }}
     >

--- a/apps/site/src/app/digest/page.tsx
+++ b/apps/site/src/app/digest/page.tsx
@@ -84,7 +84,7 @@ export default function Digest() {
                   icon: BookOpen,
                 }}
                 image={{
-                  ...(image || graphicsData.imageFallback.data),
+                  ...image,
                   alt: image?.alt || '',
                   sizes: buildImageSizeProp({
                     startSize: '100vw',

--- a/apps/site/src/app/digest/page.tsx
+++ b/apps/site/src/app/digest/page.tsx
@@ -83,16 +83,18 @@ export default function Digest() {
                   text: 'Read Article',
                   icon: BookOpen,
                 }}
-                image={{
-                  ...image,
-                  alt: image?.alt || '',
-                  sizes: buildImageSizeProp({
-                    startSize: '100vw',
-                    sm: '350px',
-                    md: '470px',
-                    lg: '360px',
-                  }),
-                }}
+                image={
+                  image && {
+                    src: image.src,
+                    alt: image.alt || '',
+                    sizes: buildImageSizeProp({
+                      startSize: '100vw',
+                      sm: '350px',
+                      md: '470px',
+                      lg: '360px',
+                    }),
+                  }
+                }
               />
             )
           })}

--- a/apps/site/src/app/ecosystem-explorer/[slug]/components/PageHeader.tsx
+++ b/apps/site/src/app/ecosystem-explorer/[slug]/components/PageHeader.tsx
@@ -16,7 +16,7 @@ export function PageHeader({ image }: PageHeaderProps) {
           fill
           priority
           src={image?.src}
-          alt={''}
+          alt=""
           className={clsx(
             image?.src && 'rounded-lg',
             'object-contain object-left-bottom',

--- a/apps/site/src/app/ecosystem-explorer/[slug]/components/PageHeader.tsx
+++ b/apps/site/src/app/ecosystem-explorer/[slug]/components/PageHeader.tsx
@@ -1,17 +1,11 @@
-import { type ImageProps } from 'next/image'
-
 import { clsx } from 'clsx'
 
 import { buildImageSizeProp } from '@/utils/buildImageSizeProp'
 
-import { SmartImage } from '@/components/SmartImage'
-
-type ImagePropsWithOptionalAlt = Omit<ImageProps, 'alt'> & {
-  alt?: string
-}
+import { SmartImage, type SmartImageProps } from '@/components/SmartImage'
 
 type PageHeaderProps = {
-  image?: ImagePropsWithOptionalAlt
+  image?: SmartImageProps
 }
 
 export function PageHeader({ image }: PageHeaderProps) {

--- a/apps/site/src/app/ecosystem-explorer/[slug]/components/PageHeader.tsx
+++ b/apps/site/src/app/ecosystem-explorer/[slug]/components/PageHeader.tsx
@@ -1,10 +1,10 @@
-import Image, { type ImageProps } from 'next/image'
+import { type ImageProps } from 'next/image'
 
 import { clsx } from 'clsx'
 
-import { graphicsData } from '@/data/graphicsData'
-
 import { buildImageSizeProp } from '@/utils/buildImageSizeProp'
+
+import { SmartImage } from '@/components/SmartImage'
 
 type ImagePropsWithOptionalAlt = Omit<ImageProps, 'alt'> & {
   alt?: string
@@ -18,10 +18,10 @@ export function PageHeader({ image }: PageHeaderProps) {
   return (
     <header className="space-y-10 md:space-y-16">
       <div className="relative h-48 md:w-3/4 lg:w-2/3 xl:w-3/5">
-        <Image
+        <SmartImage
           fill
           priority
-          src={image?.src || graphicsData.imageFallback.data.src}
+          src={image?.src}
           alt={''}
           className={clsx(
             image?.src && 'rounded-lg',

--- a/apps/site/src/app/ecosystem-explorer/[slug]/page.tsx
+++ b/apps/site/src/app/ecosystem-explorer/[slug]/page.tsx
@@ -65,7 +65,7 @@ export default async function EcosystemProject(props: EcosystemProjectProps) {
   return (
     <PageLayout>
       <StructuredDataScript structuredData={generateStructuredData(data)} />
-      <PageHeader image={image} />
+      <PageHeader image={image && { src: image.src, alt: image.alt || '' }} />
 
       <Article
         title={title}

--- a/apps/site/src/app/events/[slug]/page.tsx
+++ b/apps/site/src/app/events/[slug]/page.tsx
@@ -113,11 +113,13 @@ export default async function EventEntry(props: EventProps) {
             },
             eventHasConcluded,
           })}
-          image={{
-            ...image,
-            alt: '',
-            objectFit: 'cover',
-          }}
+          image={
+            image && {
+              src: image.src,
+              alt: '',
+              objectFit: 'cover',
+            }
+          }
         />
       </div>
 

--- a/apps/site/src/app/events/[slug]/page.tsx
+++ b/apps/site/src/app/events/[slug]/page.tsx
@@ -114,7 +114,7 @@ export default async function EventEntry(props: EventProps) {
             eventHasConcluded,
           })}
           image={{
-            ...(image || graphicsData.imageFallback.data),
+            ...image,
             alt: '',
             objectFit: 'cover',
           }}

--- a/apps/site/src/app/grants/components/FeaturedGrantGraduates.tsx
+++ b/apps/site/src/app/grants/components/FeaturedGrantGraduates.tsx
@@ -2,8 +2,6 @@ import { BookOpen } from '@phosphor-icons/react/dist/ssr'
 
 import { PATHS } from '@/constants/paths'
 
-import { graphicsData } from '@/data/graphicsData'
-
 import { buildImageSizeProp } from '@/utils/buildImageSizeProp'
 
 import { Card } from '@/components/Card'
@@ -31,17 +29,19 @@ export function FeaturedGrantGraduates({
             text: 'Read More',
             icon: BookOpen,
           }}
-          image={{
-            ...image,
-            alt: '',
-            objectFit: 'contain',
-            padding: Boolean(image),
-            sizes: buildImageSizeProp({
-              startSize: '100vw',
-              sm: '175px',
-              md: '250px',
-            }),
-          }}
+          image={
+            image && {
+              src: image.src,
+              alt: image.alt || '',
+              objectFit: 'contain',
+              padding: Boolean(image),
+              sizes: buildImageSizeProp({
+                startSize: '100vw',
+                sm: '175px',
+                md: '250px',
+              }),
+            }
+          }
         />
       ))}
     </CardGrid>

--- a/apps/site/src/app/grants/components/FeaturedGrantGraduates.tsx
+++ b/apps/site/src/app/grants/components/FeaturedGrantGraduates.tsx
@@ -32,7 +32,7 @@ export function FeaturedGrantGraduates({
             icon: BookOpen,
           }}
           image={{
-            ...(image || graphicsData.imageFallback.data),
+            ...image,
             alt: '',
             objectFit: 'contain',
             padding: Boolean(image),


### PR DESCRIPTION
## 📝 Description

**Type:** Refactor

This PR introduces `SmartImage` wrapper component (_name inspired by `SmartTextLink`_). The purpose of the component is to handle image URL validity and conditionally render the fallback.

## 🛠️ Key Changes

Currently it is used in `Card`, `PageHeader` (_app/components_) , `ArticleHeader`, `PostHeader` (_ecosystem_explorer/components_). These components require fallback handling because images in markdown frontmatter are optional.

With use of this component we can remove the "`image || graphicsData.imageFallback.data`" condition and just pass the `image` as a prop.

`SmartImage` will render the fallback (_currently fixed but can be customizable in the future_) in the following cases:
- The image is missing in the markdown frontmatter.
- The src URL in the markdown frontmatter is invalid.
- A remote image URL is passed, but the URL is broken.


## 🧪 How to Test

- Check if the fallback is shown in the cases described above.

