### PR TITLE
[UXIT-1889] Scout PR · Move Governance Calendar Cards Logic [skip percy]

### DIFF
--- a/src/app/governance/components/CalendarCards.tsx
+++ b/src/app/governance/components/CalendarCards.tsx
@@ -16,9 +16,7 @@ import { Heading } from '@/components/Heading'
 import { TagGroupContainer } from '@/components/TagComponents/TagGroupContainer'
 import { TagLabel } from '@/components/TagLabel'
 
-type CalendarProps = {
-  startDate: string
-}
+import { Calendar } from './CalendarCards/Calendar'
 
 type PlaceholderProps = {
   text: string
@@ -51,21 +49,6 @@ function Placeholder({ text }: PlaceholderProps) {
   return (
     <div className="py-8 lg:flex lg:h-[558px] lg:items-center lg:justify-center">
       {text}
-    </div>
-  )
-}
-
-function Calendar({ startDate }: CalendarProps) {
-  const { day, month } = formatDateComponentsFromISO(startDate)
-
-  return (
-    <div className="grid h-40 w-full grid-rows-[_40px,auto] rounded-md border border-blue-400 bg-brand-500 sm:w-[140px]">
-      <span className="flex items-center justify-center rounded-t text-base font-normal uppercase">
-        {month}
-      </span>
-      <span className="flex items-center justify-center rounded-b bg-brand-100 text-5xl font-bold text-brand-400">
-        {day}
-      </span>
     </div>
   )
 }

--- a/src/app/governance/components/CalendarCards.tsx
+++ b/src/app/governance/components/CalendarCards.tsx
@@ -70,7 +70,7 @@ function Calendar({ startDate }: CalendarProps) {
   )
 }
 
-export function GovernanceCalendarCards() {
+export function CalendarCards() {
   const [currentDate] = useState(new Date())
   const timeMin = encodeURIComponent(currentDate.toISOString())
 

--- a/src/app/governance/components/CalendarCards/Calendar.tsx
+++ b/src/app/governance/components/CalendarCards/Calendar.tsx
@@ -1,0 +1,20 @@
+import { formatDateComponentsFromISO } from '@/utils/dateUtils'
+
+type CalendarProps = {
+  startDate: string
+}
+
+export function Calendar({ startDate }: CalendarProps) {
+  const { day, month } = formatDateComponentsFromISO(startDate)
+
+  return (
+    <div className="grid h-40 w-full grid-rows-[_40px,auto] rounded-md border border-blue-400 bg-brand-500 sm:w-[140px]">
+      <span className="flex items-center justify-center rounded-t text-base font-normal uppercase">
+        {month}
+      </span>
+      <span className="flex items-center justify-center rounded-b bg-brand-100 text-5xl font-bold text-brand-400">
+        {day}
+      </span>
+    </div>
+  )
+}

--- a/src/app/governance/components/CalendarCards/Calendar.tsx
+++ b/src/app/governance/components/CalendarCards/Calendar.tsx
@@ -1,9 +1,9 @@
 import { formatDateComponentsFromISO } from '@/utils/dateUtils'
 
-import type { EventType } from './CalendarCards'
+import type { CalendarEventType } from '../../schemas/CalendarEventSchemas'
 
 type CalendarProps = {
-  startDate: EventType['start']['dateTime']
+  startDate: CalendarEventType['start']['dateTime']
 }
 
 export function Calendar({ startDate }: CalendarProps) {

--- a/src/app/governance/components/CalendarCards/Calendar.tsx
+++ b/src/app/governance/components/CalendarCards/Calendar.tsx
@@ -1,7 +1,9 @@
 import { formatDateComponentsFromISO } from '@/utils/dateUtils'
 
+import type { EventType } from './CalendarCards'
+
 type CalendarProps = {
-  startDate: string
+  startDate: EventType['start']['dateTime']
 }
 
 export function Calendar({ startDate }: CalendarProps) {

--- a/src/app/governance/components/CalendarCards/CalendarCard.tsx
+++ b/src/app/governance/components/CalendarCards/CalendarCard.tsx
@@ -7,10 +7,11 @@ import { Heading } from '@/components/Heading'
 import { TagGroupContainer } from '@/components/TagComponents/TagGroupContainer'
 import { TagLabel } from '@/components/TagLabel'
 
-import { Calendar } from './Calendar'
-import type { EventType } from './CalendarCards'
+import type { CalendarEventType } from '../../schemas/CalendarEventSchemas'
 
-type CalendarCardProps = Omit<EventType, 'id'>
+import { Calendar } from './Calendar'
+
+type CalendarCardProps = Omit<CalendarEventType, 'id'>
 
 export function CalendarCard({
   start,

--- a/src/app/governance/components/CalendarCards/CalendarCard.tsx
+++ b/src/app/governance/components/CalendarCards/CalendarCard.tsx
@@ -1,0 +1,49 @@
+import { Clock, CalendarPlus } from '@phosphor-icons/react/dist/ssr'
+
+import { formatDateComponentsFromISO } from '@/utils/dateUtils'
+
+import { Card } from '@/components/Card'
+import { Heading } from '@/components/Heading'
+import { TagGroupContainer } from '@/components/TagComponents/TagGroupContainer'
+import { TagLabel } from '@/components/TagLabel'
+
+import { Calendar } from './Calendar'
+import type { EventType } from './CalendarCards'
+
+type CalendarCardProps = Omit<EventType, 'id'>
+
+export function CalendarCard({
+  start,
+  end,
+  htmlLink,
+  summary,
+}: CalendarCardProps) {
+  const { time: startTime } = formatDateComponentsFromISO(start.dateTime)
+  const { time: endTime } = formatDateComponentsFromISO(end.dateTime)
+
+  return (
+    <li className="relative flex flex-col rounded-lg border border-brand-300 p-1 sm:flex-row">
+      <Calendar startDate={start.dateTime} />
+
+      <div className="flex-1 pb-14 sm:pb-0">
+        <div className="flex flex-col gap-3 p-4">
+          <TagGroupContainer>
+            <TagLabel icon={Clock}>{`UTC ${startTime} - ${endTime}`}</TagLabel>
+            <TagLabel variant="secondary">Zoom</TagLabel>
+          </TagGroupContainer>
+
+          <Heading tag="h3" variant="lg">
+            {summary}
+          </Heading>
+        </div>
+
+        <Card.Link
+          href={htmlLink}
+          icon={CalendarPlus}
+          text="Add to Google Calendar"
+          left={['left-4', 'sm:left-40']}
+        />
+      </div>
+    </li>
+  )
+}

--- a/src/app/governance/components/CalendarCards/CalendarCards.tsx
+++ b/src/app/governance/components/CalendarCards/CalendarCards.tsx
@@ -16,7 +16,7 @@ import { Heading } from '@/components/Heading'
 import { TagGroupContainer } from '@/components/TagComponents/TagGroupContainer'
 import { TagLabel } from '@/components/TagLabel'
 
-import { Calendar } from './CalendarCards/Calendar'
+import { Calendar } from './Calendar'
 
 type PlaceholderProps = {
   text: string

--- a/src/app/governance/components/CalendarCards/CalendarCards.tsx
+++ b/src/app/governance/components/CalendarCards/CalendarCards.tsx
@@ -8,21 +8,10 @@ import { API_URLS } from '@/constants/apiUrls'
 
 import { CardGrid } from '@/components/CardGrid'
 
-import { CalendarEventsSchema } from '../../schemas/CalendarEventSchemas'
+import { getCalendarEvents } from '../../utils/getCalendarEvents'
 
 import { CalendarCard } from './CalendarCard'
 import { Placeholder } from './Placeholder'
-
-async function getEvents(endpoint: string) {
-  const response = await fetch(endpoint)
-
-  if (!response.ok) {
-    throw new Error('getEvents: Failed to fetch events')
-  }
-
-  const data = await response.json()
-  return CalendarEventsSchema.parse(data)
-}
 
 export function CalendarCards() {
   const [currentDate] = useState(new Date())
@@ -30,7 +19,7 @@ export function CalendarCards() {
 
   const url = `${API_URLS.googleCalendar}${process.env.NEXT_PUBLIC_CALENDAR_ID}/events?maxResults=6&singleEvents=true&timeMin=${timeMin}&key=${process.env.NEXT_PUBLIC_CALENDAR_API_KEY}`
 
-  const { data: events, error } = useSWR(url, getEvents)
+  const { data: events, error } = useSWR(url, getCalendarEvents)
 
   if (error) {
     return <Placeholder text="Failed to load events" />

--- a/src/app/governance/components/CalendarCards/CalendarCards.tsx
+++ b/src/app/governance/components/CalendarCards/CalendarCards.tsx
@@ -3,28 +3,15 @@
 import { useState } from 'react'
 
 import useSWR from 'swr'
-import { z } from 'zod'
 
 import { API_URLS } from '@/constants/apiUrls'
 
 import { CardGrid } from '@/components/CardGrid'
 
+import { CalendarEventsSchema } from '../../schemas/CalendarEventSchemas'
+
 import { CalendarCard } from './CalendarCard'
 import { Placeholder } from './Placeholder'
-
-const eventSchema = z.object({
-  id: z.string(),
-  start: z.object({ dateTime: z.string() }),
-  end: z.object({ dateTime: z.string() }),
-  htmlLink: z.string(),
-  summary: z.string(),
-})
-
-export type EventType = z.infer<typeof eventSchema>
-
-const eventsSchema = z.object({
-  items: z.array(eventSchema),
-})
 
 async function getEvents(endpoint: string) {
   const response = await fetch(endpoint)
@@ -34,7 +21,7 @@ async function getEvents(endpoint: string) {
   }
 
   const data = await response.json()
-  return eventsSchema.parse(data)
+  return CalendarEventsSchema.parse(data)
 }
 
 export function CalendarCards() {

--- a/src/app/governance/components/CalendarCards/CalendarCards.tsx
+++ b/src/app/governance/components/CalendarCards/CalendarCards.tsx
@@ -2,25 +2,15 @@
 
 import { useState } from 'react'
 
-import { Clock, CalendarPlus } from '@phosphor-icons/react/dist/ssr'
 import useSWR from 'swr'
 import { z } from 'zod'
 
 import { API_URLS } from '@/constants/apiUrls'
 
-import { formatDateComponentsFromISO } from '@/utils/dateUtils'
-
-import { Card } from '@/components/Card'
 import { CardGrid } from '@/components/CardGrid'
-import { Heading } from '@/components/Heading'
-import { TagGroupContainer } from '@/components/TagComponents/TagGroupContainer'
-import { TagLabel } from '@/components/TagLabel'
 
-import { Calendar } from './Calendar'
-
-type PlaceholderProps = {
-  text: string
-}
+import { CalendarCard } from './CalendarCard'
+import { Placeholder } from './Placeholder'
 
 const eventSchema = z.object({
   id: z.string(),
@@ -29,6 +19,8 @@ const eventSchema = z.object({
   htmlLink: z.string(),
   summary: z.string(),
 })
+
+export type EventType = z.infer<typeof eventSchema>
 
 const eventsSchema = z.object({
   items: z.array(eventSchema),
@@ -43,14 +35,6 @@ async function getEvents(endpoint: string) {
 
   const data = await response.json()
   return eventsSchema.parse(data)
-}
-
-function Placeholder({ text }: PlaceholderProps) {
-  return (
-    <div className="py-8 lg:flex lg:h-[558px] lg:items-center lg:justify-center">
-      {text}
-    </div>
-  )
 }
 
 export function CalendarCards() {
@@ -75,42 +59,15 @@ export function CalendarCards() {
 
   return (
     <CardGrid cols="lgTwo">
-      {events.items.map((event) => {
-        const { id, start, end, htmlLink, summary } = event
-
-        const { time: startTime } = formatDateComponentsFromISO(start.dateTime)
-        const { time: endTime } = formatDateComponentsFromISO(end.dateTime)
-
-        return (
-          <li
-            key={id}
-            className="relative flex flex-col rounded-lg border border-brand-300 p-1 sm:flex-row"
-          >
-            <Calendar startDate={start.dateTime} />
-            <div className="flex-1 pb-14 sm:pb-0">
-              <div className="flex flex-col gap-3 p-4">
-                <TagGroupContainer>
-                  <TagLabel
-                    icon={Clock}
-                  >{`UTC ${startTime} - ${endTime}`}</TagLabel>
-                  <TagLabel variant="secondary">Zoom</TagLabel>
-                </TagGroupContainer>
-
-                <Heading tag="h3" variant="lg">
-                  {summary}
-                </Heading>
-              </div>
-
-              <Card.Link
-                href={htmlLink}
-                icon={CalendarPlus}
-                text="Add to Google Calendar"
-                left={['left-4', 'sm:left-40']}
-              />
-            </div>
-          </li>
-        )
-      })}
+      {events.items.map(({ id, start, end, htmlLink, summary }) => (
+        <CalendarCard
+          key={id}
+          start={start}
+          end={end}
+          htmlLink={htmlLink}
+          summary={summary}
+        />
+      ))}
     </CardGrid>
   )
 }

--- a/src/app/governance/components/CalendarCards/Placeholder.tsx
+++ b/src/app/governance/components/CalendarCards/Placeholder.tsx
@@ -1,0 +1,11 @@
+type PlaceholderProps = {
+  text: string
+}
+
+export function Placeholder({ text }: PlaceholderProps) {
+  return (
+    <div className="py-8 lg:flex lg:h-[558px] lg:items-center lg:justify-center">
+      {text}
+    </div>
+  )
+}

--- a/src/app/governance/page.tsx
+++ b/src/app/governance/page.tsx
@@ -8,13 +8,13 @@ import { getFrontmatter } from '@/utils/getFrontmatter'
 import { BaseFrontmatterSchema } from '@/schemas/FrontmatterSchema'
 
 import { CardGrid } from '@/components/CardGrid'
-import { GovernanceCalendarCards } from '@/components/GovernanceCalendarCards'
 import { HomeExploreSectionCard } from '@/components/HomeExploreSectionCard'
 import { PageHeader } from '@/components/PageHeader'
 import { PageLayout } from '@/components/PageLayout'
 import { PageSection } from '@/components/PageSection'
 import { StructuredDataScript } from '@/components/StructuredDataScript'
 
+import { CalendarCards } from './components/CalendarCards'
 import { CTAPageSection } from './components/CTAPageSection'
 import { governanceDocsData } from './data/governanceDocsData'
 import { generateStructuredData } from './utils/generateStructuredData'
@@ -83,7 +83,7 @@ export default function Governance() {
       />
 
       <PageSection kicker="Upcoming Events" title="Community Calls">
-        <GovernanceCalendarCards />
+        <CalendarCards />
       </PageSection>
 
       <CTAPageSection />

--- a/src/app/governance/page.tsx
+++ b/src/app/governance/page.tsx
@@ -14,7 +14,7 @@ import { PageLayout } from '@/components/PageLayout'
 import { PageSection } from '@/components/PageSection'
 import { StructuredDataScript } from '@/components/StructuredDataScript'
 
-import { CalendarCards } from './components/CalendarCards'
+import { CalendarCards } from './components/CalendarCards/CalendarCards'
 import { CTAPageSection } from './components/CTAPageSection'
 import { governanceDocsData } from './data/governanceDocsData'
 import { generateStructuredData } from './utils/generateStructuredData'

--- a/src/app/governance/schemas/CalendarEventSchemas.tsx
+++ b/src/app/governance/schemas/CalendarEventSchemas.tsx
@@ -1,0 +1,15 @@
+import { z } from 'zod'
+
+const CalendarEventSchema = z.object({
+  id: z.string(),
+  start: z.object({ dateTime: z.string() }),
+  end: z.object({ dateTime: z.string() }),
+  htmlLink: z.string(),
+  summary: z.string(),
+})
+
+export const CalendarEventsSchema = z.object({
+  items: z.array(CalendarEventSchema),
+})
+
+export type CalendarEventType = z.infer<typeof CalendarEventSchema>

--- a/src/app/governance/utils/getCalendarEvents.ts
+++ b/src/app/governance/utils/getCalendarEvents.ts
@@ -1,0 +1,12 @@
+import { CalendarEventsSchema } from '../schemas/CalendarEventSchemas'
+
+export async function getCalendarEvents(endpoint: string) {
+  const response = await fetch(endpoint)
+
+  if (!response.ok) {
+    throw new Error('getEvents: Failed to fetch events')
+  }
+
+  const data = await response.json()
+  return CalendarEventsSchema.parse(data)
+}


### PR DESCRIPTION
## 📝 Description

This PR refactors and organizes the Governance Calendar cards logic for improved maintainability and clarity. It includes moving relevant logic and components to dedicated files and folders, ensuring better separation of concerns and modularity.

It came about when working on https://github.com/FilecoinFoundationWeb/filecoin-foundation/pull/918.

- **Type:** Refactor

## 🛠️ Key Changes

- Moved `getCalendarEvents` logic to the Governance folder for better scoping and reuse.
- Moved Calendar schemas to a dedicated file for improved structure (`c1b35189`).
- Updated the code to use `EventType` for improved type safety (`cdb37d0f`).
- Abstracted the `CalendarCard` component for better reusability (`f0e65e13`).
- Fixed and finalized the move of `CalendarCards` to the local Governance folder (`77d6dcce`, `329feffb`).
- Created a standalone file for the Calendar component for better separation (`b337bf58`).

## 🧪 How to Test

- **Setup:** Ensure the project dependencies are installed and the local server is running.
- **Steps to Test:**
  1. Navigate to the Governance page.
  2. Verify that the Calendar cards load correctly with accurate data.
  3. Check for any UI or functional regressions in the Governance calendar features.
- **Expected Results:** 
  - Governance Calendar cards should display as expected.
  - No errors or regressions should occur after the refactor.
