### PR TITLE
[UXIT-1892] Events Page · Fix Decap CMS Recap Fields

### DIFF
--- a/public/admin/config.yml
+++ b/public/admin/config.yml
@@ -894,13 +894,13 @@ collections:
             min: 0
             max: 7
             fields: *event_sponsor_config
-          - name: recap-youtube-embed-url
-            label: Event Recap YouTube Embed URL
-            widget: string
-            required: false
-            hint: "Please enter the YouTube embed URL in the format: 'https://www.youtube.com/embed/{videoId}', without additional query parameters."
-          - name: recap-youtube-playlist-url
-            label: Event Recap YouTube Playlist URL
-            widget: string
-            required: false
+      - name: recap-youtube-embed-url
+        label: Event Recap YouTube Embed URL
+        widget: string
+        required: false
+        hint: "Please enter the YouTube embed URL in the format: 'https://www.youtube.com/embed/{videoId}', without additional query parameters."
+      - name: recap-youtube-playlist-url
+        label: Event Recap YouTube Playlist URL
+        widget: string
+        required: false
       - *meta_config_with_title_fallback

--- a/public/admin/config.yml
+++ b/public/admin/config.yml
@@ -894,13 +894,20 @@ collections:
             min: 0
             max: 7
             fields: *event_sponsor_config
-      - name: recap-youtube-embed-url
-        label: Event Recap YouTube Embed URL
-        widget: string
+      - name: "recap"
+        label: "Recap"
+        widget: "object"
         required: false
-        hint: "Please enter the YouTube embed URL in the format: 'https://www.youtube.com/embed/{videoId}', without additional query parameters."
-      - name: recap-youtube-playlist-url
-        label: Event Recap YouTube Playlist URL
-        widget: string
-        required: false
+        collapsed: true
+        fields:
+          - name: "youtube-embed-url"
+            label: "Event Recap YouTube Embed URL"
+            widget: "string"
+            required: false
+            hint: "Please enter the YouTube embed URL in the format: 'https://www.youtube.com/embed/{videoId}', without additional query parameters. Will be shown in the recap section."
+          - name: "youtube-playlist-url"
+            label: "Event Recap YouTube Playlist URL"
+            widget: "string"
+            required: false
+            hint: "Please enter the YouTube playlist URL in the format: 'https://www.youtube.com/playlist?list={playlistId}', without additional query parameters. Will be shown in the page header."
       - *meta_config_with_title_fallback

--- a/src/app/events/[slug]/components/RecapSection.tsx
+++ b/src/app/events/[slug]/components/RecapSection.tsx
@@ -7,7 +7,7 @@ import { YouTubeVideoEmbed } from '@/components/YouTubeVideoEmbed'
 import type { Event } from '../../types/eventType'
 
 type RecapSectionProps = {
-  youtubeEmbedUrl: NonNullable<Event['recapYoutubeEmbedUrl']>
+  youtubeEmbedUrl: NonNullable<NonNullable<Event['recap']>['youtubeEmbedUrl']>
 }
 
 export function RecapSection({ youtubeEmbedUrl }: RecapSectionProps) {

--- a/src/app/events/[slug]/page.tsx
+++ b/src/app/events/[slug]/page.tsx
@@ -63,13 +63,14 @@ export default function EventEntry({ params }: EventProps) {
     schedule,
     speakers,
     sponsors,
-    recapYoutubeEmbedUrl,
-    recapYoutubePlaylistUrl,
+    recap,
   } = data
+
+  const { youtubeEmbedUrl, youtubePlaylistUrl } = recap ?? {}
 
   const eventHasConcluded = isEventConcluded(startDate, endDate)
   const eventHasProgram = program && program.events.length > 0
-  const eventHasRecap = eventHasConcluded && recapYoutubeEmbedUrl
+  const eventHasRecap = eventHasConcluded && youtubeEmbedUrl
   const eventHasSchedule = schedule && schedule.days.length > 0
   const eventHasSpeakers = speakers && speakers.speakersList.length > 0
   const eventHasSponsors = sponsors && Object.keys(sponsors).length > 0
@@ -93,7 +94,11 @@ export default function EventEntry({ params }: EventProps) {
             location: location.primary,
           })}
           cta={buildCtaArray({
-            links: { externalLink, lumaCalendarLink, recapYoutubePlaylistUrl },
+            links: {
+              externalLink,
+              lumaCalendarLink,
+              youtubePlaylistUrl,
+            },
             eventHasConcluded,
           })}
           image={{
@@ -104,7 +109,7 @@ export default function EventEntry({ params }: EventProps) {
         />
       </div>
 
-      {eventHasRecap && <RecapSection youtubeEmbedUrl={recapYoutubeEmbedUrl} />}
+      {eventHasRecap && <RecapSection youtubeEmbedUrl={youtubeEmbedUrl} />}
 
       {eventHasProgram && (
         <ProgramSection

--- a/src/app/events/[slug]/utils/buildCtaArray.ts
+++ b/src/app/events/[slug]/utils/buildCtaArray.ts
@@ -6,7 +6,7 @@ import type { Event } from '../../types/eventType'
 type Links = {
   externalLink?: Event['externalLink']
   lumaCalendarLink?: Event['lumaCalendarLink']
-  recapYoutubePlaylistUrl?: Event['recapYoutubePlaylistUrl']
+  youtubePlaylistUrl?: NonNullable<Event['recap']>['youtubePlaylistUrl']
 }
 
 type CtaArrayProps = {
@@ -15,15 +15,15 @@ type CtaArrayProps = {
 }
 
 export function buildCtaArray({
-  links: { externalLink, lumaCalendarLink, recapYoutubePlaylistUrl },
+  links: { externalLink, lumaCalendarLink, youtubePlaylistUrl },
   eventHasConcluded,
 }: CtaArrayProps) {
   const ctaArray: Array<CTAProps> = []
 
   if (eventHasConcluded) {
-    if (recapYoutubePlaylistUrl) {
+    if (youtubePlaylistUrl) {
       ctaArray.push({
-        href: recapYoutubePlaylistUrl,
+        href: youtubePlaylistUrl,
         text: 'Watch Event Highlights',
       })
     } else {

--- a/src/app/events/schemas/FrontMatterSchema.ts
+++ b/src/app/events/schemas/FrontMatterSchema.ts
@@ -8,6 +8,7 @@ import { DynamicBaseDataSchema } from '@/schemas/DynamicDataBaseSchema'
 import { EventBaseFrontMatterSchema } from './EventBaseFontMatterSchema'
 import { LocationSchema } from './LocationSchema'
 import { ProgramSchema } from './ProgramSchema'
+import { RecapSchema } from './RecapSchema'
 import { ScheduleSchema } from './ScheduleSchema'
 import { SpeakersSchema } from './SpeakerSchema'
 import { SponsorsSchema } from './SponsorSchema'
@@ -25,9 +26,8 @@ export const EventFrontMatterSchema = DynamicBaseDataSchema.extend({
   location: LocationSchema,
   'luma-calendar-link': z.string().url().optional(),
   program: ProgramSchema.optional(),
+  recap: RecapSchema.optional(),
   schedule: ScheduleSchema.optional(),
   speakers: SpeakersSchema.optional(),
   sponsors: SponsorsSchema.optional(),
-  'recap-youtube-embed-url': z.string().url().optional(),
-  'recap-youtube-playlist-url': z.string().url().optional(),
 }).strict()

--- a/src/app/events/schemas/RecapSchema.ts
+++ b/src/app/events/schemas/RecapSchema.ts
@@ -1,0 +1,8 @@
+import { z } from 'zod'
+
+export const RecapSchema = z
+  .object({
+    'youtube-embed-url': z.string().url().optional(),
+    'youtube-playlist-url': z.string().url().optional(),
+  })
+  .strict()

--- a/src/app/events/schemas/SpeakerSchema.ts
+++ b/src/app/events/schemas/SpeakerSchema.ts
@@ -2,7 +2,7 @@ import { z } from 'zod'
 
 import { ImagePropsSchema } from '@/schemas/ImagePropsSchema'
 
-const speakerSchema = z.object({
+const SpeakerSchema = z.object({
   name: z.string(),
   title: z.string(),
   company: z.string(),
@@ -14,5 +14,5 @@ export const SpeakersSchema = z.object({
   kicker: z.string().optional().default('Speakers'),
   title: z.string().optional().default('Speakers'),
   description: z.string().optional(),
-  speakers_list: z.array(speakerSchema),
+  speakers_list: z.array(SpeakerSchema),
 })

--- a/src/content/events/fil-bangkok-2024.md
+++ b/src/content/events/fil-bangkok-2024.md
@@ -1,5 +1,11 @@
 ---
 title: FIL Bangkok 2024
+description: Join the Filecoin Community in Bangkok! Dive into decentralized AI
+  infrastructure, DePIN, and the data economy with the Filecoin community in
+  Bangkok, ahead of Devcon. Set in the heart of Thailand, Filecoin Foundation
+  will have dynamic programming, major announcements, and networking
+  opportunities. Seize this opportunity to help shape the future of Filecoin and
+  contribute to the next chapter of a better internet.
 created-on: 2024-09-25T11:03:42.572Z
 updated-on: 2024-09-25T11:03:42.572Z
 published-on: 2024-09-25T11:03:42.572Z
@@ -9,103 +15,71 @@ location:
   region: apac-asia
 start-date: 2024-11-6T11:18:00.000Z
 end-date: 2024-11-12T11:18:00.000Z
-description: Join the Filecoin Community in Bangkok! Dive into decentralized AI
-  infrastructure, DePIN, and the data economy with the Filecoin community in
-  Bangkok, ahead of Devcon. Set in the heart of Thailand, Filecoin Foundation
-  will have dynamic programming, major announcements, and networking
-  opportunities. Seize this opportunity to help shape the future of Filecoin and
-  contribute to the next chapter of a better internet.
 image:
   src: /assets/images/fil-bangkok-2024.webp
 luma-calendar-link: https://lu.ma/filecoin?tag=fil%20bangkok%202024
 program:
-  "events":
-    [
-      {
-        title: "DePIN Day Bangkok",
-        description: "By Fluence, Spheron Network, Parasail & Livepeer",
-        location: "Carlton Hotel Bangkok Sukhumvit",
-        start-date: "2024-11-15T03:00:00.000Z",
-        external-link: "https://lu.ma/depin-bangkok",
-      },
-      {
-        title: "Build & Bloom: Akave's Decentralized Storage Workshop",
-        description: "By Akave",
-        location: "SOCO WORK&LIVE EmQuartier",
-        start-date: "2024-11-14T04:00:00.000Z",
-        external-link: "https://lu.ma/qrk28iw4",
-      },
-      {
-        title: "Hot Ones & Zeros Party by Storacha",
-        description: "By Storacha & Cosmik Agency",
-        location: "Chim Chim",
-        start-date: "2024-11-13T10:30:00.000Z",
-        external-link: "https://lu.ma/xh9ca6fs",
-      },
-      {
-        title: "Code n' Corgi: Filecoin Builders Night",
-        description: "By FIL-B, Sarah Thiam, TPG & La Christa",
-        location: "SOCO WORK&LIVE EmQuartier",
-        start-date: "2024-11-13T10:00:00.000Z",
-        external-link: "https://lu.ma/udulaer4",
-      },
-      {
-        title: "Threshold Summit - Bangkok",
-        description: "By Randamu, Dave Grantham & Kent Bull",
-        location: "U Sathorn Bangkok",
-        start-date: "2024-11-12T05:00:00.000Z",
-        external-link: "https://lu.ma/2hqvjjzl",
-      },
-      {
-        title: "FIL Bangkok: DePIN Meets AI, in partnership with CoinDesk Studios",
-        description: "By Filecoin Foundation",
-        location: "Samyan Mitrtown",
-        start-date: "2024-11-11T02:00:00.000Z",
-        external-link: "https://lu.ma/aqyqwupe",
-      },
-      {
-        title: "IPFS Bangkok",
-        description: "By Miwa Events, Mosh & Daniel",
-        location: "JustCo – Samyan Mitrtown | Coworking & Office Space",
-        start-date: "2024-11-10T06:00:00.000Z",
-        external-link: "https://lu.ma/ipfs-bangkok",
-      },
-      {
-        title: "Filecoin Orbit: AI Commu-night #4",
-        description: "By Filecoin Orbit",
-        location: "Such A Small World",
-        start-date: "2024-11-09T10:00:00.000Z",
-        external-link: "https://www.eventpop.me/e/54742/filecoinplayground15",
-      },
-      {
-        title: "Protocol Labs Cowork Hub",
-        description: "By Protocol Labs",
-        location: "SOCO WORK&LIVE EmQuartier",
-        start-date: "2024-11-07T03:00:00.000Z",
-        external-link: "https://lu.ma/htkj4b43",
-      },
-      {
-        title: "FIL Dev Summit 5 @ LabWeek",
-        description: "By Molly, Marta Geater Piekarska & Filecoin Foundation",
-        location: "Gaysorn Urban Resort",
-        start-date: "2024-11-06T04:00:00.000Z",
-        external-link: "https://lu.ma/vcdjb8pl",
-      },
-      {
-        title: "FIL Bangkok Co-Working Space",
-        description: "By Filecoin Foundation",
-        location: "Gaysorn Urban Resort",
-        start-date: "2024-11-06T04:00:00.000Z",
-        external-link: "https://lu.ma/no08u3bt",
-      },
-      {
-        title: "Filecoin Hacker House",
-        description: "By Filecoin Foundation",
-        location: "Amphoe Mueang Chiang Mai, Chang Wat Chiang Mai",
-        start-date: "2024-10-26T09:00:00.000Z",
-        external-link: "https://lu.ma/j49yitcw",
-      },
-    ]
+  events:
+    - title: DePIN Day Bangkok
+      description: By Fluence, Spheron Network, Parasail & Livepeer
+      location: Carlton Hotel Bangkok Sukhumvit
+      start-date: 2024-11-15T03:00:00.000Z
+      external-link: https://lu.ma/depin-bangkok
+    - title: "Build & Bloom: Akave's Decentralized Storage Workshop"
+      description: By Akave
+      location: SOCO WORK&LIVE EmQuartier
+      start-date: 2024-11-14T04:00:00.000Z
+      external-link: https://lu.ma/qrk28iw4
+    - title: Hot Ones & Zeros Party by Storacha
+      description: By Storacha & Cosmik Agency
+      location: Chim Chim
+      start-date: 2024-11-13T10:30:00.000Z
+      external-link: https://lu.ma/xh9ca6fs
+    - title: "Code n' Corgi: Filecoin Builders Night"
+      description: By FIL-B, Sarah Thiam, TPG & La Christa
+      location: SOCO WORK&LIVE EmQuartier
+      start-date: 2024-11-13T10:00:00.000Z
+      external-link: https://lu.ma/udulaer4
+    - title: Threshold Summit - Bangkok
+      description: By Randamu, Dave Grantham & Kent Bull
+      location: U Sathorn Bangkok
+      start-date: 2024-11-12T05:00:00.000Z
+      external-link: https://lu.ma/2hqvjjzl
+    - title: "FIL Bangkok: DePIN Meets AI, in partnership with CoinDesk Studios"
+      description: By Filecoin Foundation
+      location: Samyan Mitrtown
+      start-date: 2024-11-11T02:00:00.000Z
+      external-link: https://lu.ma/aqyqwupe
+    - title: IPFS Bangkok
+      description: By Miwa Events, Mosh & Daniel
+      location: JustCo – Samyan Mitrtown | Coworking & Office Space
+      start-date: 2024-11-10T06:00:00.000Z
+      external-link: https://lu.ma/ipfs-bangkok
+    - title: "Filecoin Orbit: AI Commu-night #4"
+      description: By Filecoin Orbit
+      location: Such A Small World
+      start-date: 2024-11-09T10:00:00.000Z
+      external-link: https://www.eventpop.me/e/54742/filecoinplayground15
+    - title: Protocol Labs Cowork Hub
+      description: By Protocol Labs
+      location: SOCO WORK&LIVE EmQuartier
+      start-date: 2024-11-07T03:00:00.000Z
+      external-link: https://lu.ma/htkj4b43
+    - title: FIL Dev Summit 5 @ LabWeek
+      description: By Molly, Marta Geater Piekarska & Filecoin Foundation
+      location: Gaysorn Urban Resort
+      start-date: 2024-11-06T04:00:00.000Z
+      external-link: https://lu.ma/vcdjb8pl
+    - title: FIL Bangkok Co-Working Space
+      description: By Filecoin Foundation
+      location: Gaysorn Urban Resort
+      start-date: 2024-11-06T04:00:00.000Z
+      external-link: https://lu.ma/no08u3bt
+    - title: Filecoin Hacker House
+      description: By Filecoin Foundation
+      location: Amphoe Mueang Chiang Mai, Chang Wat Chiang Mai
+      start-date: 2024-10-26T09:00:00.000Z
+      external-link: https://lu.ma/j49yitcw
 schedule:
   days:
     - events:
@@ -269,8 +243,8 @@ schedule:
           speakers:
             - name: Alexander Kinstler
               company: Storacha
-            - name: "Hannah Howard "
-              company: "Storacha "
+            - name: "Hannah Howard"
+              company: "Storacha"
           location: "Samyan Mitrtown: Main Hall"
           start: 2024-11-11T16:17:00.000Z
           end: 2024-11-11T16:31:00.000Z
@@ -303,7 +277,7 @@ schedule:
             by 2026, we need smart platforms that democratize data ownership
             while embedding necessary privacy protections. Ghostdrive delivers
             an affordable, secure, AI-driven Web3 data platform empowering one
-            million users to control and monetize their data via AI. "
+            million users to control and monetize their data via AI."
         - location: "Samyan Mitrtown: Main Hall"
           title: "Sponsored Content: Decentralized Tools for Environmental Change"
           moderators:
@@ -336,8 +310,8 @@ schedule:
             roadmap and learn how GD empowers users to collaborate on generative
             AI training data –– and become a validator of AI data yourself!
           speakers:
-            - name: "Roman Nebo "
-              company: "Ghost Drive "
+            - name: "Roman Nebo"
+              company: "Ghost Drive"
         - title:
             "From Models to Marketplaces: AI, DePIN, and a New Approach to Data
             Infra"
@@ -373,7 +347,7 @@ schedule:
             valuable data to the network.
           speakers:
             - name: Masa Kikuchi
-              company: "Secured Finance "
+              company: "Secured Finance"
           start: 2024-11-11T16:32:00.000Z
           end: 2024-11-11T16:39:00.000Z
           location: "Samyan Mitrtown: Main Hall"
@@ -672,6 +646,9 @@ sponsors:
       name: Ceramic
       image:
         src: /assets/images/ceramic-logo.webp
+recap:
+  youtube-embed-url: https://www.youtube.com/embed/zMrXaGt5jv8
+  youtube-playlist-url: https://youtube.com/playlist?list=PLp3zrT1ewY0klX50yHbrNjEB2Js95jAGU
 seo:
   description: Join the Filecoin Community in Bangkok for discussions on
     decentralized AI, DePIN, and the data economy. Network, hear major

--- a/src/content/events/fil-bangkok-2024.md
+++ b/src/content/events/fil-bangkok-2024.md
@@ -89,11 +89,7 @@ schedule:
             Co-Working Space is your home base in Bangkok to expand your
             network, knowledge, and opportunities within the Filecoin ecosystem.
             From November 6th to 8th, this space is perfect for co-working,
-            meetings, and more!
-
-            ​FIL Dev Summit is a gathering of developers, builders, and engaged community members who want to contribute to the core protocol and network evolution of Filecoin. The summit is a place for meaningful and impactful conversations that help push Filecoin forward (separate registration required).
-
-            ​Filecoin Studio is a state-of-the-art content creation hub offering professional-grade equipment and space for rent to record content that elevates your vision. Book your session.
+            meetings, and more! ​FIL Dev Summit is a gathering of developers, builders, and engaged community members who want to contribute to the core protocol and network evolution of Filecoin. The summit is a place for meaningful and impactful conversations that help push Filecoin forward (separate registration required). ​Filecoin Studio is a state-of-the-art content creation hub offering professional-grade equipment and space for rent to record content that elevates your vision. Book your session.
           start: 2024-11-06T11:00:00.000Z
           end: 2024-11-06T18:30:00.000Z
           location: Gaysorn Urban Resort
@@ -120,11 +116,7 @@ schedule:
             Co-Working Space is your home base in Bangkok to expand your
             network, knowledge, and opportunities within the Filecoin ecosystem.
             From November 6th to 8th, this space is perfect for co-working,
-            meetings, and more!
-
-            ​FIL Dev Summit is a gathering of developers, builders, and engaged community members who want to contribute to the core protocol and network evolution of Filecoin. The summit is a place for meaningful and impactful conversations that help push Filecoin forward (separate registration required).
-
-            ​Filecoin Studio is a state-of-the-art content creation hub offering professional-grade equipment and space for rent to record content that elevates your vision. Book your session.
+            meetings, and more! ​FIL Dev Summit is a gathering of developers, builders, and engaged community members who want to contribute to the core protocol and network evolution of Filecoin. The summit is a place for meaningful and impactful conversations that help push Filecoin forward (separate registration required). ​Filecoin Studio is a state-of-the-art content creation hub offering professional-grade equipment and space for rent to record content that elevates your vision. Book your session.
           start: 2024-11-07T09:00:00.000Z
           end: 2024-11-07T18:30:00.000Z
           location: Gaysorn Urban Resort
@@ -150,11 +142,7 @@ schedule:
             Co-Working Space is your home base in Bangkok to expand your
             network, knowledge, and opportunities within the Filecoin ecosystem.
             From November 6th to 8th, this space is perfect for co-working,
-            meetings, and more!
-
-            ​FIL Dev Summit is a gathering of developers, builders, and engaged community members who want to contribute to the core protocol and network evolution of Filecoin. The summit is a place for meaningful and impactful conversations that help push Filecoin forward (separate registration required).
-
-            ​Filecoin Studio is a state-of-the-art content creation hub offering professional-grade equipment and space for rent to record content that elevates your vision. Book your session.
+            meetings, and more! ​FIL Dev Summit is a gathering of developers, builders, and engaged community members who want to contribute to the core protocol and network evolution of Filecoin. The summit is a place for meaningful and impactful conversations that help push Filecoin forward (separate registration required). ​Filecoin Studio is a state-of-the-art content creation hub offering professional-grade equipment and space for rent to record content that elevates your vision. Book your session.
           start: 2024-11-08T09:00:00.000Z
           end: 2024-11-08T18:00:00.000Z
           location: Gaysorn Urban Resort


### PR DESCRIPTION
## 📝 Description

This pull request addresses an implementation issue caused by an indentation mistake in the event configuration, which broke the recap functionality. Taking this opportunity, the pull request focuses on restructuring and consolidating the configuration and schema for event recap fields. 

The changes introduce a `RecapSchema` to validate and manage event recap data in a more structured and maintainable way. The updated implementation replaces individual recap fields with a unified `recap` object, ensuring cleaner code, enhanced validation, and improved maintainability.

- **Type:**  Bug fix / Refactor

## 🛠️ Key Changes

- **Added** `RecapSchema` using Zod to validate event recap fields (`youtubeEmbedUrl` and `youtubePlaylistUrl`).
- **Replaced** individual recap fields (`recap-youtube-embed-url` and `recap-youtube-playlist-url`) with a consolidated `recap` object in `EventFrontMatterSchema`.
- **Capitalized** schema constant names for consistency (e.g., `RecapSchema`).
- **Consolidated** and restructured event recap configuration to simplify management.
- **Updated** event "Fil Bangkok 2024" to use the new `recap` structure.

## 📌 To-Do Before Merging

- [x] Verify existing event entries are updated to align with the new schema structure.

## 🧪 How to Test

- **Setup:** Ensure the application is running with the latest changes.
- **Steps to Test:**
  1. Navigate to the event details page for "Fil Bangkok 2024" and verify the recap section displays correctly.
  2. Check that event recap data validates properly using the `RecapSchema`.
  3. Confirm that removing or modifying recap fields results in appropriate validation errors.
  4. Test other event entries to ensure no regressions.
- **Expected Results:** The recap section should display as expected, and validation should handle errors gracefully.