### PR TITLE
[UXIT-1905] Events Page · Add optional kicker and description to speakers section

### DIFF
--- a/public/admin/config.yml
+++ b/public/admin/config.yml
@@ -823,16 +823,16 @@ collections:
         widget: "object"
         required: false
         fields:
+          - name: "kicker"
+            label: "Section Kicker"
+            widget: "string"
+            required: false
+            hint: "This is the text that appears above the section title. Defaults to 'Speakers'."
           - name: "title"
             label: "Section Title"
             widget: "string"
             required: false
             hint: "The main heading for the speakers section. Defaults to 'Speakers'."
-          - name: "kicker"
-            label: "Section Kicker"
-            widget: "string"
-            required: false
-            hint: "A short phrase that appears above the section title. Defaults to 'Speakers'."
           - name: "description"
             label: "Section Description"
             widget: "text"

--- a/public/admin/config.yml
+++ b/public/admin/config.yml
@@ -819,34 +819,54 @@ collections:
                     widget: "string"
                     required: false
       - name: "speakers"
-        label: "Speakers"
-        widget: "list"
+        label: "Speakers Section"
+        widget: "object"
         required: false
         fields:
-          - name: "name"
-            label: "Full Name"
-            widget: "string"
           - name: "title"
-            label: "Job Title"
+            label: "Section Title"
             widget: "string"
-          - name: "company"
-            label: "Company"
+            required: false
+            hint: "The main heading for the speakers section. Defaults to 'Speakers'."
+          - name: "kicker"
+            label: "Section Kicker"
             widget: "string"
-          - name: "linkedin"
-            label: "LinkedIn Profile URL"
-            widget: "string"
-          - name: "image"
-            label: "Image"
-            widget: "object"
-            collapsed: true
+            required: false
+            hint: "A short phrase that appears above the section title. Defaults to 'Speakers'."
+          - name: "description"
+            label: "Section Description"
+            widget: "text"
+            required: false
+            hint: "A brief description of the speakers section"
+          - name: "speakers_list"
+            label: "Speakers List"
+            widget: "list"
+            required: false
             fields:
-              - name: "src"
-                label: "URL"
-                widget: "image"
-                allow_multiple: false
-                choose_url: false
-                hint: Use https://squoosh.app/ to compress images before uploading. Choose the WebP format and resize the image to max. 200px width, ensuring the aspect ratio is maintained at 2:3 (e.g., 200px width and 300px height).
-              - *image_alt_config
+              - name: "name"
+                label: "Full Name"
+                widget: "string"
+              - name: "title"
+                label: "Job Title"
+                widget: "string"
+              - name: "company"
+                label: "Company"
+                widget: "string"
+              - name: "linkedin"
+                label: "LinkedIn Profile URL"
+                widget: "string"
+              - name: "image"
+                label: "Image"
+                widget: "object"
+                collapsed: true
+                fields:
+                  - name: "src"
+                    label: "URL"
+                    widget: "image"
+                    allow_multiple: false
+                    choose_url: false
+                    hint: Use https://squoosh.app/ to compress images before uploading. Choose the WebP format and resize the image to max. 200px width, ensuring the aspect ratio is maintained at 2:3 (e.g., 200px width and 300px height).
+                  - *image_alt_config
       - name: "sponsors"
         label: "Sponsors"
         widget: "object"

--- a/src/app/events/[slug]/components/SpeakersSection.tsx
+++ b/src/app/events/[slug]/components/SpeakersSection.tsx
@@ -9,10 +9,16 @@ type SpeakersSectionProps = {
 }
 
 export function SpeakersSection({ speakers }: SpeakersSectionProps) {
+  const { title, kicker, description, speakersList } = speakers
+
   return (
-    <PageSection kicker="speakers" title="Speakers">
+    <PageSection
+      kicker={kicker || 'Speakers'}
+      title={title || 'Speakers'}
+      description={description}
+    >
       <CardGrid cols="mdTwo">
-        {speakers.map(({ name, title, company, linkedin, image }) => (
+        {speakersList.map(({ name, title, company, linkedin, image }) => (
           <KeyMemberCard
             key={name}
             name={name}

--- a/src/app/events/[slug]/components/SpeakersSection.tsx
+++ b/src/app/events/[slug]/components/SpeakersSection.tsx
@@ -12,11 +12,7 @@ export function SpeakersSection({ speakers }: SpeakersSectionProps) {
   const { title, kicker, description, speakersList } = speakers
 
   return (
-    <PageSection
-      kicker={kicker || 'Speakers'}
-      title={title || 'Speakers'}
-      description={description}
-    >
+    <PageSection kicker={kicker} title={title} description={description}>
       <CardGrid cols="mdTwo">
         {speakersList.map(({ name, title, company, linkedin, image }) => (
           <KeyMemberCard

--- a/src/app/events/[slug]/page.tsx
+++ b/src/app/events/[slug]/page.tsx
@@ -71,7 +71,7 @@ export default function EventEntry({ params }: EventProps) {
   const eventHasProgram = program && program.events.length > 0
   const eventHasRecap = eventHasConcluded && recapYoutubeEmbedUrl
   const eventHasSchedule = schedule && schedule.days.length > 0
-  const eventHasSpeakers = speakers && speakers.length > 0
+  const eventHasSpeakers = speakers && speakers.speakersList.length > 0
   const eventHasSponsors = sponsors && Object.keys(sponsors).length > 0
 
   return (

--- a/src/app/events/schemas/SpeakerSchema.ts
+++ b/src/app/events/schemas/SpeakerSchema.ts
@@ -2,7 +2,7 @@ import { z } from 'zod'
 
 import { ImagePropsSchema } from '@/schemas/ImagePropsSchema'
 
-const speakerSchema = z.object({
+const speakersListSchema = z.object({
   name: z.string(),
   title: z.string(),
   company: z.string(),
@@ -10,6 +10,9 @@ const speakerSchema = z.object({
   image: ImagePropsSchema,
 })
 
-export const SpeakersSchema = z.array(speakerSchema)
-
-export type Speaker = z.infer<typeof speakerSchema>
+export const SpeakersSchema = z.object({
+  title: z.string().optional(),
+  kicker: z.string().optional(),
+  description: z.string().optional(),
+  speakers_list: z.array(speakersListSchema),
+})

--- a/src/app/events/schemas/SpeakerSchema.ts
+++ b/src/app/events/schemas/SpeakerSchema.ts
@@ -2,7 +2,7 @@ import { z } from 'zod'
 
 import { ImagePropsSchema } from '@/schemas/ImagePropsSchema'
 
-const speakersListSchema = z.object({
+const speakerSchema = z.object({
   name: z.string(),
   title: z.string(),
   company: z.string(),
@@ -11,8 +11,8 @@ const speakersListSchema = z.object({
 })
 
 export const SpeakersSchema = z.object({
-  kicker: z.string().optional().default('Speakers'),
-  title: z.string().optional().default('Speakers'),
+  kicker: z.string().default('Speakers').optional(),
+  title: z.string().default('Speakers').optional(),
   description: z.string().optional(),
-  speakers_list: z.array(speakersListSchema),
+  speakers_list: z.array(speakerSchema),
 })

--- a/src/app/events/schemas/SpeakerSchema.ts
+++ b/src/app/events/schemas/SpeakerSchema.ts
@@ -11,8 +11,8 @@ const speakerSchema = z.object({
 })
 
 export const SpeakersSchema = z.object({
-  kicker: z.string().default('Speakers').optional(),
-  title: z.string().default('Speakers').optional(),
+  kicker: z.string().optional().default('Speakers'),
+  title: z.string().optional().default('Speakers'),
   description: z.string().optional(),
   speakers_list: z.array(speakerSchema),
 })

--- a/src/app/events/schemas/SpeakerSchema.ts
+++ b/src/app/events/schemas/SpeakerSchema.ts
@@ -11,8 +11,8 @@ const speakersListSchema = z.object({
 })
 
 export const SpeakersSchema = z.object({
-  title: z.string().optional(),
-  kicker: z.string().optional(),
+  kicker: z.string().optional().default('Speakers'),
+  title: z.string().optional().default('Speakers'),
   description: z.string().optional(),
   speakers_list: z.array(speakersListSchema),
 })

--- a/src/content/events/fil-bangkok-2024.md
+++ b/src/content/events/fil-bangkok-2024.md
@@ -484,162 +484,163 @@ schedule:
             contribute to the future of Filecoin.
       date: 2024-11-11T09:00:00.000Z
 speakers:
-  - name: Juan Benet
-    title: Founder & CEO
-    company: Protocol Labs
-    linkedin: https://www.linkedin.com/in/jbenetcs/
-    image:
-      src: /assets/images/juan-benet-headshot.webp
-  - name: Marta Belcher
-    linkedin: https://www.linkedin.com/in/martabelcher/
-    company: Filecoin Foundation
-    image:
-      src: /assets/headshots/Marta_Belcher.png
-    title: President & Chair
-  - name: Anjali George
-    title: CMO
-    company: Theoriq
-    linkedin: https://www.linkedin.com/in/anjaliegeorge/
-    image:
-      src: /assets/images/anjali-george-headshot.webp
-  - name: Ayush Ranjan
-    title: Co-founder & CEO
-    company: Huddle01
-    linkedin: https://www.linkedin.com/in/ranjan18/
-    image:
-      src: /assets/images/ayush-ranjan.webp
-  - name: Leah Callon-Butler
-    title: Director
-    company: Emfarsis
-    linkedin: https://www.linkedin.com/in/leahcallonbutler/
-    image:
-      src: /assets/images/leah-callon-butler-headshot.webp
-  - linkedin: https://www.linkedin.com/in/mollymackinlay/
-    name: Molly Mackinlay
-    title: CEO
-    company: FilOz
-    image:
-      src: /assets/images/molly-mackinlay-headshot.webp
-  - name: Alejandro Rodríguez
-    title: Value Engineer
-    company: SingularityNET
-    linkedin: https://www.linkedin.com/in/-alejandro-rodriguez/
-    image:
-      src: /assets/images/alejandro-rodri-guez-headshot.webp
-  - image:
-      src: /assets/images/alan_coast.webp
-    name: Alan Ransil
-    title: CEO
-    company: Devonian Systems
-    linkedin: https://www.linkedin.com/in/alan-ransil-53573873/
-  - name: Clara Tsao
-    title: Founding Officer
-    company: Filecoin Foundation
-    linkedin: https://www.linkedin.com/in/claratsao/
-    image:
-      src: /assets/images/clara-tsao-headshot.webp
-  - name: Sherry Chung
-    title: Business Development & Solution Architect
-    company: Numbers Co., Ltd.
-    linkedin: https://www.linkedin.com/in/sherry-chung-18223138/
-    image:
-      src: /assets/images/sherry-chung-headshot.webp
-  - name: David Dao
-    title: Co-Founder & Chief Scientist
-    company: GainForest.Earth
-    linkedin: https://www.linkedin.com/in/dwddao/
-    image:
-      src: /assets/images/david-dao-headshot.webp
-  - name: Alexander Kinstler
-    title: Chief Product Officer, Co-Founder
-    company: Storacha
-    linkedin: https://www.linkedin.com/in/alexanderkinstler/
-    image:
-      src: /assets/images/alexander-kinstler-headshot.webp
-  - name: Stefaan Vervaet
-    title: CEO
-    company: Akave.ai
-    linkedin: https://www.linkedin.com/in/stefaan-vervaet/
-    image:
-      src: /assets/images/stefaan-vervaet-headshot.webp
-  - name: Megan Klimen
-    title: Founding Officer
-    company: Filecoin Foundation
-    linkedin: https://www.linkedin.com/in/megan-klimen/
-    image:
-      src: /assets/images/megan-klimen-headshot.webp
-  - name: Masa Kikuchi
-    title: Founder & CEO
-    company: Secured Finance
-    linkedin: https://www.linkedin.com/in/masa-senshi-kikuchi-55185a23/
-    image:
-      src: /assets/images/masa-kikuchi-headshot.webp
-  - name: Ted Liao
-    title: CEO
-    company: Glitter Protocol
-    image:
-      src: /assets/images/ted-liao-headshot.webp
-    linkedin: https://www.linkedin.com/in/ted-liao-2694b8242/
-  - name: Vitalii Yatskiv
-    title: CTO
-    company: Boosty Labs
-    image:
-      src: /assets/images/1718436285615.jpeg
-    linkedin: https://www.linkedin.com/in/vitalii-yatskiv/
-  - name: Rachel Green Horn
-    title: Head of Marketing and Communications
-    company: Filecoin Foundation
-    linkedin: https://www.linkedin.com/in/rachelgreenhorn/
-    image:
-      src: /assets/images/rachel-green-horn-headshot.webp
-  - name: Jaden Yan
-    title: Web3 Chief Architect
-    company: Aethir
-    linkedin: https://www.linkedin.com/in/jaden-yan-898b65188/
-    image:
-      src: /assets/images/jaden-yan-headshot.webp
-  - name: Ethan Chae
-    title: Co-CEO
-    company: Hippocrat
-    linkedin: https://www.linkedin.com/in/ethanchae/
-    image:
-      src: /assets/images/ethan-chae-headshot.webp
-  - name: Roman Nebo
-    title: CEO & Founder
-    company: Ghost Drive
-    linkedin: https://www.linkedin.com/in/romansky
-    image:
-      src: /assets/images/roman-nebo-headshot.webp
-  - name: Patrick Kearney
-    title: Head of Growth
-    company: Fleek
-    linkedin: https://www.linkedin.com/in/palerthanale/
-    image:
-      src: /assets/images/patrick-kearney-headshot.webp
-  - name: Hannah Howard
-    title: CTO
-    company: Storacha
-    linkedin: https://www.linkedin.com/in/techgirlwonder/
-    image:
-      src: /assets/images/hannahhoward-headshot.webp
-  - name: Konstantin Tkachuk
-    title: Co-founder and CSO
-    company: Titan Network
-    linkedin: https://www.linkedin.com/in/tkachukk/
-    image:
-      src: /assets/images/konstantin-tkachuk.webp
-  - name: Jonathan Victor
-    title: Co-Founder
-    company: "Ansa Research "
-    linkedin: https://www.linkedin.com/in/jonathan-victor-69a44255/
-    image:
-      src: /assets/images/jonathan-victor-headshot-.webp
-  - name: Sarah Thiam
-    title: Founder and CEO
-    linkedin: https://www.linkedin.com/in/sarahthiam/
-    company: FIL-B
-    image:
-      src: /assets/images/sarah-thiam.webp
+  speakers_list:
+    - name: Juan Benet
+      title: Founder & CEO
+      company: Protocol Labs
+      linkedin: https://www.linkedin.com/in/jbenetcs/
+      image:
+        src: /assets/images/juan-benet-headshot.webp
+    - name: Marta Belcher
+      linkedin: https://www.linkedin.com/in/martabelcher/
+      company: Filecoin Foundation
+      image:
+        src: /assets/headshots/Marta_Belcher.png
+      title: President & Chair
+    - name: Anjali George
+      title: CMO
+      company: Theoriq
+      linkedin: https://www.linkedin.com/in/anjaliegeorge/
+      image:
+        src: /assets/images/anjali-george-headshot.webp
+    - name: Ayush Ranjan
+      title: Co-founder & CEO
+      company: Huddle01
+      linkedin: https://www.linkedin.com/in/ranjan18/
+      image:
+        src: /assets/images/ayush-ranjan.webp
+    - name: Leah Callon-Butler
+      title: Director
+      company: Emfarsis
+      linkedin: https://www.linkedin.com/in/leahcallonbutler/
+      image:
+        src: /assets/images/leah-callon-butler-headshot.webp
+    - linkedin: https://www.linkedin.com/in/mollymackinlay/
+      name: Molly Mackinlay
+      title: CEO
+      company: FilOz
+      image:
+        src: /assets/images/molly-mackinlay-headshot.webp
+    - name: Alejandro Rodríguez
+      title: Value Engineer
+      company: SingularityNET
+      linkedin: https://www.linkedin.com/in/-alejandro-rodriguez/
+      image:
+        src: /assets/images/alejandro-rodri-guez-headshot.webp
+    - image:
+        src: /assets/images/alan_coast.webp
+      name: Alan Ransil
+      title: CEO
+      company: Devonian Systems
+      linkedin: https://www.linkedin.com/in/alan-ransil-53573873/
+    - name: Clara Tsao
+      title: Founding Officer
+      company: Filecoin Foundation
+      linkedin: https://www.linkedin.com/in/claratsao/
+      image:
+        src: /assets/images/clara-tsao-headshot.webp
+    - name: Sherry Chung
+      title: Business Development & Solution Architect
+      company: Numbers Co., Ltd.
+      linkedin: https://www.linkedin.com/in/sherry-chung-18223138/
+      image:
+        src: /assets/images/sherry-chung-headshot.webp
+    - name: David Dao
+      title: Co-Founder & Chief Scientist
+      company: GainForest.Earth
+      linkedin: https://www.linkedin.com/in/dwddao/
+      image:
+        src: /assets/images/david-dao-headshot.webp
+    - name: Alexander Kinstler
+      title: Chief Product Officer, Co-Founder
+      company: Storacha
+      linkedin: https://www.linkedin.com/in/alexanderkinstler/
+      image:
+        src: /assets/images/alexander-kinstler-headshot.webp
+    - name: Stefaan Vervaet
+      title: CEO
+      company: Akave.ai
+      linkedin: https://www.linkedin.com/in/stefaan-vervaet/
+      image:
+        src: /assets/images/stefaan-vervaet-headshot.webp
+    - name: Megan Klimen
+      title: Founding Officer
+      company: Filecoin Foundation
+      linkedin: https://www.linkedin.com/in/megan-klimen/
+      image:
+        src: /assets/images/megan-klimen-headshot.webp
+    - name: Masa Kikuchi
+      title: Founder & CEO
+      company: Secured Finance
+      linkedin: https://www.linkedin.com/in/masa-senshi-kikuchi-55185a23/
+      image:
+        src: /assets/images/masa-kikuchi-headshot.webp
+    - name: Ted Liao
+      title: CEO
+      company: Glitter Protocol
+      image:
+        src: /assets/images/ted-liao-headshot.webp
+      linkedin: https://www.linkedin.com/in/ted-liao-2694b8242/
+    - name: Vitalii Yatskiv
+      title: CTO
+      company: Boosty Labs
+      image:
+        src: /assets/images/1718436285615.jpeg
+      linkedin: https://www.linkedin.com/in/vitalii-yatskiv/
+    - name: Rachel Green Horn
+      title: Head of Marketing and Communications
+      company: Filecoin Foundation
+      linkedin: https://www.linkedin.com/in/rachelgreenhorn/
+      image:
+        src: /assets/images/rachel-green-horn-headshot.webp
+    - name: Jaden Yan
+      title: Web3 Chief Architect
+      company: Aethir
+      linkedin: https://www.linkedin.com/in/jaden-yan-898b65188/
+      image:
+        src: /assets/images/jaden-yan-headshot.webp
+    - name: Ethan Chae
+      title: Co-CEO
+      company: Hippocrat
+      linkedin: https://www.linkedin.com/in/ethanchae/
+      image:
+        src: /assets/images/ethan-chae-headshot.webp
+    - name: Roman Nebo
+      title: CEO & Founder
+      company: Ghost Drive
+      linkedin: https://www.linkedin.com/in/romansky
+      image:
+        src: /assets/images/roman-nebo-headshot.webp
+    - name: Patrick Kearney
+      title: Head of Growth
+      company: Fleek
+      linkedin: https://www.linkedin.com/in/palerthanale/
+      image:
+        src: /assets/images/patrick-kearney-headshot.webp
+    - name: Hannah Howard
+      title: CTO
+      company: Storacha
+      linkedin: https://www.linkedin.com/in/techgirlwonder/
+      image:
+        src: /assets/images/hannahhoward-headshot.webp
+    - name: Konstantin Tkachuk
+      title: Co-founder and CSO
+      company: Titan Network
+      linkedin: https://www.linkedin.com/in/tkachukk/
+      image:
+        src: /assets/images/konstantin-tkachuk.webp
+    - name: Jonathan Victor
+      title: Co-Founder
+      company: "Ansa Research "
+      linkedin: https://www.linkedin.com/in/jonathan-victor-69a44255/
+      image:
+        src: /assets/images/jonathan-victor-headshot-.webp
+    - name: Sarah Thiam
+      title: Founder and CEO
+      linkedin: https://www.linkedin.com/in/sarahthiam/
+      company: FIL-B
+      image:
+        src: /assets/images/sarah-thiam.webp
 sponsors:
   first-tier:
     - name: ZETACUBE


### PR DESCRIPTION
## 📝 Description

**Type:** New feature 

This PR adds `kicker` and `description` as an optional fields in Events page Speakers section.
![Screenshot 2024-12-18 at 09 21 18](https://github.com/user-attachments/assets/fc836bd0-cee1-4c35-b01d-49f14b92cf06)
![Screenshot 2024-12-18 at 09 21 47](https://github.com/user-attachments/assets/7a87bf8c-942e-4527-bc88-ef641fb3792b)
