### PR TITLE
[UXIT-1906] Event Page · Add optional kicker and tag to schedule section

### DIFF
--- a/public/admin/config.yml
+++ b/public/admin/config.yml
@@ -754,6 +754,11 @@ collections:
         required: false
         collapsed: true
         fields:
+          - name: "kicker"
+            label: "Section Kicker"
+            widget: "string"
+            required: false
+            hint: "This is the text that appears above the section title. Defaults to 'Join Us'."
           - name: "title"
             label: "Section Title"
             widget: "string"

--- a/public/admin/config.yml
+++ b/public/admin/config.yml
@@ -776,6 +776,11 @@ collections:
                 label: "Events"
                 widget: "list"
                 fields:
+                  - name: "tag"
+                    label: "Event Tag"
+                    widget: "string"
+                    required: false
+                    hint: "A short label or category (e.g., event location or host) displayed above the event title."
                   - name: "title"
                     label: "Event Title"
                     widget: "string"

--- a/src/app/events/[slug]/components/ScheduleSection/EventDetails.tsx
+++ b/src/app/events/[slug]/components/ScheduleSection/EventDetails.tsx
@@ -10,42 +10,48 @@ import { formatTime } from '../../utils/dateUtils'
 
 import { Participants } from './Participants'
 
-export function EventDetails(event: Event) {
+export function EventDetails({
+  start,
+  end,
+  location,
+  tag,
+  title,
+  description,
+  moderators,
+  speakers,
+  url,
+}: Event) {
   return (
     <BasicCard>
       <div className="grid gap-6 lg:grid-cols-3">
         <div className="flex gap-6 text-brand-300 lg:flex-col lg:gap-1">
           <div className="text-sm font-bold">
-            <span>{formatTime(event.start)}</span>
-            {event.end && <span> – {formatTime(event.end)}</span>}
+            <span>{formatTime(start)}</span>
+            {end && <span> – {formatTime(end)}</span>}
           </div>
-          <span className="text-sm">{event.location}</span>
+          <span className="text-sm">{location}</span>
         </div>
 
         <div className="space-y-4 lg:col-span-2">
-          {event.tag && <TagLabel>{event.tag}</TagLabel>}
+          {tag && <TagLabel>{tag}</TagLabel>}
 
           <div className="space-y-2">
             <Heading tag="h3" variant="lg">
-              {event.title}
+              {title}
             </Heading>
 
-            {event.description && (
-              <p className="max-w-readable">{event.description}</p>
+            {description && <p className="max-w-readable">{description}</p>}
+
+            {moderators && (
+              <Participants title="Moderator" participants={moderators} />
             )}
 
-            {event.moderators && (
-              <Participants title="Moderator" participants={event.moderators} />
-            )}
-
-            {event.speakers && (
-              <Participants title="Speaker" participants={event.speakers} />
+            {speakers && (
+              <Participants title="Speaker" participants={speakers} />
             )}
           </div>
 
-          {event.url && (
-            <SmartTextLink href={event.url}>View Details</SmartTextLink>
-          )}
+          {url && <SmartTextLink href={url}>View Details</SmartTextLink>}
         </div>
       </div>
     </BasicCard>

--- a/src/app/events/[slug]/components/ScheduleSection/EventDetails.tsx
+++ b/src/app/events/[slug]/components/ScheduleSection/EventDetails.tsx
@@ -2,6 +2,7 @@
 
 import { BasicCard } from '@/components/BasicCard'
 import { Heading } from '@/components/Heading'
+import { TagLabel } from '@/components/TagLabel'
 import { SmartTextLink } from '@/components/TextLink/SmartTextLink'
 
 import type { Event } from '../../../schemas/ScheduleSchema'
@@ -20,11 +21,12 @@ export function EventDetails(event: Event) {
           </div>
           <span className="text-sm">{event.location}</span>
         </div>
-        <div className="lg:col-span-2">
-          <Heading tag="h3" variant="lg">
-            {event.title}
-          </Heading>
-          <div className="mt-2 space-y-2">
+        <div className="space-y-4 lg:col-span-2">
+          {event.tag && <TagLabel>{event.tag}</TagLabel>}
+          <div className="space-y-2">
+            <Heading tag="h3" variant="lg">
+              {event.title}
+            </Heading>
             {event.description && (
               <p className="max-w-readable">{event.description}</p>
             )}
@@ -36,9 +38,7 @@ export function EventDetails(event: Event) {
             )}
           </div>
           {event.url && (
-            <div className="mt-4">
-              <SmartTextLink href={event.url}>View Details</SmartTextLink>
-            </div>
+            <SmartTextLink href={event.url}>View Details</SmartTextLink>
           )}
         </div>
       </div>

--- a/src/app/events/[slug]/components/ScheduleSection/EventDetails.tsx
+++ b/src/app/events/[slug]/components/ScheduleSection/EventDetails.tsx
@@ -21,22 +21,28 @@ export function EventDetails(event: Event) {
           </div>
           <span className="text-sm">{event.location}</span>
         </div>
+
         <div className="space-y-4 lg:col-span-2">
           {event.tag && <TagLabel>{event.tag}</TagLabel>}
+
           <div className="space-y-2">
             <Heading tag="h3" variant="lg">
               {event.title}
             </Heading>
+
             {event.description && (
               <p className="max-w-readable">{event.description}</p>
             )}
+
             {event.moderators && (
               <Participants title="Moderator" participants={event.moderators} />
             )}
+
             {event.speakers && (
               <Participants title="Speaker" participants={event.speakers} />
             )}
           </div>
+
           {event.url && (
             <SmartTextLink href={event.url}>View Details</SmartTextLink>
           )}

--- a/src/app/events/[slug]/components/ScheduleSection/ScheduleSection.tsx
+++ b/src/app/events/[slug]/components/ScheduleSection/ScheduleSection.tsx
@@ -10,7 +10,7 @@ type ScheduleSectionProps = {
 
 export function ScheduleSection({ schedule }: ScheduleSectionProps) {
   return (
-    <PageSection kicker="Join Us" title={schedule.title || 'Schedule'}>
+    <PageSection kicker={schedule.kicker} title={schedule.title}>
       <Tabs schedule={schedule} />
     </PageSection>
   )

--- a/src/app/events/schemas/ScheduleSchema.ts
+++ b/src/app/events/schemas/ScheduleSchema.ts
@@ -29,7 +29,8 @@ const EventDaySchema = z
 
 export const ScheduleSchema = z
   .object({
-    title: z.string().optional(),
+    kicker: z.string().optional().default('Join Us'),
+    title: z.string().optional().default('Schedule'),
     days: z.array(EventDaySchema),
   })
   .strict()

--- a/src/app/events/schemas/ScheduleSchema.ts
+++ b/src/app/events/schemas/ScheduleSchema.ts
@@ -9,6 +9,7 @@ const ParticipantSchema = z
 
 const EventSchema = z
   .object({
+    tag: z.string().optional(),
     title: z.string(),
     description: z.string().optional(),
     moderators: z.array(ParticipantSchema).nonempty().optional(),


### PR DESCRIPTION
## 📝 Description

**Type:** New feature

This PR introduces `kicker` and `tag` field in Events page Schedule section.

![Screenshot 2024-12-18 at 11 46 45](https://github.com/user-attachments/assets/4197e30b-8ece-4588-9a34-95e34772be34)
