### PR TITLE
[UXIT-1795] - Flatten Subcategories

### DIFF
--- a/src/app/_hooks/useFilter.ts
+++ b/src/app/_hooks/useFilter.ts
@@ -5,23 +5,19 @@ import { type Object } from '@/types/utils'
 
 import { DEFAULT_FILTER_ID } from '@/constants/filterConstants'
 
-import { normalizeQueryParam } from '@/utils/queryUtils'
+type QueryValue = NextServerSearchParams[keyof NextServerSearchParams]
 
-export type UseFilterProps<Entry extends Object> = {
-  searchParams: NextServerSearchParams
+export type UseFilterProps<Entry extends Object, Query extends QueryValue> = {
   entries: Array<Entry>
-  filterKey: string
-  filterFn: (entry: Entry, query?: string) => boolean
+  filterQuery: Query
+  filterFn: (entry: Entry, filterQuery: Query) => boolean
 }
 
-export function useFilter<Entry extends Object>({
-  searchParams,
+export function useFilter<Entry extends Object, Query extends QueryValue>({
   entries,
-  filterKey,
+  filterQuery,
   filterFn,
-}: UseFilterProps<Entry>) {
-  const filterQuery = normalizeQueryParam(searchParams, filterKey)
-
+}: UseFilterProps<Entry, Query>) {
   const filterByQuery = useCallback(
     (entry: Entry) => filterFn(entry, filterQuery),
     [filterFn, filterQuery],

--- a/src/app/_utils/filterUtils.ts
+++ b/src/app/_utils/filterUtils.ts
@@ -15,7 +15,7 @@ export function entryMatchesCategoryQuery<Entry extends WithCategory>(
 
 export function entryMatchesSubcategoryQuery<Entry extends WithSubcategory>(
   entry: Entry,
-  query?: string,
+  queries?: Array<string>,
 ) {
-  return entry.subcategory === query
+  return Boolean(queries?.includes(entry.subcategory))
 }

--- a/src/app/_utils/filterUtils.ts
+++ b/src/app/_utils/filterUtils.ts
@@ -2,9 +2,20 @@ type WithCategory = {
   category: string
 }
 
+type WithSubcategory = {
+  subcategory: string
+}
+
 export function entryMatchesCategoryQuery<Entry extends WithCategory>(
   entry: Entry,
   query?: string,
 ) {
   return entry.category === query
+}
+
+export function entryMatchesSubcategoryQuery<Entry extends WithSubcategory>(
+  entry: Entry,
+  query?: string,
+) {
+  return entry.subcategory === query
 }

--- a/src/app/blog/page.tsx
+++ b/src/app/blog/page.tsx
@@ -17,6 +17,7 @@ import { extractSlugFromFilename } from '@/utils/fileUtils'
 import { entryMatchesCategoryQuery } from '@/utils/filterUtils'
 import { getFrontmatter } from '@/utils/getFrontmatter'
 import { getSortOptions } from '@/utils/getSortOptions'
+import { normalizeQueryParam } from '@/utils/queryUtils'
 
 import { FeaturedPageFrontmatterSchema } from '@/schemas/FrontmatterSchema'
 
@@ -88,9 +89,8 @@ export default function Blog({ searchParams }: Props) {
   })
 
   const { filteredEntries } = useFilter({
-    searchParams,
     entries: sortedResults,
-    filterKey: CATEGORY_KEY,
+    filterQuery: normalizeQueryParam(searchParams, CATEGORY_KEY),
     filterFn: entryMatchesCategoryQuery,
   })
 

--- a/src/app/ecosystem-explorer/[slug]/page.tsx
+++ b/src/app/ecosystem-explorer/[slug]/page.tsx
@@ -54,12 +54,12 @@ export default function EcosystemProject({ params }: EcosystemProjectProps) {
     repo,
     twitter,
     featuredContent,
-    subcategories,
+    subcategory,
   } = data
 
   const projectSubcategory = findOrThrow(
     cmsSubcategories,
-    ({ value }) => value === subcategories[0],
+    (cmsSubcategory) => cmsSubcategory.value === subcategory,
   )
 
   return (

--- a/src/app/ecosystem-explorer/hooks/useEcosystemCategory.ts
+++ b/src/app/ecosystem-explorer/hooks/useEcosystemCategory.ts
@@ -1,36 +1,18 @@
 import { useMemo } from 'react'
 
-import type { NextServerSearchParams } from '@/types/searchParams'
-
-import { CATEGORY_KEY } from '@/constants/searchParams'
-
 import type { EcosystemProject } from '../types/ecosystemProjectType'
 import { getEcosystemCMSCategories } from '../utils/getEcosystemCMSCategories'
-import { parseCategoryQueryParam } from '../utils/parseCategoryQueryParam'
 
 type UseEcosystemCategoryProps<Entry extends EcosystemProject> = {
-  searchParams: NextServerSearchParams
   categories: ReturnType<typeof getEcosystemCMSCategories>['categories']
   subcategories: ReturnType<typeof getEcosystemCMSCategories>['subcategories']
   entries: Array<Entry>
 }
 export function useEcosystemCategory<Entry extends EcosystemProject>({
-  searchParams,
   entries,
   categories,
   subcategories,
 }: UseEcosystemCategoryProps<Entry>) {
-  const categoryParams = searchParams[CATEGORY_KEY]
-  const categoryIds = parseCategoryQueryParam(categoryParams)
-
-  const filteredEntries = useMemo(() => {
-    if (!categoryIds) {
-      return entries
-    }
-
-    return entries.filter((entry) => categoryIds.includes(entry.subcategory))
-  }, [categoryIds, entries])
-
   const entriesPerSubcategory = useMemo(() => {
     const counts = new Map()
 
@@ -59,9 +41,5 @@ export function useEcosystemCategory<Entry extends EcosystemProject>({
     [categories, subcategories, entriesPerSubcategory],
   )
 
-  return {
-    filteredEntries,
-    categoryTree,
-    categoryQueries: categoryIds,
-  }
+  return { categoryTree }
 }

--- a/src/app/ecosystem-explorer/hooks/useEcosystemCategory.ts
+++ b/src/app/ecosystem-explorer/hooks/useEcosystemCategory.ts
@@ -28,16 +28,14 @@ export function useEcosystemCategory<Entry extends EcosystemProject>({
       return entries
     }
 
-    return entries.filter((entry) =>
-      categoryIds.includes(entry.subcategories[0]),
-    )
+    return entries.filter((entry) => categoryIds.includes(entry.subcategory))
   }, [categoryIds, entries])
 
   const entriesPerSubcategory = useMemo(() => {
     const counts = new Map()
 
     entries.forEach((entry) => {
-      const subcategory = entry.subcategories[0]
+      const subcategory = entry.subcategory
       counts.set(subcategory, (counts.get(subcategory) || 0) + 1)
     })
 

--- a/src/app/ecosystem-explorer/hooks/useEcosystemCategoryTree.ts
+++ b/src/app/ecosystem-explorer/hooks/useEcosystemCategoryTree.ts
@@ -8,7 +8,7 @@ type UseEcosystemCategoryProps<Entry extends EcosystemProject> = {
   subcategories: ReturnType<typeof getEcosystemCMSCategories>['subcategories']
   entries: Array<Entry>
 }
-export function useEcosystemCategory<Entry extends EcosystemProject>({
+export function useEcosystemCategoryTree<Entry extends EcosystemProject>({
   entries,
   categories,
   subcategories,
@@ -41,5 +41,5 @@ export function useEcosystemCategory<Entry extends EcosystemProject>({
     [categories, subcategories, entriesPerSubcategory],
   )
 
-  return { categoryTree }
+  return categoryTree
 }

--- a/src/app/ecosystem-explorer/hooks/useEcosystemCategoryTree.ts
+++ b/src/app/ecosystem-explorer/hooks/useEcosystemCategoryTree.ts
@@ -26,16 +26,15 @@ export function useEcosystemCategoryTree<Entry extends EcosystemProject>({
 
   const categoryTree = useMemo(
     () =>
-      categories.map((category) => ({
-        value: category.value,
-        label: category.label,
+      categories.map(({ value, label }) => ({
+        value,
+        label,
         subcategories: subcategories
-          .filter(
-            (subcategory) => subcategory.parent_category === category.value,
-          )
-          .map((subcategory) => ({
-            ...subcategory,
-            count: entriesPerSubcategory.get(subcategory.value) || 0,
+          .filter(({ parent_category }) => parent_category === value)
+          .map(({ value, label }) => ({
+            value,
+            label,
+            count: entriesPerSubcategory.get(value) || 0,
           })),
       })),
     [categories, subcategories, entriesPerSubcategory],

--- a/src/app/ecosystem-explorer/page.tsx
+++ b/src/app/ecosystem-explorer/page.tsx
@@ -5,17 +5,20 @@ import { BookOpen } from '@phosphor-icons/react/dist/ssr'
 import type { NextServerSearchParams } from '@/types/searchParams'
 
 import { PATHS } from '@/constants/paths'
+import { CATEGORY_KEY } from '@/constants/searchParams'
 
 import { graphicsData } from '@/data/graphicsData'
 
 import { buildImageSizeProp } from '@/utils/buildImageSizeProp'
 import { createMetadata } from '@/utils/createMetadata'
+import { entryMatchesSubcategoryQuery } from '@/utils/filterUtils'
 import { findOrThrow } from '@/utils/findOrThrow'
 import { getFrontmatter } from '@/utils/getFrontmatter'
 import { getSortOptions } from '@/utils/getSortOptions'
 
 import { BaseFrontmatterSchema } from '@/schemas/FrontmatterSchema'
 
+import { useFilter } from '@/hooks/useFilter'
 import { usePagination } from '@/hooks/usePagination'
 import { useSearch } from '@/hooks/useSearch'
 import { useSort } from '@/hooks/useSort'
@@ -84,8 +87,14 @@ export default function EcosystemExplorer({ searchParams }: Props) {
     defaultsTo: 'a-z',
   })
 
-  const { categoryTree, filteredEntries } = useEcosystemCategory({
+  const { filteredEntries } = useFilter({
     searchParams,
+    entries: sortedResults,
+    filterKey: CATEGORY_KEY,
+    filterFn: entryMatchesSubcategoryQuery,
+  })
+
+  const { categoryTree } = useEcosystemCategory({
     entries: sortedResults,
     categories,
     subcategories,

--- a/src/app/ecosystem-explorer/page.tsx
+++ b/src/app/ecosystem-explorer/page.tsx
@@ -39,7 +39,7 @@ import { StructuredDataScript } from '@/components/StructuredDataScript'
 import { CategoryFilters } from './components/CategoryFilters'
 import { CategoryFiltersSlider } from './components/CategoryFiltersSlider'
 import { ecosystemProjectsSortConfigs } from './constants/sortConfigs'
-import { useEcosystemCategory } from './hooks/useEcosystemCategory'
+import { useEcosystemCategoryTree } from './hooks/useEcosystemCategoryTree'
 import { generateStructuredData } from './utils/generateStructuredData'
 import { getEcosystemCMSCategories } from './utils/getEcosystemCMSCategories'
 import { getEcosystemProjectsData } from './utils/getEcosystemProjectData'
@@ -94,7 +94,7 @@ export default function EcosystemExplorer({ searchParams }: Props) {
     filterFn: entryMatchesSubcategoryQuery,
   })
 
-  const { categoryTree } = useEcosystemCategory({
+  const categoryTree = useEcosystemCategoryTree({
     entries: sortedResults,
     categories,
     subcategories,

--- a/src/app/ecosystem-explorer/page.tsx
+++ b/src/app/ecosystem-explorer/page.tsx
@@ -155,13 +155,13 @@ export default function EcosystemExplorer({ searchParams }: Props) {
                         title,
                         description,
                         image,
-                        subcategories: [categoryId],
+                        subcategory: subcategoryId,
                       } = project
 
                       const isFirstTwoImages = i < 2
                       const category = findOrThrow(
                         subcategories,
-                        ({ value }) => value === categoryId,
+                        ({ value }) => value === subcategoryId,
                       )
 
                       return (

--- a/src/app/ecosystem-explorer/page.tsx
+++ b/src/app/ecosystem-explorer/page.tsx
@@ -43,6 +43,7 @@ import { useEcosystemCategoryTree } from './hooks/useEcosystemCategoryTree'
 import { generateStructuredData } from './utils/generateStructuredData'
 import { getEcosystemCMSCategories } from './utils/getEcosystemCMSCategories'
 import { getEcosystemProjectsData } from './utils/getEcosystemProjectData'
+import { parseCategoryQueryParam } from './utils/parseCategoryQueryParam'
 
 const NoSSRPagination = dynamic(
   () => import('@/components/Pagination').then((module) => module.Pagination),
@@ -88,9 +89,8 @@ export default function EcosystemExplorer({ searchParams }: Props) {
   })
 
   const { filteredEntries } = useFilter({
-    searchParams,
     entries: sortedResults,
-    filterKey: CATEGORY_KEY,
+    filterQuery: parseCategoryQueryParam(searchParams, CATEGORY_KEY),
     filterFn: entryMatchesSubcategoryQuery,
   })
 

--- a/src/app/ecosystem-explorer/project-form/utils/buildEcosystemMarkdownTemplate.ts
+++ b/src/app/ecosystem-explorer/project-form/utils/buildEcosystemMarkdownTemplate.ts
@@ -1,6 +1,5 @@
 import type { EcosystemProject } from '@/ecosystem-explorer/types/ecosystemProjectType'
 
-type Subcategory = EcosystemProject['subcategories'][number]
 type Tech = EcosystemProject['tech'][number]
 
 export type MarkdownTemplateParams = {
@@ -9,7 +8,7 @@ export type MarkdownTemplateParams = {
   title: EcosystemProject['title']
   image: NonNullable<EcosystemProject['image']>
   category: EcosystemProject['category']
-  subcategories: Array<Subcategory>
+  subcategory: EcosystemProject['subcategory']
   tech: Array<Tech>
   description: EcosystemProject['description']
   content: NonNullable<EcosystemProject['content']>
@@ -36,7 +35,7 @@ ${renderLine('full-name', data.fullName)}
 image:
   ${renderLine('src', data.image.src)}
 ${renderLine('category', data.category)}
-${renderArray('subcategories', data.subcategories)}
+${renderLine('subcategory', data.subcategory)}
 ${renderArray('tech', data.tech)}
 ${renderLine('description', cleanDescription)}
 ${renderLine('website', data.website)}

--- a/src/app/ecosystem-explorer/project-form/utils/formatFormData.ts
+++ b/src/app/ecosystem-explorer/project-form/utils/formatFormData.ts
@@ -16,7 +16,7 @@ export function formatFormData(data: EcosystemProjectFormDataWithoutLogo) {
     email: encrypt(data.email.trim()),
     title: data.title,
     category: data.category.id,
-    subcategories: [data.subcategory.id],
+    subcategory: data.subcategory.id,
     tech: buildArrayFromTruthyKeys(data.tech),
     description: data.briefSummary,
     content: data.networkUseCase,

--- a/src/app/ecosystem-explorer/schemas/FrontMatterSchema.ts
+++ b/src/app/ecosystem-explorer/schemas/FrontMatterSchema.ts
@@ -20,8 +20,4 @@ export const EcosystemProjectFrontMatter = DynamicBaseDataSchema.extend({
   content: z.string().optional(),
   email: z.string(),
   'full-name': z.string(),
-})
-  .strict()
-  .transform(function temporaryForBackwardCompatibility(data) {
-    return { ...data, subcategories: [data.subcategory] }
-  })
+}).strict()

--- a/src/app/ecosystem-explorer/types/ecosystemCategoryType.ts
+++ b/src/app/ecosystem-explorer/types/ecosystemCategoryType.ts
@@ -1,8 +1,8 @@
-import type { useEcosystemCategory } from '../hooks/useEcosystemCategory'
+import type { useEcosystemCategoryTree } from '../hooks/useEcosystemCategoryTree'
 
 export type CategoriesAndSubcategoriesWithCount = ReturnType<
-  typeof useEcosystemCategory
->['categoryTree']
+  typeof useEcosystemCategoryTree
+>
 
 export type SubcategoriesWithCount =
   CategoriesAndSubcategoriesWithCount[number]['subcategories']

--- a/src/app/ecosystem-explorer/utils/parseCategoryQueryParam.ts
+++ b/src/app/ecosystem-explorer/utils/parseCategoryQueryParam.ts
@@ -4,13 +4,16 @@ import { CATEGORY_KEY } from '@/constants/searchParams'
 
 import { CATEGORY_QUERY_SEPARATOR_SYMBOL } from '../constants/searchParams'
 
-type CategoryParams = NextServerSearchParams[typeof CATEGORY_KEY]
+export function parseCategoryQueryParam(
+  searchParams: NextServerSearchParams,
+  key: typeof CATEGORY_KEY,
+) {
+  const categoryParams = searchParams[key]
 
-export function parseCategoryQueryParam(categoryParams: CategoryParams) {
   const categoryIds =
     typeof categoryParams === 'string'
       ? categoryParams.split(CATEGORY_QUERY_SEPARATOR_SYMBOL)
-      : null
+      : undefined
 
   return categoryIds
 }

--- a/src/app/events/page.tsx
+++ b/src/app/events/page.tsx
@@ -18,6 +18,7 @@ import { extractSlugFromFilename } from '@/utils/fileUtils'
 import { entryMatchesCategoryQuery } from '@/utils/filterUtils'
 import { getFrontmatter } from '@/utils/getFrontmatter'
 import { getSortOptions } from '@/utils/getSortOptions'
+import { normalizeQueryParam } from '@/utils/queryUtils'
 
 import { FeaturedPageFrontmatterSchema } from '@/schemas/FrontmatterSchema'
 
@@ -95,9 +96,8 @@ export default function Events({ searchParams }: Props) {
   })
 
   const { filteredEntries } = useFilter({
-    searchParams,
     entries: sortedResults,
-    filterKey: CATEGORY_KEY,
+    filterQuery: normalizeQueryParam(searchParams, CATEGORY_KEY),
     filterFn: entryMatchesCategoryQuery,
   })
 


### PR DESCRIPTION
## 📝 Description

This PR removes the temporary Zod transform function `temporaryForBackwardCompatibility` and updates the codebase to align with the new schema, where `category` is now a singular value.

## 🛠️ Key Changes

- Removed `temporaryForBackwardCompatibility`.
- Updated functions in the ecosystem-explorer project form.
- Removed filtering logic from `useEcosystemCategory`  - now `useEcosystemCategoryTree` - in favor of `useFilter`.
- Reworked `useFilter` to handle arrays of query values instead of only strings.

## 🧪 How to Test

- Verify that filtering works correctly on all pages where entries are filtered.