### PR TITLE
Fix createMetadata function

### DIFF
--- a/src/app/_schemas/FrontmatterSchema.ts
+++ b/src/app/_schemas/FrontmatterSchema.ts
@@ -4,14 +4,11 @@ import { z } from 'zod'
 
 import { isValidMarkdownPath } from '@/utils/fileUtils'
 
+import { SeoMetadataSchema } from './SeoMetadataSchema'
+
 const FrontmatterHeaderSchema = z.object({
   title: z.string(),
   description: z.string().or(z.array(z.string())),
-})
-
-const FrontmatterSeoSchema = z.object({
-  title: z.string(),
-  description: z.string(),
 })
 
 export const MarkdownPathSchema = z
@@ -25,7 +22,7 @@ export const MarkdownPathSchema = z
 
 export const BaseFrontmatterSchema = z.object({
   header: FrontmatterHeaderSchema,
-  seo: FrontmatterSeoSchema,
+  seo: SeoMetadataSchema,
 })
 
 export const FeaturedPageFrontmatterSchema = BaseFrontmatterSchema.extend({

--- a/src/app/_schemas/SeoMetadataSchema.ts
+++ b/src/app/_schemas/SeoMetadataSchema.ts
@@ -13,7 +13,6 @@ const OpenGraphMetadataSchema = z
     image: z.string().optional(),
   })
   .strict()
-  .optional()
 
 const TwitterMetadataSchema = z
   .object({
@@ -22,14 +21,15 @@ const TwitterMetadataSchema = z
     creator: z.string().optional(),
   })
   .strict()
-  .optional()
 
-const BaseSeoMetadataSchema = z.object({
-  description: z.string().max(seo_metadata_description_max_characters),
-  image: z.string().optional(),
-  'open-graph': OpenGraphMetadataSchema,
-  twitter: TwitterMetadataSchema,
-})
+const BaseSeoMetadataSchema = z
+  .object({
+    description: z.string().max(seo_metadata_description_max_characters),
+    image: z.string().optional(),
+    'open-graph': OpenGraphMetadataSchema.optional(),
+    twitter: TwitterMetadataSchema.optional(),
+  })
+  .strict()
 
 export const SeoMetadataSchema = BaseSeoMetadataSchema.extend({
   title: z.string(),

--- a/src/app/_utils/createMetadata.ts
+++ b/src/app/_utils/createMetadata.ts
@@ -48,14 +48,10 @@ export function createMetadata({
     description: parsedEnrichedSEO.description,
     openGraph: {
       title: parsedEnrichedSEO['open-graph']?.title,
-      description: parsedEnrichedSEO.description,
+      description: parsedEnrichedSEO['open-graph']?.description,
       images: parsedEnrichedSEO['open-graph']?.image,
     },
-    twitter: {
-      card: parsedEnrichedSEO.twitter?.card,
-      site: parsedEnrichedSEO.twitter?.site,
-      creator: parsedEnrichedSEO.twitter?.creator,
-    },
+    twitter: { ...parsedEnrichedSEO.twitter },
     alternates: {
       canonical: path,
     },


### PR DESCRIPTION
## 📝 Description

This PR fixes and enhances the SeoMetadataSchema and related schemas for stricter typing and improved alignment of optional properties. 

![CleanShot 2024-12-27 at 15 24 46@2x](https://github.com/user-attachments/assets/7179f78d-6e5c-4e92-8da0-7d87526427ba)

- **Type:** Bug Fix

## 🛠️ Key Changes

- **Refactored `SeoMetadataSchema` and related schemas:**
  - Removed `.optional()` calls on `OpenGraphMetadataSchema` and `TwitterMetadataSchema` definitions and moved the optionality to `BaseSeoMetadataSchema`.
  - Applied `.strict()` at the schema level for all objects to enforce strict validation.
- Updated `BaseSeoMetadataSchema` to mark open-graph and twitter properties as optional, reflecting their usage accurately.
- Improved code clarity by aligning optional properties with intended use at the correct schema level.

## 🧪 How to Test

- **Setup:**
  - Ensure the application is configured to use the updated schema definitions.
  - Load a set of test data containing valid and invalid SEO metadata.

- **Steps to Test:**
  1. Verify that valid metadata passes validation using the updated schemas.
  2. Check that metadata with invalid or missing properties is correctly rejected.
  3. Test scenarios where optional properties are omitted to confirm correct behavior.

- **Expected Results:**
  - Valid SEO metadata should pass validation without errors.
  - Invalid or incomplete metadata should produce meaningful validation errors.
  - Optional properties should work seamlessly when omitted.
  
## 📝 NOTE:

We should work on fixing the problem of Page Attributes never being parsed

- When using `createMetadata` with raw attributes like this:

```typescript
export const metadata = createMetadata({
  seo: attributes.seo,
  path: PATHS.TERMS_OF_USE.path,
});
```
  
the `attributes.seo` object is passed as-is, and no transformations or validations are applied. This means essential metadata transformations like setting default values or replacing empty strings with defaults don’t occur.

This is one of the reasons why we must handle default values and transformations for SEO metadata in `createMetadata` for now.

The other one being that nested values (e.g., `open-graph.title`) often rely on other metadata values like `seo.title`, which are accessible in `createMetadata` but not within schema definitions.