### PR TITLE
[UXIT-1963] Events Page · Fix CMS Region Field [skip percy]

### DIFF
--- a/apps/site/public/admin/config.yml
+++ b/apps/site/public/admin/config.yml
@@ -656,6 +656,7 @@ collections:
           - name: "region"
             label: "Region"
             widget: "select"
+            required: false
             options:
               - label: "Africa"
                 value: "africa"

--- a/apps/site/public/admin/config.yml
+++ b/apps/site/public/admin/config.yml
@@ -712,7 +712,6 @@ collections:
           - name: "events"
             label: "Events"
             widget: "list"
-            required: true
             fields:
               - name: "title"
                 label: "Title"

--- a/apps/site/src/app/_utils/filterUtils.ts
+++ b/apps/site/src/app/_utils/filterUtils.ts
@@ -1,14 +1,12 @@
 import { VIRTUAL_EVENT_FILTER_OPTION } from '@/events/constants/constants'
+import type { Location } from '@/events/schemas/LocationSchema'
 
 type WithCategory = {
   category: string
 }
 
 type WithLocation = {
-  location: {
-    primary: string
-    region?: string | null
-  }
+  location: Location
 }
 
 export function entryMatchesCategoryQuery<Entry extends WithCategory>(

--- a/apps/site/src/app/_utils/filterUtils.ts
+++ b/apps/site/src/app/_utils/filterUtils.ts
@@ -7,7 +7,7 @@ type WithCategory = {
 type WithLocation = {
   location: {
     primary: string
-    region?: string
+    region?: string | null
   }
 }
 

--- a/apps/site/src/app/ecosystem-explorer/project-form/constants/projectFormDescription.tsx
+++ b/apps/site/src/app/ecosystem-explorer/project-form/constants/projectFormDescription.tsx
@@ -6,9 +6,9 @@ import { ExternalTextLink } from '@/components/TextLink/ExternalTextLink'
 
 export const PROJECT_FORM_DESCRIPTION = [
   <>
-    Let's get started with some basic information about what you're building.
-    Please submit your project to the Filecoin ecosystem page below. To update
-    an existing project, send an email to{' '}
+    Let&apos;s get started with some basic information about what you&apos;re
+    building. Please submit your project to the Filecoin ecosystem page below.
+    To update an existing project, send an email to{' '}
     <ExternalTextLink href={FILECOIN_FOUNDATION_URLS.ecosystem.email.href}>
       {extractEmailAddress(FILECOIN_FOUNDATION_URLS.ecosystem.email.href)}
     </ExternalTextLink>

--- a/apps/site/src/app/events/[slug]/utils/generateStructuredData.ts
+++ b/apps/site/src/app/events/[slug]/utils/generateStructuredData.ts
@@ -83,7 +83,7 @@ function getLocation({
         '@type': 'PostalAddress',
         addressLocality: city,
         addressCountry: country,
-        addressRegion: location.region,
+        addressRegion: location.region || undefined,
       },
     }
   }

--- a/apps/site/src/app/events/schemas/LocationSchema.ts
+++ b/apps/site/src/app/events/schemas/LocationSchema.ts
@@ -35,7 +35,7 @@ function isVirtual(location: Location) {
 }
 
 function hasRegion(location: Location) {
-  return location.region !== undefined && location.region !== null
+  return Boolean(location.region)
 }
 
 function virtualEventHasNoRegion(location: Location) {

--- a/apps/site/src/app/events/schemas/LocationSchema.ts
+++ b/apps/site/src/app/events/schemas/LocationSchema.ts
@@ -3,7 +3,7 @@ import { z } from 'zod'
 import { getCMSFieldOptionsAndValidIds } from '@/utils/getCMSFieldOptionsAndValidIds'
 import { createEnumSchema } from '@/utils/zodUtils'
 
-type Location = {
+export type Location = {
   primary: string
   region?: string | null
 }

--- a/apps/site/src/app/events/schemas/LocationSchema.ts
+++ b/apps/site/src/app/events/schemas/LocationSchema.ts
@@ -5,7 +5,7 @@ import { createEnumSchema } from '@/utils/zodUtils'
 
 type Location = {
   primary: string
-  region?: string
+  region?: string | null
 }
 
 const { validIds: validRegionIds } = getCMSFieldOptionsAndValidIds({
@@ -18,7 +18,7 @@ const RegionSchema = createEnumSchema(validRegionIds)
 export const LocationSchema = z
   .object({
     primary: z.string(),
-    region: RegionSchema.optional(),
+    region: RegionSchema.nullable().optional(),
   })
   .strict()
   .refine(virtualEventHasNoRegion, {
@@ -30,22 +30,22 @@ export const LocationSchema = z
     path: ['region'],
   })
 
-function isVirtual(location: Location): boolean {
+function isVirtual(location: Location) {
   return location.primary === 'Virtual'
 }
 
-function hasRegion(location: Location): boolean {
-  return location.region !== undefined
+function hasRegion(location: Location) {
+  return location.region !== undefined && location.region !== null
 }
 
-function virtualEventHasNoRegion(location: Location): boolean {
+function virtualEventHasNoRegion(location: Location) {
   if (isVirtual(location)) {
     return !hasRegion(location)
   }
   return true
 }
 
-function inPersonEventHasRegion(location: Location): boolean {
+function inPersonEventHasRegion(location: Location) {
   if (!isVirtual(location)) {
     return hasRegion(location)
   }

--- a/apps/site/src/app/events/schemas/LocationSchema.ts
+++ b/apps/site/src/app/events/schemas/LocationSchema.ts
@@ -18,7 +18,7 @@ const RegionSchema = createEnumSchema(validRegionIds)
 export const LocationSchema = z
   .object({
     primary: z.string(),
-    region: RegionSchema.nullable().optional(),
+    region: RegionSchema.nullish(),
   })
   .strict()
   .refine(virtualEventHasNoRegion, {


### PR DESCRIPTION
## 📝 Description

Region should be optional so that we can also handle Virtual events per hint: `"Select the region where the in-person event takes place. Leave empty for virtual events."`

- **Type:** Bug fix 

## 📸 Screenshots

BUG

![CleanShot 2025-01-06 at 12 38 43@2x](https://github.com/user-attachments/assets/cdfb3228-c1a0-4013-9290-3a51b9b2b261)
