### PR TITLE
[UXIT-1966] - Remove push trigger from site link checker workflow

### DIFF
--- a/.github/workflows/site-link-checker.yml
+++ b/.github/workflows/site-link-checker.yml
@@ -1,10 +1,6 @@
 name: Site Link Checker
 
 on:
-  push:
-    branches: "cms/**"
-    paths:
-      - "apps/site/**"
   schedule:
     - cron: "0 2 * * 0"
   workflow_dispatch:


### PR DESCRIPTION
## 📝 Description

This PR ensures that the link checker runs only on a schedule and not on push so that it doesn't block content PRs: https://github.com/FilecoinFoundationWeb/filecoin-foundation/actions/runs/12693025987/job/35379696722?pr=998

It seems to be broken currently, all relative URLs raise an error.