### PR TITLE
[UXIT-1984] - Update event default sorting to upcoming events

### DIFF
--- a/apps/site/src/app/events/components/EventsContent.tsx
+++ b/apps/site/src/app/events/components/EventsContent.tsx
@@ -55,7 +55,7 @@ export default function EventsContent({ searchParams }: EventsContentProps) {
     searchParams,
     entries: searchResults,
     configs: eventsSortConfigs,
-    defaultsTo: 'all-events',
+    defaultsTo: 'upcoming-events',
   })
 
   const { filteredEntries: filteredEventsByLocation } = useFilter({

--- a/apps/site/src/app/events/constants/sortConfigs.ts
+++ b/apps/site/src/app/events/constants/sortConfigs.ts
@@ -6,14 +6,14 @@ import {
 
 export const eventsSortConfigs = [
   {
-    key: 'all-events',
-    label: 'All Events',
-    sortFn: sortEventsDesc,
-  },
-  {
     key: 'upcoming-events',
     label: 'Upcoming Events',
     sortFn: getUpcomingEvents,
+  },
+  {
+    key: 'all-events',
+    label: 'All Events',
+    sortFn: sortEventsDesc,
   },
   {
     key: 'past-events',


### PR DESCRIPTION
## 📝 Description

This PR updates the default filtering on the events, from showing all events to upcoming events, as requested by the events team.

[Slack convo](https://filecoinfoundation.slack.com/archives/C06MTEQ3SP6/p1736785573428099)