### PR TITLE
[UXIT-2004] - Update @types/react and @types/react-dom to latest versions in package-lock.json

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -75,8 +75,8 @@
         "@types/node": "^22.10.2",
         "@types/pluralize": "^0.0.33",
         "@types/ramda": "^0.30.2",
-        "@types/react": "19.0.3",
-        "@types/react-dom": "19.0.2",
+        "@types/react": "19.0.6",
+        "@types/react-dom": "19.0.3",
         "@typescript-eslint/eslint-plugin": "^8.19.1",
         "cypress": "^13.17.0",
         "eslint": "^9",
@@ -7437,19 +7437,18 @@
       }
     },
     "node_modules/@types/react": {
-      "version": "19.0.3",
-      "resolved": "https://registry.npmjs.org/@types/react/-/react-19.0.3.tgz",
-      "integrity": "sha512-UavfHguIjnnuq9O67uXfgy/h3SRJbidAYvNjLceB+2RIKVRBzVsh0QO+Pw6BCSQqFS9xwzKfwstXx0m6AbAREA==",
+      "version": "19.0.6",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-19.0.6.tgz",
+      "integrity": "sha512-gIlMztcTeDgXCUj0vCBOqEuSEhX//63fW9SZtCJ+agxoQTOklwDfiEMlTWn4mR/C/UK5VHlpwsCsOyf7/hc4lw==",
       "dependencies": {
         "csstype": "^3.0.2"
       }
     },
     "node_modules/@types/react-dom": {
-      "version": "19.0.2",
-      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-19.0.2.tgz",
-      "integrity": "sha512-c1s+7TKFaDRRxr1TxccIX2u7sfCnc3RxkVyBIUA2lCpyqCF+QoAwQ/CBg7bsMdVwP120HEH143VQezKtef5nCg==",
+      "version": "19.0.3",
+      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-19.0.3.tgz",
+      "integrity": "sha512-0Knk+HJiMP/qOZgMyNFamlIjw9OFCsyC2ZbigmEEyXXixgre6IQpm/4V+r3qH4GC1JPvRJKInw+on2rV6YZLeA==",
       "devOptional": true,
-      "license": "MIT",
       "peerDependencies": {
         "@types/react": "^19.0.0"
       }


### PR DESCRIPTION
This PR updates `package-lock.json` after dependabot PR merge: https://github.com/FilecoinFoundationWeb/filecoin-foundation/pull/1005

Dependabot only updated the `package.json` in `apps/site`, but not the `package-lock.json` at the root of the monorepo.