### PR TITLE
Make useSearch isomorphic

### DIFF
--- a/apps/site/src/app/_hooks/useSearch.ts
+++ b/apps/site/src/app/_hooks/useSearch.ts
@@ -2,15 +2,10 @@ import { useMemo } from 'react'
 
 import slugify from 'slugify'
 
-import type { NextServerSearchParams } from '@/types/searchParams'
 import type { Object } from '@/types/utils'
 
-import { SEARCH_KEY } from '@/constants/searchParams'
-
-import { normalizeQueryParam } from '@/utils/queryUtils'
-
 type UseSearchProps<Entry extends Object> = {
-  searchParams: NextServerSearchParams
+  searchQuery: string | undefined
   entries: Array<Entry>
   searchBy: keyof Entry | Array<keyof Entry>
 }
@@ -38,25 +33,21 @@ function matchesQuery<Entry extends Object>(
 }
 
 export function useSearch<Entry extends Object>({
-  searchParams,
+  searchQuery,
   entries,
   searchBy,
 }: UseSearchProps<Entry>) {
-  const normalizedQuery = normalizeQueryParam(searchParams, SEARCH_KEY)
-
   const searchResults = useMemo(() => {
-    if (!normalizedQuery) {
+    if (!searchQuery) {
       return entries
     }
 
     const searchByKeys = Array.isArray(searchBy) ? searchBy : [searchBy]
 
     return entries.filter((entry) => {
-      return searchByKeys.some((key) =>
-        matchesQuery(entry[key], normalizedQuery),
-      )
+      return searchByKeys.some((key) => matchesQuery(entry[key], searchQuery))
     })
-  }, [entries, normalizedQuery, searchBy])
+  }, [entries, searchQuery, searchBy])
 
-  return { searchQuery: normalizedQuery, searchResults }
+  return { searchQuery, searchResults }
 }

--- a/apps/site/src/app/_hooks/useSearch.ts
+++ b/apps/site/src/app/_hooks/useSearch.ts
@@ -10,28 +10,6 @@ type UseSearchProps<Entry extends Object> = {
   searchBy: keyof Entry | Array<keyof Entry>
 }
 
-function normalizeString(str: string) {
-  return slugify(str, {
-    strict: true,
-    trim: true,
-    lower: true,
-  })
-}
-
-function matchesQuery<Entry extends Object>(
-  value: Entry[keyof Entry],
-  query: string,
-): boolean {
-  if (typeof value !== 'string' && typeof value !== 'number') {
-    return false
-  }
-
-  const normalizedValue = normalizeString(String(value))
-  const normalizedQuery = normalizeString(query)
-
-  return normalizedValue.includes(normalizedQuery)
-}
-
 export function useSearch<Entry extends Object>({
   searchQuery,
   entries,
@@ -50,4 +28,26 @@ export function useSearch<Entry extends Object>({
   }, [entries, searchQuery, searchBy])
 
   return { searchQuery, searchResults }
+}
+
+function matchesQuery<Entry extends Object>(
+  value: Entry[keyof Entry],
+  query: string,
+) {
+  if (typeof value !== 'string' && typeof value !== 'number') {
+    return false
+  }
+
+  const normalizedValue = normalizeString(String(value))
+  const normalizedQuery = normalizeString(query)
+
+  return normalizedValue.includes(normalizedQuery)
+}
+
+function normalizeString(str: string) {
+  return slugify(str, {
+    strict: true,
+    trim: true,
+    lower: true,
+  })
 }

--- a/apps/site/src/app/blog/components/BlogContent.tsx
+++ b/apps/site/src/app/blog/components/BlogContent.tsx
@@ -4,7 +4,7 @@ import type { NextServerSearchParams } from '@/types/searchParams'
 
 import { DEFAULT_CATEGORY_FILTER_OPTION } from '@/constants/filterConstants'
 import { PATHS } from '@/constants/paths'
-import { CATEGORY_KEY, PAGE_KEY } from '@/constants/searchParams'
+import { CATEGORY_KEY, PAGE_KEY, SEARCH_KEY } from '@/constants/searchParams'
 
 import { graphicsData } from '@/data/graphicsData'
 
@@ -45,7 +45,7 @@ export function BlogContent({
   sortOptions,
 }: BlogContentProps) {
   const { searchQuery, searchResults } = useSearch({
-    searchParams,
+    searchQuery: normalizeQueryParam(searchParams, SEARCH_KEY),
     entries: posts,
     searchBy: ['title', 'description'],
   })

--- a/apps/site/src/app/ecosystem-explorer/components/EcosystemExplorerContent.tsx
+++ b/apps/site/src/app/ecosystem-explorer/components/EcosystemExplorerContent.tsx
@@ -3,7 +3,7 @@ import { BookOpen } from '@phosphor-icons/react/dist/ssr'
 import type { NextServerSearchParams } from '@/types/searchParams'
 
 import { PATHS } from '@/constants/paths'
-import { CATEGORY_KEY, PAGE_KEY } from '@/constants/searchParams'
+import { CATEGORY_KEY, PAGE_KEY, SEARCH_KEY } from '@/constants/searchParams'
 
 import { graphicsData } from '@/data/graphicsData'
 
@@ -47,7 +47,7 @@ export function EcosystemExplorerContent({
   searchParams,
 }: EcosystemExplorerContentProps) {
   const { searchQuery, searchResults } = useSearch({
-    searchParams,
+    searchQuery: normalizeQueryParam(searchParams, SEARCH_KEY),
     entries: ecosystemProjects,
     searchBy: ['title', 'description'],
   })

--- a/apps/site/src/app/events/components/EventsContent.tsx
+++ b/apps/site/src/app/events/components/EventsContent.tsx
@@ -3,7 +3,12 @@ import { MagnifyingGlass } from '@phosphor-icons/react/dist/ssr'
 import type { NextServerSearchParams } from '@/types/searchParams'
 
 import { PATHS } from '@/constants/paths'
-import { CATEGORY_KEY, LOCATION_KEY, PAGE_KEY } from '@/constants/searchParams'
+import {
+  CATEGORY_KEY,
+  LOCATION_KEY,
+  PAGE_KEY,
+  SEARCH_KEY,
+} from '@/constants/searchParams'
 
 import { graphicsData } from '@/data/graphicsData'
 
@@ -46,7 +51,7 @@ const locationOptions = getLocationListboxOptions()
 
 export default function EventsContent({ searchParams }: EventsContentProps) {
   const { searchQuery, searchResults } = useSearch({
-    searchParams,
+    searchQuery: normalizeQueryParam(searchParams, SEARCH_KEY),
     entries: events,
     searchBy: ['title', 'location'],
   })

--- a/apps/site/src/app/orbit/components/EventsSection.tsx
+++ b/apps/site/src/app/orbit/components/EventsSection.tsx
@@ -3,7 +3,7 @@ import { ZodError } from 'zod'
 
 import type { NextServerSearchParams } from '@/types/searchParams'
 
-import { PAGE_KEY } from '@/constants/searchParams'
+import { PAGE_KEY, SEARCH_KEY } from '@/constants/searchParams'
 import { FILECOIN_FOUNDATION_URLS } from '@/constants/siteMetadata'
 
 import { formatDate } from '@/utils/dateUtils'
@@ -64,7 +64,7 @@ type OrbitEventsProps = {
 
 function OrbitEvents({ events, searchParams }: OrbitEventsProps) {
   const { searchQuery, searchResults } = useSearch({
-    searchParams,
+    searchQuery: normalizeQueryParam(searchParams, SEARCH_KEY),
     entries: events,
     searchBy: ['title', 'city'],
   })


### PR DESCRIPTION
> [!NOTE]
> This is PR 2/3 to make our hooks isomorphic, meaning they don't contain any server or client-specific code and can run in both environments. More information on the motivation is in the [Notion ticket](https://www.notion.so/filecoin/FF-Make-hooks-isomorphic-1827631f2825809083eee8c67df2660f?pvs=4). 

## 📝 Description

This PR is about making `useSearch` isomorphic.

## 🛠️ Key Changes

- Remove `NextServerSearchParams` from `useSearch` props and use `searchQuery` instead
- Implement changes on all pages
- Clean the hook

## 🧪 How to Test

Make sure the search works the same as on fil.org
