### PR TITLE
Make useSort isomorphic

### DIFF
--- a/apps/site/src/app/_hooks/useSort.ts
+++ b/apps/site/src/app/_hooks/useSort.ts
@@ -1,18 +1,13 @@
 import { useMemo } from 'react'
 
-import type { NextServerSearchParams } from '@/types/searchParams'
 import type { SortConfig } from '@/types/sortTypes'
 import type { NonEmptyReadonlyArray, Object } from '@/types/utils'
-
-import { SORT_KEY } from '@/constants/searchParams'
-
-import { normalizeQueryParam } from '@/utils/queryUtils'
 
 type UseSortProps<
   Entry extends Object,
   Configs extends NonEmptyReadonlyArray<SortConfig<Entry>>,
 > = {
-  searchParams: NextServerSearchParams
+  sortQuery: string | undefined
   entries: Array<Entry>
   configs: Configs
   defaultsTo: Configs[number]['key']
@@ -21,22 +16,16 @@ type UseSortProps<
 export function useSort<
   Entry extends Object,
   Configs extends NonEmptyReadonlyArray<SortConfig<Entry>>,
->({
-  searchParams,
-  entries,
-  configs,
-  defaultsTo,
-}: UseSortProps<Entry, Configs>) {
-  const queryParamValue = normalizeQueryParam(searchParams, SORT_KEY)
+>({ sortQuery, entries, configs, defaultsTo }: UseSortProps<Entry, Configs>) {
   const defaultConfig =
     configs.find((config) => config.key === defaultsTo) || configs[0]
 
   const validSortKey = useMemo(() => {
     const validSortKeys = configs.map((config) => config.key)
-    const sortKey = validSortKeys.find((key) => key === queryParamValue)
+    const sortKey = validSortKeys.find((key) => key === sortQuery)
 
     return sortKey || defaultConfig.key
-  }, [configs, defaultConfig.key, queryParamValue])
+  }, [configs, defaultConfig.key, sortQuery])
 
   const sortedResults = useMemo(() => {
     const config = configs.find((config) => config.key === validSortKey)

--- a/apps/site/src/app/_hooks/useSort.ts
+++ b/apps/site/src/app/_hooks/useSort.ts
@@ -10,16 +10,18 @@ type UseSortProps<
   sortQuery: string | undefined
   entries: Array<Entry>
   configs: Configs
-  defaultQuery: Configs[number]['key']
+  defaultConfig?: Configs[number]
 }
 
 export function useSort<
   Entry extends Object,
   Configs extends NonEmptyReadonlyArray<SortConfig<Entry>>,
->({ sortQuery, entries, configs, defaultQuery }: UseSortProps<Entry, Configs>) {
-  const defaultConfig =
-    configs.find((config) => config.key === defaultQuery) || configs[0]
-
+>({
+  sortQuery,
+  entries,
+  configs,
+  defaultConfig = configs[0],
+}: UseSortProps<Entry, Configs>) {
   const validSortKey = useMemo(() => {
     const validSortKeys = configs.map((config) => config.key)
     const sortKey = validSortKeys.find((key) => key === sortQuery)

--- a/apps/site/src/app/_hooks/useSort.ts
+++ b/apps/site/src/app/_hooks/useSort.ts
@@ -10,15 +10,15 @@ type UseSortProps<
   sortQuery: string | undefined
   entries: Array<Entry>
   configs: Configs
-  defaultsTo: Configs[number]['key']
+  defaultQuery: Configs[number]['key']
 }
 
 export function useSort<
   Entry extends Object,
   Configs extends NonEmptyReadonlyArray<SortConfig<Entry>>,
->({ sortQuery, entries, configs, defaultsTo }: UseSortProps<Entry, Configs>) {
+>({ sortQuery, entries, configs, defaultQuery }: UseSortProps<Entry, Configs>) {
   const defaultConfig =
-    configs.find((config) => config.key === defaultsTo) || configs[0]
+    configs.find((config) => config.key === defaultQuery) || configs[0]
 
   const validSortKey = useMemo(() => {
     const validSortKeys = configs.map((config) => config.key)

--- a/apps/site/src/app/blog/components/BlogContent.tsx
+++ b/apps/site/src/app/blog/components/BlogContent.tsx
@@ -59,7 +59,6 @@ export function BlogContent({
     sortQuery: normalizeQueryParam(searchParams, SORT_KEY),
     entries: searchResults,
     configs: blogSortConfigs,
-    defaultQuery: 'newest',
   })
 
   const { filteredEntries } = useFilter({

--- a/apps/site/src/app/blog/components/BlogContent.tsx
+++ b/apps/site/src/app/blog/components/BlogContent.tsx
@@ -4,7 +4,12 @@ import type { NextServerSearchParams } from '@/types/searchParams'
 
 import { DEFAULT_CATEGORY_FILTER_OPTION } from '@/constants/filterConstants'
 import { PATHS } from '@/constants/paths'
-import { CATEGORY_KEY, PAGE_KEY, SEARCH_KEY } from '@/constants/searchParams'
+import {
+  CATEGORY_KEY,
+  PAGE_KEY,
+  SEARCH_KEY,
+  SORT_KEY,
+} from '@/constants/searchParams'
 
 import { graphicsData } from '@/data/graphicsData'
 
@@ -51,7 +56,7 @@ export function BlogContent({
   })
 
   const { sortQuery, sortedResults, defaultSortQuery } = useSort({
-    searchParams,
+    sortQuery: normalizeQueryParam(searchParams, SORT_KEY),
     entries: searchResults,
     configs: blogSortConfigs,
     defaultsTo: 'newest',

--- a/apps/site/src/app/blog/components/BlogContent.tsx
+++ b/apps/site/src/app/blog/components/BlogContent.tsx
@@ -59,7 +59,7 @@ export function BlogContent({
     sortQuery: normalizeQueryParam(searchParams, SORT_KEY),
     entries: searchResults,
     configs: blogSortConfigs,
-    defaultsTo: 'newest',
+    defaultQuery: 'newest',
   })
 
   const { filteredEntries } = useFilter({

--- a/apps/site/src/app/ecosystem-explorer/components/EcosystemExplorerContent.tsx
+++ b/apps/site/src/app/ecosystem-explorer/components/EcosystemExplorerContent.tsx
@@ -61,7 +61,6 @@ export function EcosystemExplorerContent({
     sortQuery: normalizeQueryParam(searchParams, SORT_KEY),
     entries: searchResults,
     configs: ecosystemProjectsSortConfigs,
-    defaultQuery: 'a-z',
   })
 
   const { filteredEntries } = useFilter({

--- a/apps/site/src/app/ecosystem-explorer/components/EcosystemExplorerContent.tsx
+++ b/apps/site/src/app/ecosystem-explorer/components/EcosystemExplorerContent.tsx
@@ -3,7 +3,12 @@ import { BookOpen } from '@phosphor-icons/react/dist/ssr'
 import type { NextServerSearchParams } from '@/types/searchParams'
 
 import { PATHS } from '@/constants/paths'
-import { CATEGORY_KEY, PAGE_KEY, SEARCH_KEY } from '@/constants/searchParams'
+import {
+  CATEGORY_KEY,
+  PAGE_KEY,
+  SEARCH_KEY,
+  SORT_KEY,
+} from '@/constants/searchParams'
 
 import { graphicsData } from '@/data/graphicsData'
 
@@ -53,7 +58,7 @@ export function EcosystemExplorerContent({
   })
 
   const { sortQuery, sortedResults, defaultSortQuery } = useSort({
-    searchParams,
+    sortQuery: normalizeQueryParam(searchParams, SORT_KEY),
     entries: searchResults,
     configs: ecosystemProjectsSortConfigs,
     defaultsTo: 'a-z',

--- a/apps/site/src/app/ecosystem-explorer/components/EcosystemExplorerContent.tsx
+++ b/apps/site/src/app/ecosystem-explorer/components/EcosystemExplorerContent.tsx
@@ -61,7 +61,7 @@ export function EcosystemExplorerContent({
     sortQuery: normalizeQueryParam(searchParams, SORT_KEY),
     entries: searchResults,
     configs: ecosystemProjectsSortConfigs,
-    defaultsTo: 'a-z',
+    defaultQuery: 'a-z',
   })
 
   const { filteredEntries } = useFilter({

--- a/apps/site/src/app/events/components/EventsContent.tsx
+++ b/apps/site/src/app/events/components/EventsContent.tsx
@@ -61,7 +61,7 @@ export default function EventsContent({ searchParams }: EventsContentProps) {
     sortQuery: normalizeQueryParam(searchParams, SORT_KEY),
     entries: searchResults,
     configs: eventsSortConfigs,
-    defaultsTo: 'upcoming-events',
+    defaultQuery: 'upcoming-events',
   })
 
   const { filteredEntries: filteredEventsByLocation } = useFilter({

--- a/apps/site/src/app/events/components/EventsContent.tsx
+++ b/apps/site/src/app/events/components/EventsContent.tsx
@@ -61,7 +61,6 @@ export default function EventsContent({ searchParams }: EventsContentProps) {
     sortQuery: normalizeQueryParam(searchParams, SORT_KEY),
     entries: searchResults,
     configs: eventsSortConfigs,
-    defaultQuery: 'upcoming-events',
   })
 
   const { filteredEntries: filteredEventsByLocation } = useFilter({

--- a/apps/site/src/app/events/components/EventsContent.tsx
+++ b/apps/site/src/app/events/components/EventsContent.tsx
@@ -8,6 +8,7 @@ import {
   LOCATION_KEY,
   PAGE_KEY,
   SEARCH_KEY,
+  SORT_KEY,
 } from '@/constants/searchParams'
 
 import { graphicsData } from '@/data/graphicsData'
@@ -57,7 +58,7 @@ export default function EventsContent({ searchParams }: EventsContentProps) {
   })
 
   const { sortedResults } = useSort({
-    searchParams,
+    sortQuery: normalizeQueryParam(searchParams, SORT_KEY),
     entries: searchResults,
     configs: eventsSortConfigs,
     defaultsTo: 'upcoming-events',


### PR DESCRIPTION
> [!NOTE]
> This is PR 3/3 to make our hooks isomorphic, meaning they don't contain any server or client-specific code and can run in both environments. More information on the motivation is in the [Notion ticket](https://www.notion.so/filecoin/FF-Make-hooks-isomorphic-1827631f2825809083eee8c67df2660f?pvs=4). 

## 📝 Description

This PR is about making `useSort` isomorphic, as well as removing the explicit `defaultsTo` prop in favour of using the first item in the array of sort configuration

## 🛠️ Key Changes

- Remove `NextServerSearchParams` from `useSort` props and use `sortQuery` instead
- Implement changes on all pages
- Use the first sort configuration item as the default sort, instead of explicitly using a sort key. The first item is usually the default, so this duplication is unnecessary.

## 🧪 How to Test

Make sure the sort works the same as on fil.org
