### PR TITLE
Add unstable_cache to getBlogPostsData [skip percy]

### DIFF
--- a/apps/site/src/app/blog/utils/getBlogPostData.ts
+++ b/apps/site/src/app/blog/utils/getBlogPostData.ts
@@ -1,3 +1,5 @@
+import { unstable_cache } from 'next/cache'
+
 import { PATHS } from '@/constants/paths'
 
 import { getMarkdownData } from '@/utils/getMarkdownData'
@@ -13,14 +15,18 @@ export function getBlogPostData(slug: string) {
   return transformBlogPostData(data)
 }
 
-export async function getBlogPostsData() {
-  const allPosts = await getAllMarkdownDataAsync({
-    directoryPath: BLOG_DIRECTORY_PATH,
-    zodSchema: BlogPostFrontmatterSchema,
-  })
+export const getBlogPostsData = unstable_cache(
+  async () => {
+    const allPosts = await getAllMarkdownDataAsync({
+      directoryPath: BLOG_DIRECTORY_PATH,
+      zodSchema: BlogPostFrontmatterSchema,
+    })
 
-  return allPosts.map(transformBlogPostData)
-}
+    return allPosts.map(transformBlogPostData)
+  },
+  ['blog-posts'],
+  { revalidate: false },
+)
 
 function getBlogPostMarkdownData(slug: string) {
   return getMarkdownData({


### PR DESCRIPTION
## 📝 Description

This PR implements Next's `unstable_cache` on `getBlogPostsData` to test whether it improves performance on the blog page.

https://nextjs.org/docs/app/api-reference/functions/unstable_cache