### PR TITLE
Remove force-static from Blog page [skip percy]

### DIFF
--- a/apps/site/src/app/blog/page.tsx
+++ b/apps/site/src/app/blog/page.tsx
@@ -1,3 +1,5 @@
+import { Suspense } from 'react'
+
 import { PATHS } from '@/constants/paths'
 
 import { graphicsData } from '@/data/graphicsData'
@@ -63,7 +65,9 @@ export default async function Blog() {
         title="Filecoin Ecosystem Updates"
         description="Read the latest updates and announcements from the Filecoin ecosystem and Filecoin Foundation."
       >
-        <BlogContent posts={posts} />
+        <Suspense>
+          <BlogContent posts={posts} />
+        </Suspense>
       </PageSection>
     </PageLayout>
   )

--- a/apps/site/src/app/blog/page.tsx
+++ b/apps/site/src/app/blog/page.tsx
@@ -17,8 +17,6 @@ import { generateStructuredData } from './utils/generateStructuredData'
 import { getBlogPostsData } from './utils/getBlogPostData'
 import { getMetaData } from './utils/getMetaData'
 
-export const dynamic = 'force-static'
-
 export async function generateMetadata() {
   const { seo } = await getFrontmatterAsync({
     path: PATHS.BLOG,

--- a/apps/site/src/app/layout.tsx
+++ b/apps/site/src/app/layout.tsx
@@ -9,8 +9,6 @@ import { BASE_URL, ORGANIZATION_NAME } from '@/constants/siteMetadata'
 
 import { SiteLayout } from '@/components/SiteLayout'
 
-export const revalidate = 86400
-
 export const metadata: Metadata = {
   title: {
     template: `%s | ${ORGANIZATION_NAME}`,


### PR DESCRIPTION
## 📝 Description

This PR removes the `export const dynamic` and `export const revalidate` directives.

From Next's documentation
> The new model in the app directory favors granular caching control at the fetch request level over the binary all-or-nothing model of getServerSideProps and getStaticProps at the page-level in the pages directory. The dynamic option is a way to opt back in to the previous model as a convenience and provides a simpler migration path.

## 🔖 Resources

- https://nextjs.org/docs/app/api-reference/file-conventions/route-segment-config#dynamic
- https://nextjs.org/docs/app/api-reference/file-conventions/route-segment-config#revalidate
