### PR TITLE
Add generateStaticParams to slug pages

### DIFF
--- a/apps/site/src/app/_types/paramsTypes.ts
+++ b/apps/site/src/app/_types/paramsTypes.ts
@@ -1,0 +1,3 @@
+export type SlugParams = {
+  slug: string
+}

--- a/apps/site/src/app/blog/[slug]/page.tsx
+++ b/apps/site/src/app/blog/[slug]/page.tsx
@@ -20,24 +20,6 @@ type BlogPostProps = {
   params: Promise<SlugParams>
 }
 
-export async function generateStaticParams() {
-  const entries = await getBlogPostsData()
-  return entries.map(({ slug }) => ({ slug }))
-}
-
-export async function generateMetadata(props: BlogPostProps) {
-  const { slug } = await props.params
-  const data = getBlogPostData(slug)
-
-  return createMetadata({
-    seo: {
-      ...data.seo,
-      image: data.image?.src || graphicsData.blog.data.src,
-    },
-    path: `${PATHS.BLOG.path}/${data.slug}` as DynamicPathValues,
-  })
-}
-
 export default async function BlogPost(props: BlogPostProps) {
   const { slug } = await props.params
   const data = getBlogPostData(slug)
@@ -68,4 +50,22 @@ export default async function BlogPost(props: BlogPostProps) {
       </div>
     </PageLayout>
   )
+}
+
+export async function generateStaticParams() {
+  const entries = await getBlogPostsData()
+  return entries.map(({ slug }) => ({ slug }))
+}
+
+export async function generateMetadata(props: BlogPostProps) {
+  const { slug } = await props.params
+  const data = getBlogPostData(slug)
+
+  return createMetadata({
+    seo: {
+      ...data.seo,
+      image: data.image?.src || graphicsData.blog.data.src,
+    },
+    path: `${PATHS.BLOG.path}/${data.slug}` as DynamicPathValues,
+  })
 }

--- a/apps/site/src/app/blog/[slug]/page.tsx
+++ b/apps/site/src/app/blog/[slug]/page.tsx
@@ -1,3 +1,5 @@
+import { type SlugParams } from '@/types/paramsTypes'
+
 import { type DynamicPathValues, PATHS } from '@/constants/paths'
 
 import { graphicsData } from '@/data/graphicsData'
@@ -9,15 +11,21 @@ import { PageLayout } from '@/components/PageLayout'
 import { ShareArticle } from '@/components/ShareArticle'
 import { StructuredDataScript } from '@/components/StructuredDataScript'
 
-import { getBlogPostData } from '../utils/getBlogPostData'
+import { getBlogPostData, getBlogPostsData } from '../utils/getBlogPostData'
 
 import { BlogPostHeader } from './components/BlogPostHeader'
 import { generateStructuredData } from './utils/generateStructuredData'
 
 type BlogPostProps = {
-  params: Promise<{
-    slug: string
-  }>
+  params: Promise<SlugParams>
+}
+
+export async function generateStaticParams() {
+  const entries = await getBlogPostsData()
+
+  return entries.map((entry) => ({
+    slug: entry.slug,
+  }))
 }
 
 export async function generateMetadata(props: BlogPostProps) {

--- a/apps/site/src/app/blog/[slug]/page.tsx
+++ b/apps/site/src/app/blog/[slug]/page.tsx
@@ -22,10 +22,7 @@ type BlogPostProps = {
 
 export async function generateStaticParams() {
   const entries = await getBlogPostsData()
-
-  return entries.map((entry) => ({
-    slug: entry.slug,
-  }))
+  return entries.map(({ slug }) => ({ slug }))
 }
 
 export async function generateMetadata(props: BlogPostProps) {

--- a/apps/site/src/app/digest/[slug]/page.tsx
+++ b/apps/site/src/app/digest/[slug]/page.tsx
@@ -1,3 +1,5 @@
+import { type SlugParams } from '@/types/paramsTypes'
+
 import { type DynamicPathValues, PATHS } from '@/constants/paths'
 
 import { graphicsData } from '@/data/graphicsData'
@@ -9,15 +11,24 @@ import { PageLayout } from '@/components/PageLayout'
 import { ShareArticle } from '@/components/ShareArticle'
 import { StructuredDataScript } from '@/components/StructuredDataScript'
 
-import { getDigestArticleData } from '../utils/getDigestArticleData'
+import {
+  getDigestArticleData,
+  getDigestArticlesData,
+} from '../utils/getDigestArticleData'
 
 import { DigestArticleHeader } from './components/DigestArticleHeader'
 import { generateStructuredData } from './utils/generateStructuredData'
 
 type DigestArticleProps = {
-  params: Promise<{
-    slug: string
-  }>
+  params: Promise<SlugParams>
+}
+
+export async function generateStaticParams() {
+  const entries = await getDigestArticlesData()
+
+  return entries.map((entry) => ({
+    slug: entry.slug,
+  }))
 }
 
 export async function generateMetadata(props: DigestArticleProps) {

--- a/apps/site/src/app/digest/[slug]/page.tsx
+++ b/apps/site/src/app/digest/[slug]/page.tsx
@@ -23,24 +23,6 @@ type DigestArticleProps = {
   params: Promise<SlugParams>
 }
 
-export async function generateStaticParams() {
-  const entries = await getDigestArticlesData()
-  return entries.map(({ slug }) => ({ slug }))
-}
-
-export async function generateMetadata(props: DigestArticleProps) {
-  const { slug } = await props.params
-  const data = getDigestArticleData(slug)
-
-  return createMetadata({
-    seo: {
-      ...data.seo,
-      image: data.image?.src || graphicsData.digest.data.src,
-    },
-    path: `${PATHS.DIGEST.path}/${data.slug}` as DynamicPathValues,
-  })
-}
-
 export default async function DigestArticle(props: DigestArticleProps) {
   const { slug } = await props.params
   const data = getDigestArticleData(slug)
@@ -66,4 +48,22 @@ export default async function DigestArticle(props: DigestArticleProps) {
       </div>
     </PageLayout>
   )
+}
+
+export async function generateStaticParams() {
+  const entries = await getDigestArticlesData()
+  return entries.map(({ slug }) => ({ slug }))
+}
+
+export async function generateMetadata(props: DigestArticleProps) {
+  const { slug } = await props.params
+  const data = getDigestArticleData(slug)
+
+  return createMetadata({
+    seo: {
+      ...data.seo,
+      image: data.image?.src || graphicsData.digest.data.src,
+    },
+    path: `${PATHS.DIGEST.path}/${data.slug}` as DynamicPathValues,
+  })
 }

--- a/apps/site/src/app/digest/[slug]/page.tsx
+++ b/apps/site/src/app/digest/[slug]/page.tsx
@@ -25,10 +25,7 @@ type DigestArticleProps = {
 
 export async function generateStaticParams() {
   const entries = await getDigestArticlesData()
-
-  return entries.map((entry) => ({
-    slug: entry.slug,
-  }))
+  return entries.map(({ slug }) => ({ slug }))
 }
 
 export async function generateMetadata(props: DigestArticleProps) {

--- a/apps/site/src/app/ecosystem-explorer/[slug]/page.tsx
+++ b/apps/site/src/app/ecosystem-explorer/[slug]/page.tsx
@@ -1,3 +1,5 @@
+import { type SlugParams } from '@/types/paramsTypes'
+
 import { type DynamicPathValues, PATHS } from '@/constants/paths'
 import { FILECOIN_FOUNDATION_URLS } from '@/constants/siteMetadata'
 
@@ -14,19 +16,26 @@ import { StructuredDataScript } from '@/components/StructuredDataScript'
 import { ExternalTextLink } from '@/components/TextLink/ExternalTextLink'
 
 import { getEcosystemCMSCategories } from '../utils/getEcosystemCMSCategories'
-import { getEcosystemProjectData } from '../utils/getEcosystemProjectData'
+import {
+  getEcosystemProjectData,
+  getEcosystemProjectsData,
+} from '../utils/getEcosystemProjectData'
 
 import { Article } from './components/Article'
 import { PageHeader } from './components/PageHeader'
 import { generateStructuredData } from './utils/generateStructuredData'
 
 type EcosystemProjectProps = {
-  params: Promise<{
-    slug: string
-  }>
+  params: Promise<SlugParams>
 }
 
-const categories = getEcosystemCMSCategories()
+export async function generateStaticParams() {
+  const entries = await getEcosystemProjectsData()
+
+  return entries.map((entry) => ({
+    slug: entry.slug,
+  }))
+}
 
 export async function generateMetadata(props: EcosystemProjectProps) {
   const { slug } = await props.params
@@ -40,6 +49,8 @@ export async function generateMetadata(props: EcosystemProjectProps) {
     path: `${PATHS.ECOSYSTEM_EXPLORER.path}/${data.slug}` as DynamicPathValues,
   })
 }
+
+const categories = getEcosystemCMSCategories()
 
 export default async function EcosystemProject(props: EcosystemProjectProps) {
   const { slug } = await props.params

--- a/apps/site/src/app/ecosystem-explorer/[slug]/page.tsx
+++ b/apps/site/src/app/ecosystem-explorer/[slug]/page.tsx
@@ -31,10 +31,7 @@ type EcosystemProjectProps = {
 
 export async function generateStaticParams() {
   const entries = await getEcosystemProjectsData()
-
-  return entries.map((entry) => ({
-    slug: entry.slug,
-  }))
+  return entries.map(({ slug }) => ({ slug }))
 }
 
 export async function generateMetadata(props: EcosystemProjectProps) {

--- a/apps/site/src/app/ecosystem-explorer/[slug]/page.tsx
+++ b/apps/site/src/app/ecosystem-explorer/[slug]/page.tsx
@@ -29,24 +29,6 @@ type EcosystemProjectProps = {
   params: Promise<SlugParams>
 }
 
-export async function generateStaticParams() {
-  const entries = await getEcosystemProjectsData()
-  return entries.map(({ slug }) => ({ slug }))
-}
-
-export async function generateMetadata(props: EcosystemProjectProps) {
-  const { slug } = await props.params
-  const data = getEcosystemProjectData(slug)
-
-  return createMetadata({
-    seo: {
-      ...data.seo,
-      image: graphicsData.ecosystem.data.src,
-    },
-    path: `${PATHS.ECOSYSTEM_EXPLORER.path}/${data.slug}` as DynamicPathValues,
-  })
-}
-
 const categories = getEcosystemCMSCategories()
 
 export default async function EcosystemProject(props: EcosystemProjectProps) {
@@ -111,4 +93,22 @@ export default async function EcosystemProject(props: EcosystemProjectProps) {
       />
     </PageLayout>
   )
+}
+
+export async function generateStaticParams() {
+  const entries = await getEcosystemProjectsData()
+  return entries.map(({ slug }) => ({ slug }))
+}
+
+export async function generateMetadata(props: EcosystemProjectProps) {
+  const { slug } = await props.params
+  const data = getEcosystemProjectData(slug)
+
+  return createMetadata({
+    seo: {
+      ...data.seo,
+      image: graphicsData.ecosystem.data.src,
+    },
+    path: `${PATHS.ECOSYSTEM_EXPLORER.path}/${data.slug}` as DynamicPathValues,
+  })
 }

--- a/apps/site/src/app/events/[slug]/components/ScheduleSection/ScheduleSection.tsx
+++ b/apps/site/src/app/events/[slug]/components/ScheduleSection/ScheduleSection.tsx
@@ -1,3 +1,5 @@
+import { Suspense } from 'react'
+
 import { PageSection } from '@/components/PageSection'
 
 import type { Event } from '../../../types/eventType'
@@ -11,7 +13,9 @@ type ScheduleSectionProps = {
 export function ScheduleSection({ schedule }: ScheduleSectionProps) {
   return (
     <PageSection kicker={schedule.kicker} title={schedule.title}>
-      <Tabs schedule={schedule} />
+      <Suspense>
+        <Tabs schedule={schedule} />
+      </Suspense>
     </PageSection>
   )
 }

--- a/apps/site/src/app/events/[slug]/page.tsx
+++ b/apps/site/src/app/events/[slug]/page.tsx
@@ -34,10 +34,7 @@ type EventProps = {
 
 export async function generateStaticParams() {
   const entries = await getEventsData()
-
-  return entries.map((entry) => ({
-    slug: entry.slug,
-  }))
+  return entries.map(({ slug }) => ({ slug }))
 }
 
 export async function generateMetadata(props: EventProps) {

--- a/apps/site/src/app/events/[slug]/page.tsx
+++ b/apps/site/src/app/events/[slug]/page.tsx
@@ -32,24 +32,6 @@ type EventProps = {
   params: Promise<SlugParams>
 }
 
-export async function generateStaticParams() {
-  const entries = await getEventsData()
-  return entries.map(({ slug }) => ({ slug }))
-}
-
-export async function generateMetadata(props: EventProps) {
-  const { slug } = await props.params
-  const data = getEventData(slug)
-
-  return createMetadata({
-    seo: {
-      ...data.seo,
-      image: graphicsData.events1.data.src,
-    },
-    path: `${PATHS.EVENTS.path}/${data.slug}` as DynamicPathValues,
-  })
-}
-
 export default async function EventEntry(props: EventProps) {
   const { slug } = await props.params
   const data = getEventData(slug)
@@ -149,4 +131,22 @@ export default async function EventEntry(props: EventProps) {
       />
     </PageLayout>
   )
+}
+
+export async function generateStaticParams() {
+  const entries = await getEventsData()
+  return entries.map(({ slug }) => ({ slug }))
+}
+
+export async function generateMetadata(props: EventProps) {
+  const { slug } = await props.params
+  const data = getEventData(slug)
+
+  return createMetadata({
+    seo: {
+      ...data.seo,
+      image: graphicsData.events1.data.src,
+    },
+    path: `${PATHS.EVENTS.path}/${data.slug}` as DynamicPathValues,
+  })
 }

--- a/apps/site/src/app/events/[slug]/page.tsx
+++ b/apps/site/src/app/events/[slug]/page.tsx
@@ -1,3 +1,5 @@
+import { type SlugParams } from '@/types/paramsTypes'
+
 import { type DynamicPathValues, PATHS } from '@/constants/paths'
 
 import { graphicsData } from '@/data/graphicsData'
@@ -13,7 +15,7 @@ import { TagGroup } from '@/components/TagComponents/TagGroup'
 import { TagLabel } from '@/components/TagComponents/TagLabel'
 
 import { getInvolvedData } from '../data/getInvolvedData'
-import { getEventData } from '../utils/getEventData'
+import { getEventData, getEventsData } from '../utils/getEventData'
 import { getMetaData } from '../utils/getMetaData'
 import { isEventConcluded } from '../utils/isEventConcluded'
 import { sortNonEmptyEventsAsc } from '../utils/sortEvents'
@@ -27,9 +29,15 @@ import { buildCtaArray } from './utils/buildCtaArray'
 import { generateStructuredData } from './utils/generateStructuredData'
 
 type EventProps = {
-  params: Promise<{
-    slug: string
-  }>
+  params: Promise<SlugParams>
+}
+
+export async function generateStaticParams() {
+  const entries = await getEventsData()
+
+  return entries.map((entry) => ({
+    slug: entry.slug,
+  }))
 }
 
 export async function generateMetadata(props: EventProps) {


### PR DESCRIPTION
## 📝 Description

This PR implements `generateStaticParams` to statically generate pages at build time instead of on-demand at request time.

## 🛠️ Key Changes

- Adds `generateStaticParams` to `[slug]` pages
- Creates `SlugParams` type
- Add `Suspense` boundary around `Tabs`

## 🔖 Resources

https://nextjs.org/docs/app/api-reference/functions/generate-static-params
