### PR TITLE
Fix CMS featured entry paths

### DIFF
--- a/apps/site/public/admin/config.yml
+++ b/apps/site/public/admin/config.yml
@@ -243,7 +243,7 @@ collections:
 
       - name: "ecosystem-explorer"
         label: "Ecosystem Explorer"
-        file: "apps/site/src/content/pages/ecosystem-explorer.md"
+        file: "apps/site/src/content/pages/ecosystem-explorer/ecosystem-explorer.md"
         preview_path: "ecosystem-explorer"
         fields:
           - *header_config

--- a/apps/site/src/app/_utils/fileUtils.ts
+++ b/apps/site/src/app/_utils/fileUtils.ts
@@ -3,7 +3,11 @@ import path from 'path'
 
 import { notFound } from 'next/navigation'
 
-import { CONTENT_ROOT, MARKDOWN_EXTENSION } from '@/constants/paths'
+import {
+  WORKSPACE_ROOT,
+  CONTENT_ROOT,
+  MARKDOWN_EXTENSION,
+} from '@/constants/paths'
 
 export function extractSlugFromFilename(filename: string) {
   return path.parse(filename).name
@@ -19,7 +23,10 @@ export function handleFileNotFound(filePath: string) {
 }
 
 export function isValidMarkdownPath(path: string) {
-  return path.startsWith(CONTENT_ROOT) && path.endsWith(MARKDOWN_EXTENSION)
+  return (
+    path.startsWith(`${WORKSPACE_ROOT}/${CONTENT_ROOT}`) &&
+    path.endsWith(MARKDOWN_EXTENSION)
+  )
 }
 
 export function readFileContents(filePath: string) {

--- a/apps/site/src/content/pages/blog.md
+++ b/apps/site/src/content/pages/blog.md
@@ -2,7 +2,7 @@
 header:
   title: Blog
   description: Filecoin Foundation Blog
-featured_entry: src/content/blog/filecoin-mainnet-marks-four-years.md
+featured_entry: "apps/site/src/content/blog/filecoin-mainnet-marks-four-years.md"
 seo:
   title: Filecoin Foundation Blog | Ecosystem Updates & Announcements
   description: Read the latest updates, insights, and announcements from the

--- a/apps/site/src/content/pages/events.md
+++ b/apps/site/src/content/pages/events.md
@@ -2,7 +2,7 @@
 header:
   title: Events
   description: Filecoin Foundation Events
-featured_entry: src/content/events/filecoin-ethdenver-2025.md
+featured_entry: "apps/site/src/content/events/filecoin-ethdenver-2025.md"
 seo:
   title: Filecoin Foundation Events – Connect & Collaborate
   description: Explore upcoming Filecoin Foundation, Web3, and community events.

--- a/apps/site/src/content/pages/grants.md
+++ b/apps/site/src/content/pages/grants.md
@@ -8,12 +8,12 @@ header:
     ]
 featured_grant_graduates:
   [
-    src/content/ecosystem-explorer/cavalry.md,
-    src/content/ecosystem-explorer/filedrive.md,
-    src/content/ecosystem-explorer/fileverse.md,
-    src/content/ecosystem-explorer/museum-of-crypto-art-m-c.md,
-    src/content/ecosystem-explorer/opsci.md,
-    src/content/ecosystem-explorer/portrait.md,
+    "apps/site/src/content/ecosystem-explorer/cavalry.md",
+    "apps/site/src/content/ecosystem-explorer/filedrive.md",
+    "apps/site/src/content/ecosystem-explorer/fileverse.md",
+    "apps/site/src/content/ecosystem-explorer/museum-of-crypto-art-m-c.md",
+    "apps/site/src/content/ecosystem-explorer/opsci.md",
+    "apps/site/src/content/ecosystem-explorer/portrait.md",
   ]
 seo:
   title: "Filecoin Foundation Grants & Funding Opportunities"

--- a/apps/site/src/content/pages/home.md
+++ b/apps/site/src/content/pages/home.md
@@ -4,12 +4,12 @@ header:
   description: "Filecoin is the world’s largest decentralized storage network. Filecoin Foundation's mission is to preserve humanity's most important information, as well as to facilitate the open source governance of the Filecoin network, fund research and development projects for decentralized technologies, and support the growth of the Filecoin ecosystem and community."
 featured_ecosystem_projects:
   [
-    "src/content/ecosystem-explorer/nuklai.md",
-    "src/content/ecosystem-explorer/fleek.md",
-    "src/content/ecosystem-explorer/tableland.md",
-    "src/content/ecosystem-explorer/lighthouse.md",
-    "src/content/ecosystem-explorer/genrait.md",
-    "src/content/ecosystem-explorer/starling-lab.md",
+    "apps/site/src/content/ecosystem-explorer/nuklai.md",
+    "apps/site/src/content/ecosystem-explorer/fleek.md",
+    "apps/site/src/content/ecosystem-explorer/tableland.md",
+    "apps/site/src/content/ecosystem-explorer/lighthouse.md",
+    "apps/site/src/content/ecosystem-explorer/genrait.md",
+    "apps/site/src/content/ecosystem-explorer/starling-lab.md",
   ]
 seo:
   title: "Filecoin Foundation | Decentralized Storage Solutions"


### PR DESCRIPTION
## 📝 Description

This PR standardizes CMS paths by adding the `apps/site` prefix to featured entries in the frontmatter, keeping them consistent with other file paths:

```yml
- name: "about"
  label: "About"
  file: "apps/site/src/content/pages/about.md"
  preview_path: "about"
```

Now that we have a mono repo set up, Decap CMS uses the full entry path, as shown in https://github.com/FilecoinFoundationWeb/filecoin-foundation/pull/1084 for instance.

## 🛠️ Key Changes

- Adds `app/sites` to featured entries in `config.yml` - https://github.com/FilecoinFoundationWeb/filecoin-foundation/pull/1075/commits/4856b864f6393f7d1ce3bd7f21263de951c918b2
- Updates `isValidMarkdownPath` to reflect the path changes - https://github.com/FilecoinFoundationWeb/filecoin-foundation/pull/1075/commits/f4d3ab5e0970e9593f03eee4f893c27950129342
- Fixes invalid content path - https://github.com/FilecoinFoundationWeb/filecoin-foundation/pull/1075/commits/b771f6e97ed38adebbbe586d6fa11f0deacc4658

## 🧪 How to Test

> [!NOTE]
> This works locally, but the featured entries do not appear in the select component when using the CMS via the preview link. They do not appear either when using the production [link](https://fil.org/admin/index.html#/collections/pages/entries/blog), I'm hoping that this PR fixes the problem.