### PR TITLE
Remove time from event date field in the CMS [skip percy]

### DIFF
--- a/apps/site/public/admin/config.yml
+++ b/apps/site/public/admin/config.yml
@@ -767,6 +767,7 @@ collections:
               - name: "date"
                 label: "Date"
                 widget: "datetime"
+                date_format: *date_iso_format
               - name: "events"
                 label: "Events"
                 widget: "list"

--- a/apps/site/src/app/_schemas/DateTimeSchema.ts
+++ b/apps/site/src/app/_schemas/DateTimeSchema.ts
@@ -1,0 +1,12 @@
+import { z } from 'zod'
+
+const ZERO_TIMESTAMP = '00:00:00.000Z'
+
+export const IsoDateSchema = z.date().refine(isZeroTimestamp, {
+  message:
+    'This date must not contain a time portion in the CMS, it should follow ISO 8601 format: YYYY-MM-DD',
+})
+
+function isZeroTimestamp(date: Date) {
+  return date.toISOString().endsWith(ZERO_TIMESTAMP)
+}

--- a/apps/site/src/app/events/[slug]/utils/filterAndSortScheduleDays.ts
+++ b/apps/site/src/app/events/[slug]/utils/filterAndSortScheduleDays.ts
@@ -18,9 +18,7 @@ export function filterAndSortScheduleDays(
   }))
 
   const sortedDays = daysWithEventsSortedByTime.toSorted((a, b) => {
-    const dateA = new UTCDate(a.date)
-    const dateB = new UTCDate(b.date)
-    return compareAsc(dateA, dateB)
+    return compareAsc(a.date, b.date)
   })
 
   return sortedDays

--- a/apps/site/src/app/events/schemas/ScheduleSchema.ts
+++ b/apps/site/src/app/events/schemas/ScheduleSchema.ts
@@ -1,5 +1,7 @@
 import { z } from 'zod'
 
+import { IsoDateSchema } from '@/schemas/DateTimeSchema'
+
 const ParticipantSchema = z
   .object({
     name: z.string(),
@@ -23,7 +25,7 @@ const EventSchema = z
 
 const EventDaySchema = z
   .object({
-    date: z.coerce.date(),
+    date: IsoDateSchema,
     events: z.array(EventSchema),
   })
   .strict()

--- a/apps/site/src/content/events/davos.md
+++ b/apps/site/src/content/events/davos.md
@@ -82,8 +82,8 @@ schedule:
           tag: Registration Needed
           end: 2025-01-20T16:25:00.000Z
           description: What is Crypto Good For?
-      date: 2025-01-20T10:00:00.000Z
-    - date: 2025-01-21T09:00:00.000Z
+      date: 2025-01-20
+    - date: 2025-01-21
       events:
         - tag: Registration Needed
           title: Rachel Horn at Equality Lounge @ Davos
@@ -210,8 +210,8 @@ schedule:
             - name: Daniel Ammann
               company: Onocoy Association
           end: 2025-01-22T17:15:00.000Z
-      date: 2025-01-22T12:00:00.000Z
-    - date: 2025-01-24T12:00:00.000Z
+      date: 2025-01-22
+    - date: 2025-01-24
       events:
         - tag: Registration Needed
           title: Clara Tsao at Invest India Lounge

--- a/apps/site/src/content/events/fil-bangkok-2024.md
+++ b/apps/site/src/content/events/fil-bangkok-2024.md
@@ -107,8 +107,8 @@ schedule:
           end: 2024-11-06T20:00:00.000Z
           location: Gaysorn Urban Resort
           url: https://www.fildev.io/FDS-5
-      date: 2024-11-06T11:00:00.000Z
-    - date: 2024-11-07T09:00:00.000Z
+      date: 2024-11-06
+    - date: 2024-11-07
       events:
         - title: FIL Bangkok Co-Working Space
           description: >-
@@ -134,7 +134,7 @@ schedule:
           location: Gaysorn Urban Resort
           start: 2024-11-07T09:00:00.000Z
           end: 2024-11-07T18:30:00.000Z
-    - date: 2024-11-08T09:00:00.000Z
+    - date: 2024-11-08
       events:
         - title: FIL Bangkok Co-Working Space
           description: >-
@@ -444,7 +444,7 @@ schedule:
             rapid-fire overview of the startups and tools the Filecoin network
             needs built and how FIL-B is making it easy for devs to onboard and
             contribute to the future of Filecoin.
-      date: 2024-11-11T09:00:00.000Z
+      date: 2024-11-11
 speakers:
   speakers_list:
     - name: Juan Benet

--- a/apps/site/src/content/events/filecoin-consensus-hong-kong.md
+++ b/apps/site/src/content/events/filecoin-consensus-hong-kong.md
@@ -37,7 +37,7 @@ schedule:
           start: 2025-02-19T15:30:00.000Z
           location: Hashkey Capital Headquarters
           url: https://lu.ma/deaisummitHK
-      date: 2025-02-19T09:00:00.000Z
+      date: 2025-02-19
     - events:
         - title: Clara Tsao at Consensus Hong Kong
           tag: Registration Needed
@@ -56,7 +56,7 @@ schedule:
           start: 2025-02-20T10:00:00.000Z
           location: Renaissance Hong Kong Harbour View Hotel
           url: https://lu.ma/hack_hk
-      date: 2025-02-20T09:00:00.000Z
+      date: 2025-02-20
     - events:
         - tag: Registration Needed
           title: "Clara Tsao at ALPHA: HONG KONG EDITION"
@@ -68,7 +68,7 @@ schedule:
           start: 2025-02-21T13:05:00.000Z
           location: Cardinal Point
           url: https://lu.ma/hcge9jg4
-      date: 2025-02-21T09:00:00.000Z
+      date: 2025-02-21
 speakers:
   kicker: CONNECT WITH US
   title: Meet The Team


### PR DESCRIPTION
> [!NOTE]
> This is PR 2/3 aimed at improving the date UX in the CMS.

## 📝 Description 

This PR updates the event's `date` field by removing the time portion, as only the day is needed.

## 🛠️ Key Changes

- Updates `config.yml`
- Removes the time portion from Markdown entries
- Creates a `IsoDateSchema` schema, to replace `z.coerce.date()`. This schema ensures that the Date instance loaded from the CMS has no time component, meaning it ends with `00:00:00.000Z`.
- Refactors `filterAndSortScheduleDays`

## 🧪 How to Test

Run the CMS locally, create an event and make sure the start and end times are only dates, not times.

## 📸 Screenshots

![CleanShot 2025-02-13 at 11 24 21@2x](https://github.com/user-attachments/assets/f0f6cb74-622a-4783-8b90-0b1d8ed46930)

## 🔖 Resources

- https://decapcms.org/docs/widgets/#datetime
