### PR TITLE
Remove time from program startDate / endDate fields in the CMS [skip percy]

### DIFF
--- a/apps/site/public/admin/config.yml
+++ b/apps/site/public/admin/config.yml
@@ -726,14 +726,12 @@ collections:
                 widget: "datetime"
                 date_format: *date_iso_format
                 hint: "First day of event"
-                picker_utc: true
               - name: "end-date"
                 label: "End Date"
                 widget: "datetime"
                 date_format: *date_iso_format
                 required: false
                 hint: "Last day of event. Leave empty for single-day events."
-                picker_utc: true
               - name: "location"
                 label: "Location"
                 widget: "string"

--- a/apps/site/public/admin/config.yml
+++ b/apps/site/public/admin/config.yml
@@ -724,13 +724,15 @@ collections:
               - name: "start-date"
                 label: "Start Date"
                 widget: "datetime"
+                date_format: *date_iso_format
                 hint: "First day of event"
                 picker_utc: true
               - name: "end-date"
                 label: "End Date"
                 widget: "datetime"
+                date_format: *date_iso_format
                 required: false
-                hint: "Last day of event"
+                hint: "Last day of event. Leave empty for single-day events."
                 picker_utc: true
               - name: "location"
                 label: "Location"

--- a/apps/site/src/app/_utils/dateUtils.ts
+++ b/apps/site/src/app/_utils/dateUtils.ts
@@ -1,7 +1,7 @@
 import { format, isValid } from 'date-fns'
 
-export function formatDate(date: Date) {
-  return format(date, 'MMM d, yyyy')
+export function formatDate(date: Date, formatString = 'MMM d, yyyy') {
+  return format(date, formatString)
 }
 
 export function formatDateComponentsFromISO(isoDateString: string) {

--- a/apps/site/src/app/events/[slug]/components/ScheduleSection/Tabs.tsx
+++ b/apps/site/src/app/events/[slug]/components/ScheduleSection/Tabs.tsx
@@ -8,7 +8,7 @@ import theme from 'tailwindcss/defaultTheme'
 import { useIsMounted, useMediaQuery } from 'usehooks-ts'
 
 import type { Event } from '../../../types/eventType'
-import { abbreviateDate } from '../../utils/dateUtils'
+import { formatShortDate } from '../../utils/dateUtils'
 import { filterAndSortScheduleDays } from '../../utils/filterAndSortScheduleDays'
 import { scrollTabContentIntoView } from '../../utils/scrollTabContentIntoView'
 
@@ -57,17 +57,17 @@ export function Tabs({ schedule }: TabsProps) {
       <TabList className="sticky top-0 -m-2 flex gap-4 overflow-auto bg-brand-800 p-2 lg:static">
         {sortedDays.map((day) => (
           <Tab
-            key={abbreviateDate(day.date)}
+            key={formatShortDate(day.date)}
             className="whitespace-nowrap rounded-lg p-3 font-bold text-brand-300 focus:brand-outline data-[hover]:bg-brand-700 data-[selected]:bg-brand-700 data-[selected]:text-brand-400"
           >
-            {abbreviateDate(day.date)}
+            {formatShortDate(day.date)}
           </Tab>
         ))}
       </TabList>
       <TabPanels>
         {sortedDays.map((day) => (
           <TabPanel
-            key={abbreviateDate(day.date)}
+            key={formatShortDate(day.date)}
             className="rounded-lg focus:brand-outline"
           >
             <div className="grid gap-4">

--- a/apps/site/src/app/events/[slug]/components/ScheduleSection/Tabs.tsx
+++ b/apps/site/src/app/events/[slug]/components/ScheduleSection/Tabs.tsx
@@ -8,7 +8,7 @@ import theme from 'tailwindcss/defaultTheme'
 import { useIsMounted, useMediaQuery } from 'usehooks-ts'
 
 import type { Event } from '../../../types/eventType'
-import { formatDate } from '../../utils/dateUtils'
+import { abbreviateDate } from '../../utils/dateUtils'
 import { filterAndSortScheduleDays } from '../../utils/filterAndSortScheduleDays'
 import { scrollTabContentIntoView } from '../../utils/scrollTabContentIntoView'
 
@@ -57,17 +57,17 @@ export function Tabs({ schedule }: TabsProps) {
       <TabList className="sticky top-0 -m-2 flex gap-4 overflow-auto bg-brand-800 p-2 lg:static">
         {sortedDays.map((day) => (
           <Tab
-            key={formatDate(day.date)}
+            key={abbreviateDate(day.date)}
             className="whitespace-nowrap rounded-lg p-3 font-bold text-brand-300 focus:brand-outline data-[hover]:bg-brand-700 data-[selected]:bg-brand-700 data-[selected]:text-brand-400"
           >
-            {formatDate(day.date)}
+            {abbreviateDate(day.date)}
           </Tab>
         ))}
       </TabList>
       <TabPanels>
         {sortedDays.map((day) => (
           <TabPanel
-            key={formatDate(day.date)}
+            key={abbreviateDate(day.date)}
             className="rounded-lg focus:brand-outline"
           >
             <div className="grid gap-4">

--- a/apps/site/src/app/events/[slug]/page.tsx
+++ b/apps/site/src/app/events/[slug]/page.tsx
@@ -53,6 +53,7 @@ export default async function EventEntry(props: EventProps) {
     sponsors,
     recap,
   } = data
+
   const categoryLabel = getCategoryLabel({
     collectionName: 'event_entries',
     category,

--- a/apps/site/src/app/events/[slug]/utils/dateUtils.ts
+++ b/apps/site/src/app/events/[slug]/utils/dateUtils.ts
@@ -1,9 +1,10 @@
 import { UTCDate } from '@date-fns/utc'
 import { format } from 'date-fns'
 
-export function formatDate(date: Date) {
-  const utcDate = new UTCDate(date)
-  return format(utcDate, 'EEE, MMM d')
+import { formatDate } from '@/utils/dateUtils'
+
+export function abbreviateDate(date: Date) {
+  return formatDate(date, 'EEE, MMM d')
 }
 
 export function formatTime(date: Date) {

--- a/apps/site/src/app/events/[slug]/utils/dateUtils.ts
+++ b/apps/site/src/app/events/[slug]/utils/dateUtils.ts
@@ -3,7 +3,7 @@ import { format } from 'date-fns'
 
 import { formatDate } from '@/utils/dateUtils'
 
-export function abbreviateDate(date: Date) {
+export function formatShortDate(date: Date) {
   return formatDate(date, 'EEE, MMM d')
 }
 

--- a/apps/site/src/app/events/schemas/EventBaseFrontmatterSchema.ts
+++ b/apps/site/src/app/events/schemas/EventBaseFrontmatterSchema.ts
@@ -1,10 +1,12 @@
 import { z } from 'zod'
 
+import { IsoDateSchema } from '@/schemas/DateTimeSchema'
+
 export const EventBaseFrontmatterSchema = z
   .object({
     title: z.string(),
-    'start-date': z.date(),
-    'end-date': z.date().optional(),
+    'start-date': IsoDateSchema,
+    'end-date': IsoDateSchema.optional(),
     description: z.string().optional(),
     'external-link': z.string().url().optional(),
   })

--- a/apps/site/src/content/events/consensus-toronto.md
+++ b/apps/site/src/content/events/consensus-toronto.md
@@ -18,8 +18,8 @@ category: supported-sponsored
 location:
   primary: Toronto, Canada
   region: north-america
-start-date: 2025-05-14T14:00:00.000Z
-end-date: 2025-05-16T11:00:00.000Z
+start-date: 2025-05-14
+end-date: 2025-05-16
 external-link: https://consensus2025.coindesk.com/
 seo:
   twitter:

--- a/apps/site/src/content/events/davos.md
+++ b/apps/site/src/content/events/davos.md
@@ -18,10 +18,11 @@ image:
 program:
   events:
     - title: The Filecoin Penthouse. Hosted by Filecoin Foundation
-      start-date: 2025-01-20T09:00:00.000Z
-      end-date: 2025-01-23T17:30:00.000Z
+      start-date: 2025-01-20
+      end-date: 2025-01-23
       location: Davos, Switzerland
-      description: "The Filecoin Penthouse is an exclusive lounge in the heart of
+      description:
+        "The Filecoin Penthouse is an exclusive lounge in the heart of
         Davos, designed for networking, casual meetings, and relaxing with
         coffee while enjoying breathtaking views. A private meeting room is
         available upon request. Located in WEF’s Secure Zone, the venue requires
@@ -35,27 +36,31 @@ program:
         industry. Co-hosted by Filecoin Foundation, Joe Landon, and Dylan
         Taylor.
       external-link: https://cvent.me/q54O0N
-      start-date: 2025-01-20T19:00:00.000Z
+      start-date: 2025-01-20
     - title: Friends of Filecoin Foundation Reception
       location: Davos, Switzerland
-      description: Join leaders and innovators from across the Filecoin ecosystem for
+      description:
+        Join leaders and innovators from across the Filecoin ecosystem for
         an evening reception in the heart of Davos.
       external-link: https://cvent.me/Mm01XX
-      start-date: 2025-01-20T20:30:00.000Z
-    - title: "With Honor Action Reception. With Special Guests: Members of the U.S.
+      start-date: 2025-01-20
+    - title:
+        "With Honor Action Reception. With Special Guests: Members of the U.S.
         Congressional Delegation. Hosted by Filecoin Foundation, With Honor
         Action"
-      start-date: 2025-01-22T20:30:00.000Z
-      description: With Honor Action, in partnership with Filecoin Foundation, is
+      start-date: 2025-01-22
+      description:
+        With Honor Action, in partnership with Filecoin Foundation, is
         hosting the 4th Annual Reception for the bipartisan U.S. Congressional
         Delegation to the World Economic Forum. This invitation-only event will
         occur on Wednesday night. Space is limited, and attendance is by prior
         confirmation only.
       location: Davos, Switzerland
     - title: Policy Reception. Hosted by Filecoin Foundation, Hedera, and GBBC.
-      start-date: 2025-01-22T17:00:00.000Z
+      start-date: 2025-01-22
       location: Davos, Switzerland
-      description: The Policy Reception, hosted by Filecoin Foundation, Hedera, and
+      description:
+        The Policy Reception, hosted by Filecoin Foundation, Hedera, and
         GBBC, will bring together senior industry leaders and policymakers from
         around the globe for engaging conversations on the future of technology
         and governance.
@@ -87,7 +92,8 @@ schedule:
       events:
         - tag: Registration Needed
           title: Rachel Horn at Equality Lounge @ Davos
-          description: "From Innovators to Influencers: Women Scaling Blockchain and
+          description:
+            "From Innovators to Influencers: Women Scaling Blockchain and
             Financial Inclusion"
           url: "https://thefemalequotient.equalitylounge.com/davos25/ "
           location: Promenade 40 7270 Davos Platz, Switzerland
@@ -196,7 +202,8 @@ schedule:
           url: https://web3hubdavos.com/
           start: 2025-01-22T16:45:00.000Z
           location: Ob. Str. 33, 7270 Davos Platz, Switzerland
-          description: "Emerging Macro Trends in DePIN: Disruptive Solutions to Global
+          description:
+            "Emerging Macro Trends in DePIN: Disruptive Solutions to Global
             Infrastructure Challenges"
           speakers:
             - name: Megan Klimen
@@ -215,7 +222,8 @@ schedule:
       events:
         - tag: Registration Needed
           title: Clara Tsao at Invest India Lounge
-          description: How Women Are Shaping Global Innovation in Tech, Sustainability,
+          description:
+            How Women Are Shaping Global Innovation in Tech, Sustainability,
             and Start-Ups
           start: 2025-01-24T12:00:00.000Z
           location: Promenade 67 and 73
@@ -224,7 +232,8 @@ schedule:
 speakers:
   kicker: Connect with us
   title: Meet the Team
-  description: Our experts are here to discuss Web3, decentralization, and policy
+  description:
+    Our experts are here to discuss Web3, decentralization, and policy
     innovation. Request a meeting at marketing@fil.org to explore opportunities.
   speakers_list:
     - name: Marta Belcher

--- a/apps/site/src/content/events/digital-real-estate-summit.md
+++ b/apps/site/src/content/events/digital-real-estate-summit.md
@@ -8,7 +8,6 @@ location:
   primary: "Miami, Florida"
   region: north-america
 start-date: 2025-02-11
-end-date: 2025-02-11
 external-link: https://lu.ma/n4c8aotx?tk=GRGiWo
 seo:
   twitter:

--- a/apps/site/src/content/events/fil-bangkok-2024.md
+++ b/apps/site/src/content/events/fil-bangkok-2024.md
@@ -23,62 +23,62 @@ program:
     - title: DePIN Day Bangkok
       description: By Fluence, Spheron Network, Parasail & Livepeer
       location: Carlton Hotel Bangkok Sukhumvit
-      start-date: 2024-11-15T03:00:00.000Z
+      start-date: 2024-11-15
       external-link: https://lu.ma/depin-bangkok
     - title: "Build & Bloom: Akave's Decentralized Storage Workshop"
       description: By Akave
       location: SOCO WORK&LIVE EmQuartier
-      start-date: 2024-11-14T04:00:00.000Z
+      start-date: 2024-11-14
       external-link: https://lu.ma/qrk28iw4
     - title: Hot Ones & Zeros Party by Storacha
       description: By Storacha & Cosmik Agency
       location: Chim Chim
-      start-date: 2024-11-13T10:30:00.000Z
+      start-date: 2024-11-13
       external-link: https://lu.ma/xh9ca6fs
     - title: "Code n' Corgi: Filecoin Builders Night"
       description: By FIL-B, Sarah Thiam, TPG & La Christa
       location: SOCO WORK&LIVE EmQuartier
-      start-date: 2024-11-13T10:00:00.000Z
+      start-date: 2024-11-13
       external-link: https://lu.ma/udulaer4
     - title: Threshold Summit - Bangkok
       description: By Randamu, Dave Grantham & Kent Bull
       location: U Sathorn Bangkok
-      start-date: 2024-11-12T05:00:00.000Z
+      start-date: 2024-11-12
       external-link: https://lu.ma/2hqvjjzl
     - title: "FIL Bangkok: DePIN Meets AI, in partnership with CoinDesk Studios"
       description: By Filecoin Foundation
       location: Samyan Mitrtown
-      start-date: 2024-11-11T02:00:00.000Z
+      start-date: 2024-11-11
       external-link: https://lu.ma/aqyqwupe
     - title: IPFS Bangkok
       description: By Miwa Events, Mosh & Daniel
       location: JustCo – Samyan Mitrtown | Coworking & Office Space
-      start-date: 2024-11-10T06:00:00.000Z
+      start-date: 2024-11-10
       external-link: https://lu.ma/ipfs-bangkok
     - title: "Filecoin Orbit: AI Commu-night #4"
       description: By Filecoin Orbit
       location: Such A Small World
-      start-date: 2024-11-09T10:00:00.000Z
+      start-date: 2024-11-09
       external-link: https://www.eventpop.me/e/54742/filecoinplayground15
     - title: Protocol Labs Cowork Hub
       description: By Protocol Labs
       location: SOCO WORK&LIVE EmQuartier
-      start-date: 2024-11-07T03:00:00.000Z
+      start-date: 2024-11-07
       external-link: https://lu.ma/htkj4b43
     - title: FIL Dev Summit 5 @ LabWeek
       description: By Molly, Marta Geater Piekarska & Filecoin Foundation
       location: Gaysorn Urban Resort
-      start-date: 2024-11-06T04:00:00.000Z
+      start-date: 2024-11-06
       external-link: https://lu.ma/vcdjb8pl
     - title: FIL Bangkok Co-Working Space
       description: By Filecoin Foundation
       location: Gaysorn Urban Resort
-      start-date: 2024-11-06T04:00:00.000Z
+      start-date: 2024-11-06
       external-link: https://lu.ma/no08u3bt
     - title: Filecoin Hacker House
       description: By Filecoin Foundation
       location: Amphoe Mueang Chiang Mai, Chang Wat Chiang Mai
-      start-date: 2024-10-26T09:00:00.000Z
+      start-date: 2024-10-26
       external-link: https://lu.ma/j49yitcw
 schedule:
   days:

--- a/apps/site/src/content/events/filecoin-consensus-hong-kong.md
+++ b/apps/site/src/content/events/filecoin-consensus-hong-kong.md
@@ -19,7 +19,7 @@ program:
   events:
     - title: "Decentralized Intelligence: Filecoin x AI Night. Hosted by NDLabs,
         Supported by Filecoin Orbit and Filecoin Foundation"
-      start-date: 2025-02-17T17:00:00.000Z
+      start-date: 2025-02-17
       location: Maggie Choo's
       external-link: https://lu.ma/9462sbyn
   kicker: FIND US AROUND HONG KONG
@@ -60,7 +60,8 @@ schedule:
     - events:
         - tag: Registration Needed
           title: "Clara Tsao at ALPHA: HONG KONG EDITION"
-          description: "Future-Proofing Layer 1s: Designing Blockchain Infrastructure for
+          description:
+            "Future-Proofing Layer 1s: Designing Blockchain Infrastructure for
             2025 and beyond"
           speakers:
             - name: Clara Tsao

--- a/apps/site/src/content/events/filecoin-ethdenver-2025.md
+++ b/apps/site/src/content/events/filecoin-ethdenver-2025.md
@@ -20,7 +20,7 @@ program:
   events:
     - title: Code N Corgi. Hosted by FIL Builders, Supported by Filecoin Foundation
       location: Denver, CO
-      start-date: 2025-02-28T17:00:00.000Z
+      start-date: 2025-02-28
       external-link: https://lu.ma/gd767xu5
       description:
         ​A community gathering for Filecoin builders and friends! Come for
@@ -33,7 +33,7 @@ program:
         Denver, Colorado for a FWS, Onramps, and Tooling Colo leading up to ETH
         Denver. The goal of this Colo is to further the work started in Bangkok
         for reaching Product Market Fit.
-      start-date: 2025-02-23T09:00:00.000Z
+      start-date: 2025-02-23
     - title: Schelling Point. Hosted by Gitcoin, Sponsored by Filecoin Foundation
       external-link: https://schellingpoint.gitcoin.co/
       location: Denver, CO
@@ -48,7 +48,7 @@ program:
         builders at every stage of their journey. Expect unique opportunities to
         connect with top ecosystems, explore cutting-edge funding mechanisms,
         and scale your impact like never before."
-      start-date: 2025-02-27T10:00:00.000Z
+      start-date: 2025-02-27
     - title:
         Executive Leaders Roundtable Luncheon. Hosted by DeStor and Filecoin
         Foundation
@@ -56,10 +56,10 @@ program:
       description: An expert moderator will guide the knowledge-sharing event,
         stimulating discussion between participants in a closed, confidential
         environment. Attendance is complimentary and by invitation only.
-      start-date: 2025-02-25T12:00:00.000Z
+      start-date: 2025-02-25
       external-link: https://www.ortusclub.com/event/security-portability-and-ai-driven-innovation/
     - title: Private Luncheon. Hosted by Storacha, Sponsored by Filecoin Foundation
-      start-date: 2025-02-26T14:30:00.000Z
+      start-date: 2025-02-26
       location: "Denver, CO"
       description:
         On February 26th, the Storacha Network is hosting an exclusive,
@@ -73,8 +73,8 @@ program:
         the space. This event is invite-only with limited seating, ensuring a
         high-value experience for all participants.
     - title: "Solana Speed by OFFLINE x Storacha | ETHDenver 2025"
-      start-date: 2025-02-26T16:00:00.000Z
-      end-date: 2026-02-26T21:00:00.000Z
+      start-date: 2025-02-26
+      end-date: 2026-02-26
       description:
         Join OFFLINE x Storacha for Solana Speed at ETHDenver, featuring
         Backer/Builder matchmaking, crypto panels, and networking. Explore
@@ -83,8 +83,8 @@ program:
       location: Birch Road (The Highlands)
       external-link: https://lu.ma/solanaspeed
     - title: Decentralized Media Summit
-      start-date: 2025-02-26T08:30:00.000Z
-      end-date: 2025-02-26T12:00:00.000Z
+      start-date: 2025-02-26
+      end-date: 2025-02-26
       location: Milk Market
       external-link: https://lu.ma/i9gatw59
       description: ​Join pioneers of decentralized media as they chart out a new
@@ -100,8 +100,8 @@ program:
     - title:
         "GLIF Pool Party: lendng and staking pool meetup, Sponsored by Filecoin
         Foundation"
-      start-date: 2025-02-27T17:00:00.000Z
-      end-date: 2025-02-27T20:00:00.000Z
+      start-date: 2025-02-27
+      end-date: 2025-02-27
       location: Denver, CO
       description:
         "Join us at GLIF's Pool Party for a fun-filled evening with lending
@@ -111,7 +111,7 @@ program:
       external-link: https://lu.ma/444wnmwb
     - title: DePIN Day Denver 2025, Hosted by Fluence, Sponsored by Filecoin
         Foundation
-      start-date: 2025-02-26T10:00:00.000Z
+      start-date: 2025-02-26
       external-link: https://lu.ma/depin-denver
       description:
         ​​​Join us for the all-day event full of vital conversations around

--- a/apps/site/src/content/events/filecoin-ethdenver-2025.md
+++ b/apps/site/src/content/events/filecoin-ethdenver-2025.md
@@ -74,7 +74,6 @@ program:
         high-value experience for all participants.
     - title: "Solana Speed by OFFLINE x Storacha | ETHDenver 2025"
       start-date: 2025-02-26
-      end-date: 2026-02-26
       description:
         Join OFFLINE x Storacha for Solana Speed at ETHDenver, featuring
         Backer/Builder matchmaking, crypto panels, and networking. Explore
@@ -84,7 +83,6 @@ program:
       external-link: https://lu.ma/solanaspeed
     - title: Decentralized Media Summit
       start-date: 2025-02-26
-      end-date: 2025-02-26
       location: Milk Market
       external-link: https://lu.ma/i9gatw59
       description: ​Join pioneers of decentralized media as they chart out a new
@@ -101,7 +99,6 @@ program:
         "GLIF Pool Party: lendng and staking pool meetup, Sponsored by Filecoin
         Foundation"
       start-date: 2025-02-27
-      end-date: 2025-02-27
       location: Denver, CO
       description:
         "Join us at GLIF's Pool Party for a fun-filled evening with lending

--- a/apps/site/src/content/events/nft-vision-hack.md
+++ b/apps/site/src/content/events/nft-vision-hack.md
@@ -8,7 +8,6 @@ location:
   primary: Virtual
 external-link: https://www.nftvisionhack.com/
 start-date: 2021-06-30
-end-date: 2021-08-30
 seo:
   description: Join the NFT Vision Hack to innovate and create the future of NFTs.
 ---

--- a/apps/site/src/content/events/nft-vision-hack.md
+++ b/apps/site/src/content/events/nft-vision-hack.md
@@ -8,6 +8,7 @@ location:
   primary: Virtual
 external-link: https://www.nftvisionhack.com/
 start-date: 2021-06-30
+end-date: 2021-08-30
 seo:
   description: Join the NFT Vision Hack to innovate and create the future of NFTs.
 ---


### PR DESCRIPTION
> [!NOTE]
> This is PR 3/3 aimed at improving the date UX in the CMS.

## 📝 Description 

This PR updates the event's program `startdate` & `endDate` fields by removing the time portion, as only the day is needed.

## 🛠️ Key Changes

- Updates `config.yml`
- Removes the time portion from Markdown entries
- Adds `IsoDateSchema` schema to `EventBaseFrontmatterSchema` to replace`z.coerce.date()`. 
- Scout clean: Remove unnecessary end dates
- Rename local `formatDate` to `abbreviateDate` to avoid confusion 

## 🧪 How to Test

Run the CMS locally, create an event and make sure the start and end times are only dates, not times.

## 🔖 Resources

- https://decapcms.org/docs/widgets/#datetime
