### PR TITLE
Improve CMS Event Times

### DIFF
--- a/apps/site/public/admin/config.yml
+++ b/apps/site/public/admin/config.yml
@@ -13,6 +13,7 @@ media_folder: "apps/site/public/assets/images"
 public_folder: "/assets/images"
 
 date_iso_format: &date_iso_format "YYYY-MM-DD"
+time_iso_format: &time_iso_format "HH:mm:ss.SSSZ"
 
 slug:
   encoding: "ascii"
@@ -808,15 +809,18 @@ collections:
                         label: "Company"
                         widget: "string"
                     required: false
-                  - name: "start"
+                  - name: "start-time"
                     label: "Start Time"
                     widget: "datetime"
+                    time_format: *time_iso_format
                     picker_utc: true
-                  - name: "end"
+                  - name: "end-time"
                     label: "End Time"
                     widget: "datetime"
+                    time_format: *time_iso_format
                     picker_utc: true
                     required: false
+                    hint: "Leave empty if the event has no end time."
                   - name: "location"
                     label: "Location"
                     widget: "string"

--- a/apps/site/src/app/_schemas/DateTimeSchema.ts
+++ b/apps/site/src/app/_schemas/DateTimeSchema.ts
@@ -1,15 +1,16 @@
 import { z } from 'zod'
 
 const ZERO_TIMESTAMP = '00:00:00.000Z'
-const ISO_TIME_REGEX = /^\d{2}:\d{2}:\d{2}\.000Z$/
 
 export const IsoDateSchema = z.date().refine(isZeroTimestamp, {
   message:
     'This date must not contain a time portion in the CMS, it should follow ISO 8601 format: YYYY-MM-DD',
 })
 
-export const IsoTimeSchema = z.string().regex(ISO_TIME_REGEX)
-
 function isZeroTimestamp(date: Date) {
   return date.toISOString().endsWith(ZERO_TIMESTAMP)
 }
+
+export const ISO_TIME_REGEX = /^\d{2}:\d{2}:\d{2}\.000Z$/
+
+export const IsoTimeSchema = z.string().regex(ISO_TIME_REGEX)

--- a/apps/site/src/app/_schemas/DateTimeSchema.ts
+++ b/apps/site/src/app/_schemas/DateTimeSchema.ts
@@ -1,11 +1,14 @@
 import { z } from 'zod'
 
 const ZERO_TIMESTAMP = '00:00:00.000Z'
+const ISO_TIME_REGEX = /^\d{2}:\d{2}:\d{2}\.000Z$/
 
 export const IsoDateSchema = z.date().refine(isZeroTimestamp, {
   message:
     'This date must not contain a time portion in the CMS, it should follow ISO 8601 format: YYYY-MM-DD',
 })
+
+export const IsoTimeSchema = z.string().regex(ISO_TIME_REGEX)
 
 function isZeroTimestamp(date: Date) {
   return date.toISOString().endsWith(ZERO_TIMESTAMP)

--- a/apps/site/src/app/events/[slug]/components/ScheduleSection/EventDetails.tsx
+++ b/apps/site/src/app/events/[slug]/components/ScheduleSection/EventDetails.tsx
@@ -5,14 +5,19 @@ import { Heading } from '@/components/Heading'
 import { TagLabel } from '@/components/TagComponents/TagLabel'
 import { SmartTextLink } from '@/components/TextLink/SmartTextLink'
 
-import type { Event } from '../../../schemas/ScheduleSchema'
+import type { Event } from '@/events/types/eventType'
+
 import { formatTime } from '../../utils/dateUtils'
 
 import { Participants } from './Participants'
 
+type EventDetailsProps = NonNullable<
+  Event['schedule']
+>['days'][number]['events'][number]
+
 export function EventDetails({
-  start,
-  end,
+  startTime,
+  endTime,
   location,
   tag,
   title,
@@ -20,14 +25,14 @@ export function EventDetails({
   moderators,
   speakers,
   url,
-}: Event) {
+}: EventDetailsProps) {
   return (
     <BasicCard>
       <div className="grid gap-6 lg:grid-cols-3">
         <div className="flex gap-6 text-brand-300 lg:flex-col lg:gap-1">
           <div className="text-sm font-bold">
-            <span>{formatTime(start)}</span>
-            {end && <span> – {formatTime(end)}</span>}
+            <span>{formatTime(startTime)}</span>
+            {endTime && <span> – {formatTime(endTime)}</span>}
           </div>
           <span className="text-sm">{location}</span>
         </div>

--- a/apps/site/src/app/events/[slug]/utils/dateUtils.ts
+++ b/apps/site/src/app/events/[slug]/utils/dateUtils.ts
@@ -3,6 +3,8 @@ import { format } from 'date-fns'
 
 import { formatDate } from '@/utils/dateUtils'
 
+import { ISO_TIME_REGEX } from '@/schemas/DateTimeSchema'
+
 const PLACEHOLDER_DATE = '1970-01-01'
 
 export function formatShortDate(date: Date) {
@@ -10,14 +12,16 @@ export function formatShortDate(date: Date) {
 }
 
 export function formatTime(isoTimeString: string) {
-  const utcTime = createComparableTimeUTC(isoTimeString)
+  const utcTime = createUTCDateFromTime(isoTimeString)
   const formattedTime = format(utcTime, 'h:mma')
   return formattedTime.replace(/(am|pm)/i, ' $1')
 }
 
-export function createComparableTimeUTC(isoTimeString: string) {
-  if (!isoTimeString.endsWith('Z')) {
-    throw new Error('ISO time string must end with Z')
+export function createUTCDateFromTime(isoTimeString: string) {
+  const isISOString = ISO_TIME_REGEX.test(isoTimeString)
+
+  if (!isISOString) {
+    throw new Error('isoTimeString does not match the right format')
   }
 
   return new UTCDate(`${PLACEHOLDER_DATE}T${isoTimeString}`)

--- a/apps/site/src/app/events/[slug]/utils/dateUtils.ts
+++ b/apps/site/src/app/events/[slug]/utils/dateUtils.ts
@@ -3,12 +3,22 @@ import { format } from 'date-fns'
 
 import { formatDate } from '@/utils/dateUtils'
 
+const PLACEHOLDER_DATE = '1970-01-01'
+
 export function formatShortDate(date: Date) {
   return formatDate(date, 'EEE, MMM d')
 }
 
-export function formatTime(date: Date) {
-  const utcDate = new UTCDate(date)
-  const formattedTime = format(utcDate, 'h:mma')
+export function formatTime(isoTimeString: string) {
+  const utcTime = createComparableTimeUTC(isoTimeString)
+  const formattedTime = format(utcTime, 'h:mma')
   return formattedTime.replace(/(am|pm)/i, ' $1')
+}
+
+export function createComparableTimeUTC(isoTimeString: string) {
+  if (!isoTimeString.endsWith('Z')) {
+    throw new Error('ISO time string must end with Z')
+  }
+
+  return new UTCDate(`${PLACEHOLDER_DATE}T${isoTimeString}`)
 }

--- a/apps/site/src/app/events/[slug]/utils/filterAndSortScheduleDays.ts
+++ b/apps/site/src/app/events/[slug]/utils/filterAndSortScheduleDays.ts
@@ -2,7 +2,7 @@ import { compareAsc } from 'date-fns'
 
 import type { Event } from '../../types/eventType'
 
-import { createComparableTimeUTC } from './dateUtils'
+import { createUTCDateFromTime } from './dateUtils'
 
 export function filterAndSortScheduleDays(
   schedule: NonNullable<Event['schedule']>,
@@ -12,8 +12,8 @@ export function filterAndSortScheduleDays(
   const daysWithEventsSortedByTime = daysWithEvents.map((day) => ({
     ...day,
     events: day.events.toSorted((a, b) => {
-      const timeA = createComparableTimeUTC(a.startTime)
-      const timeB = createComparableTimeUTC(b.startTime)
+      const timeA = createUTCDateFromTime(a.startTime)
+      const timeB = createUTCDateFromTime(b.startTime)
       return compareAsc(timeA, timeB)
     }),
   }))

--- a/apps/site/src/app/events/[slug]/utils/filterAndSortScheduleDays.ts
+++ b/apps/site/src/app/events/[slug]/utils/filterAndSortScheduleDays.ts
@@ -1,7 +1,8 @@
-import { UTCDate } from '@date-fns/utc'
 import { compareAsc } from 'date-fns'
 
 import type { Event } from '../../types/eventType'
+
+import { createComparableTimeUTC } from './dateUtils'
 
 export function filterAndSortScheduleDays(
   schedule: NonNullable<Event['schedule']>,
@@ -11,9 +12,9 @@ export function filterAndSortScheduleDays(
   const daysWithEventsSortedByTime = daysWithEvents.map((day) => ({
     ...day,
     events: day.events.toSorted((a, b) => {
-      const startA = new UTCDate(a.start)
-      const startB = new UTCDate(b.start)
-      return compareAsc(startA, startB)
+      const timeA = createComparableTimeUTC(a.startTime)
+      const timeB = createComparableTimeUTC(b.startTime)
+      return compareAsc(timeA, timeB)
     }),
   }))
 

--- a/apps/site/src/app/events/schemas/ScheduleSchema.ts
+++ b/apps/site/src/app/events/schemas/ScheduleSchema.ts
@@ -1,6 +1,6 @@
 import { z } from 'zod'
 
-import { IsoDateSchema } from '@/schemas/DateTimeSchema'
+import { IsoDateSchema, IsoTimeSchema } from '@/schemas/DateTimeSchema'
 
 const ParticipantSchema = z
   .object({
@@ -16,8 +16,8 @@ const EventSchema = z
     description: z.string().optional(),
     moderators: z.array(ParticipantSchema).nonempty().optional(),
     speakers: z.array(ParticipantSchema).nonempty().optional(),
-    start: z.coerce.date(),
-    end: z.coerce.date().optional(),
+    'start-time': IsoTimeSchema,
+    'end-time': IsoTimeSchema.optional(),
     location: z.string(),
     url: z.string().url().optional(),
   })

--- a/apps/site/src/app/events/schemas/ScheduleSchema.ts
+++ b/apps/site/src/app/events/schemas/ScheduleSchema.ts
@@ -40,4 +40,3 @@ export const ScheduleSchema = z
 
 export type Event = z.infer<typeof EventSchema>
 export type Participant = z.infer<typeof ParticipantSchema>
-export type Schedule = z.infer<typeof ScheduleSchema>

--- a/apps/site/src/content/events/davos.md
+++ b/apps/site/src/content/events/davos.md
@@ -71,7 +71,7 @@ schedule:
   title: Speaking Engagements
   days:
     - events:
-        - start: 2025-01-20T15:50:00.000Z
+        - start-time: 15:50:00.000Z
           url: https://www.gbbc.io/events/save-the-date-8th-annual-blockchain-central-davos
           speakers:
             - name: Marta Belcher
@@ -85,7 +85,7 @@ schedule:
           location: Promenade 89, 7270 Davos, Switzerland
           title: Marta Belcher at GBBC’s 8th Annual Blockchain Central Davos
           tag: Registration Needed
-          end: 2025-01-20T16:25:00.000Z
+          end-time: 16:25:00.000Z
           description: What is Crypto Good For?
       date: 2025-01-20
     - date: 2025-01-21
@@ -97,8 +97,8 @@ schedule:
             Financial Inclusion"
           url: "https://thefemalequotient.equalitylounge.com/davos25/ "
           location: Promenade 40 7270 Davos Platz, Switzerland
-          start: 2025-01-21T11:30:00.000Z
-          end: 2025-01-21T12:00:00.000Z
+          start-time: 11:30:00.000Z
+          end-time: 12:00:00.000Z
           speakers:
             - name: Rachel Horn
               company: FF
@@ -111,7 +111,7 @@ schedule:
         - tag: Registration Needed
           title: Porter Stowell at Web3 Investor Gathering
           location: Hotel Seehof
-          start: 2025-01-21T12:10:00.000Z
+          start-time: 12:10:00.000Z
           description: "Foundations of the Future: Blockchain Infrastructure for
             Enterprise Adoption"
           speakers:
@@ -125,11 +125,11 @@ schedule:
               company: Circle
             - name: Annelise Osborne
               company: Kadena
-          end: 2025-01-21T12:40:00.000Z
+          end-time: 12:40:00.000Z
         - tag: Registration Needed
           title: Marta Belcher at Davos Decentralized AI Salon
           description: Why the Future of AI Depends on Decentralized Storage
-          start: 2025-01-21T14:54:00.000Z
+          start-time: 14:54:00.000Z
           location: Promenade 89, 7270 Davos, Switzerland
           url: https://lu.ma/so88195w
           speakers:
@@ -137,7 +137,7 @@ schedule:
               company: FF
             - name: Michael Casey
               company: Decentralized AI Society
-          end: 2025-01-21T15:07:00.000Z
+          end-time: 15:07:00.000Z
         - tag: Registration Needed
           title: Clara Tsao at EmTech Invest 2025
           description: The Future of Blockchain in the Quantum Era
@@ -152,16 +152,16 @@ schedule:
               company: BTC OS
             - name: Kapil Dhiman
               company: Quranium
-          start: 2025-01-21T14:50:00.000Z
-          end: 2025-01-21T15:20:00.000Z
+          start-time: 14:50:00.000Z
+          end-time: 15:20:00.000Z
           location: Promenade 89, 7270 Davos, Switzerland
           url: https://emtech2024.com/
         - tag: Registration Needed
           title: Marta Belcher at Future House
           description: "Fixing the System: How Decentralization Can Upgrade the Internet"
           location: Hotel Europe, 63 Promenade, Davos, GR 7270
-          start: 2025-01-21T17:30:00.000Z
-          end: 2025-01-21T18:00:00.000Z
+          start-time: 17:30:00.000Z
+          end-time: 18:00:00.000Z
           url: https://futurehousedavos.io/
           speakers:
             - name: Marta Belcher
@@ -176,31 +176,31 @@ schedule:
         - tag: Registration Needed
           title: Megan Klimen at Digital Davos
           description: "The Decentralized Web: Infrastructure, Data, and Governance"
-          start: 2025-01-22T10:00:00.000Z
-          end: 2025-01-22T10:45:00.000Z
+          start-time: 10:00:00.000Z
+          end-time: 10:45:00.000Z
           location: TBA
         - tag: Registration Needed
           title: Clara Tsao at Digital Davos
           description: AI, Security, and the Decentralized Web
-          start: 2025-01-22T10:00:00.000Z
-          end: 2025-01-22T10:45:00.000Z
+          start-time: 10:00:00.000Z
+          end-time: 10:45:00.000Z
           location: TBA
         - tag: Registration Needed
           title: Porter Stowell at Digital Davos
           description: "Decentralized Storage: Bridging Innovation and User Experience"
-          start: 2025-01-22T11:00:00.000Z
-          end: 2025-01-22T11:45:00.000Z
+          start-time: 11:00:00.000Z
+          end-time: 11:45:00.000Z
           location: Davos, Switzerland
         - tag: Registration Needed
           title: Danny O’Brien at Digital Davos
           description: "Community and Inclusion: Building the Next Web"
-          start: 2025-01-22T14:00:00.000Z
-          end: 2025-01-22T14:45:00.000Z
+          start-time: 14:00:00.000Z
+          end-time: 14:45:00.000Z
           location: Davos, Switzerland
         - tag: Registration Needed
           title: Megan Klimen at Web3 Hub Davos
           url: https://web3hubdavos.com/
-          start: 2025-01-22T16:45:00.000Z
+          start-time: 16:45:00.000Z
           location: Ob. Str. 33, 7270 Davos Platz, Switzerland
           description:
             "Emerging Macro Trends in DePIN: Disruptive Solutions to Global
@@ -216,7 +216,7 @@ schedule:
               company: very early Ventures
             - name: Daniel Ammann
               company: Onocoy Association
-          end: 2025-01-22T17:15:00.000Z
+          end-time: 17:15:00.000Z
       date: 2025-01-22
     - date: 2025-01-24
       events:
@@ -225,7 +225,7 @@ schedule:
           description:
             How Women Are Shaping Global Innovation in Tech, Sustainability,
             and Start-Ups
-          start: 2025-01-24T12:00:00.000Z
+          start-time: 12:00:00.000Z
           location: Promenade 67 and 73
           url: https://www.investindia.gov.in/davos
   kicker: Don't miss out

--- a/apps/site/src/content/events/fil-bangkok-2024.md
+++ b/apps/site/src/content/events/fil-bangkok-2024.md
@@ -90,8 +90,8 @@ schedule:
             network, knowledge, and opportunities within the Filecoin ecosystem.
             From November 6th to 8th, this space is perfect for co-working,
             meetings, and more! ​FIL Dev Summit is a gathering of developers, builders, and engaged community members who want to contribute to the core protocol and network evolution of Filecoin. The summit is a place for meaningful and impactful conversations that help push Filecoin forward (separate registration required). ​Filecoin Studio is a state-of-the-art content creation hub offering professional-grade equipment and space for rent to record content that elevates your vision. Book your session.
-          start: 2024-11-06T11:00:00.000Z
-          end: 2024-11-06T18:30:00.000Z
+          start-time: 11:00:00.000Z
+          end-time: 18:30:00.000Z
           location: Gaysorn Urban Resort
           url: https://lu.ma/no08u3bt
         - title: FIL Dev Summit 5
@@ -103,8 +103,8 @@ schedule:
             impactful conversations that help push Filecoin forward.
 
             Find the full agenda at fildev.io/FDS-5.
-          start: 2024-11-06T11:00:00.000Z
-          end: 2024-11-06T20:00:00.000Z
+          start-time: 11:00:00.000Z
+          end-time: 20:00:00.000Z
           location: Gaysorn Urban Resort
           url: https://www.fildev.io/FDS-5
       date: 2024-11-06
@@ -117,8 +117,8 @@ schedule:
             network, knowledge, and opportunities within the Filecoin ecosystem.
             From November 6th to 8th, this space is perfect for co-working,
             meetings, and more! ​FIL Dev Summit is a gathering of developers, builders, and engaged community members who want to contribute to the core protocol and network evolution of Filecoin. The summit is a place for meaningful and impactful conversations that help push Filecoin forward (separate registration required). ​Filecoin Studio is a state-of-the-art content creation hub offering professional-grade equipment and space for rent to record content that elevates your vision. Book your session.
-          start: 2024-11-07T09:00:00.000Z
-          end: 2024-11-07T18:30:00.000Z
+          start-time: 09:00:00.000Z
+          end-time: 18:30:00.000Z
           location: Gaysorn Urban Resort
           url: https://lu.ma/no08u3bt
         - title: FIL Dev Summit 5
@@ -132,8 +132,8 @@ schedule:
             Find the full agenda at fildev.io/FDS-5.
           url: https://fildev.io/FDS-5
           location: Gaysorn Urban Resort
-          start: 2024-11-07T09:00:00.000Z
-          end: 2024-11-07T18:30:00.000Z
+          start-time: 09:00:00.000Z
+          end-time: 18:30:00.000Z
     - date: 2024-11-08
       events:
         - title: FIL Bangkok Co-Working Space
@@ -143,8 +143,8 @@ schedule:
             network, knowledge, and opportunities within the Filecoin ecosystem.
             From November 6th to 8th, this space is perfect for co-working,
             meetings, and more! ​FIL Dev Summit is a gathering of developers, builders, and engaged community members who want to contribute to the core protocol and network evolution of Filecoin. The summit is a place for meaningful and impactful conversations that help push Filecoin forward (separate registration required). ​Filecoin Studio is a state-of-the-art content creation hub offering professional-grade equipment and space for rent to record content that elevates your vision. Book your session.
-          start: 2024-11-08T09:00:00.000Z
-          end: 2024-11-08T18:00:00.000Z
+          start-time: 09:00:00.000Z
+          end-time: 18:00:00.000Z
           location: Gaysorn Urban Resort
           url: https://lu.ma/no08u3bt
         - title: FIL Dev Summit 5
@@ -158,22 +158,22 @@ schedule:
             Find the full agenda at fildev.io/FDS-5.
           url: https://fildev.io/FDS-5
           location: Gaysorn Urban Resort
-          start: 2024-11-08T09:00:00.000Z
-          end: 2024-11-08T20:00:00.000Z
+          start-time: 09:00:00.000Z
+          end-time: 20:00:00.000Z
     - events:
         - title: Doors Open
           description:
             "Welcome to FIL Bangkok: DePIN Meets AI! Doors open at 9AM with
             Thai milk teas and networking. Come check out our sponsor booths and
             massage stations!"
-          start: 2024-11-11T09:00:00.000Z
+          start-time: 09:00:00.000Z
           location: Samyan Mitrtown
         - title: "Where DePIN Meets AI: A Filecoin Ecosystem Survey"
           speakers:
             - name: Clara Tsao
               company: Filecoin Foundation
-          start: 2024-11-11T15:02:00.000Z
-          end: 2024-11-11T15:12:00.000Z
+          start-time: 15:02:00.000Z
+          end-time: 15:12:00.000Z
           location: "Samyan Mitrtown: Main Hall"
           description:
             In the realms of DePIN and AI, storage isn’t the endgame — it’s
@@ -187,8 +187,8 @@ schedule:
           speakers:
             - name: Sherry Chung
               company: Numbers Protocol
-          start: 2024-11-11T15:30:00.000Z
-          end: 2024-11-11T15:37:00.000Z
+          start-time: 15:30:00.000Z
+          end-time: 15:37:00.000Z
           location: "Samyan Mitrtown: Main Hall"
           description:
             In a historic year of global elections, billions of voters face the
@@ -201,8 +201,8 @@ schedule:
           speakers:
             - name: Ted Liao
               company: Glitter Protocol
-          start: 2024-11-11T15:38:00.000Z
-          end: 2024-11-11T15:45:00.000Z
+          start-time: 15:38:00.000Z
+          end-time: 15:45:00.000Z
           location: "Samyan Mitrtown: Main Hall"
           description:
             Ethereum’s future lies in expanding beyond financial use cases by
@@ -216,8 +216,8 @@ schedule:
           speakers:
             - name: Stefaan Vervaet
               company: Akave.ai
-          start: 2024-11-11T15:46:00.000Z
-          end: 2024-11-11T15:53:00.000Z
+          start-time: 15:46:00.000Z
+          end-time: 15:53:00.000Z
           location: "Samyan Mitrtown: Main Hall"
           description:
             Meet a data onboarding solution making it easier than ever for
@@ -234,8 +234,8 @@ schedule:
             - name: "Hannah Howard"
               company: "Storacha"
           location: "Samyan Mitrtown: Main Hall"
-          start: 2024-11-11T16:17:00.000Z
-          end: 2024-11-11T16:31:00.000Z
+          start-time: 16:17:00.000Z
+          end-time: 16:31:00.000Z
           description:
             Find out how Storacha is adding spice to the Filecoin network by
             unlocking hot object storage and making it easy to onboard small or
@@ -244,8 +244,8 @@ schedule:
           speakers:
             - name: Marta Belcher
               company: Filecoin Foundation
-          start: 2024-11-11T16:40:00.000Z
-          end: 2024-11-11T16:55:00.000Z
+          start-time: 16:40:00.000Z
+          end-time: 16:55:00.000Z
           location: "Samyan Mitrtown: Main Hall"
           moderators:
             - name: Leah Callon-Butler
@@ -257,8 +257,8 @@ schedule:
           speakers:
             - name: Roman
               company: GhostDrive
-          start: 2024-11-11T15:13:00.000Z
-          end: 2024-11-11T15:20:00.000Z
+          start-time: 15:13:00.000Z
+          end-time: 15:20:00.000Z
           location: "Samyan Mitrtown: Main Hall"
           description:
             "With AI-generated content expected to represent 90% of online data
@@ -278,8 +278,8 @@ schedule:
               company: Devonian
             - name: David Dao
               company: GainForest
-          start: 2024-11-11T12:00:00.000Z
-          end: 2024-11-11T12:30:00.000Z
+          start-time: 12:00:00.000Z
+          end-time: 12:30:00.000Z
           description:
             The current system for addressing the climate crisis is inefficient
             and ineffective, with ESG metrics difficult to track and valuable
@@ -289,8 +289,8 @@ schedule:
             available and authenticating energy and environmental claims,
             they’re cultivating a world where we’re accountable for our impact.
         - title: "Demo: GhostDrive: An AI-Enabled Data Platform"
-          start: 2024-11-11T11:00:00.000Z
-          end: 2024-11-11T12:00:00.000Z
+          start-time: 11:00:00.000Z
+          end-time: 12:00:00.000Z
           location: "Samyan Mitrtown: Main Hall"
           description:
             Join the GhostDrive team for a hands-on demo of their Web3 data
@@ -323,8 +323,8 @@ schedule:
             - name: Jaden Yan
               company: Aethir
           location: "Samyan Mitrtown: Main Hall"
-          start: 2024-11-11T14:00:00.000Z
-          end: 1904-11-11T14:30:00.000Z
+          start-time: 14:00:00.000Z
+          end-time: 14:30:00.000Z
         - title: "Sponsor Content: Driving Onchain Activity with a FIL-Backed Stablecoin"
           description:
             Backed by FIL, USDFC is more than just a stablecoin. It’s a
@@ -336,8 +336,8 @@ schedule:
           speakers:
             - name: Masa Kikuchi
               company: "Secured Finance"
-          start: 2024-11-11T16:32:00.000Z
-          end: 2024-11-11T16:39:00.000Z
+          start-time: 16:32:00.000Z
+          end-time: 16:39:00.000Z
           location: "Samyan Mitrtown: Main Hall"
         - title:
             "From Milestones to Moonshots: A 2024 Filecoin Network Retrospective and
@@ -351,8 +351,8 @@ schedule:
           speakers:
             - name: Molly Mackinlay
               company: FilOZ
-          start: 2024-11-11T15:55:00.000Z
-          end: 2024-11-11T16:15:00.000Z
+          start-time: 15:55:00.000Z
+          end-time: 16:15:00.000Z
           location: "Samyan Mitrtown: Main Hall"
         - title:
             "Sponsor Content: Building AI Agents in the Era of DePIN: Ensuring Trust
@@ -369,8 +369,8 @@ schedule:
           speakers:
             - name: Patrick Kearney
               company: Fleek
-          start: 2024-11-11T14:47:00.000Z
-          end: 2024-11-11T15:00:00.000Z
+          start-time: 14:47:00.000Z
+          end-time: 15:00:00.000Z
           location: "Samyan Mitrtown: Main Hall"
         - title:
             "Sponsored Content: Revolutionizing Healthcare Data Sovereignty:
@@ -381,12 +381,12 @@ schedule:
           speakers:
             - name: Ethan Chae
               company: Hippocrat
-          start: 2024-11-11T14:34:00.000Z
-          end: 2024-11-11T14:46:00.000Z
+          start-time: 14:34:00.000Z
+          end-time: 14:46:00.000Z
           location: "Samyan Mitrtown: Main Hall"
         - title: Lunch
-          start: 2024-11-11T12:30:00.000Z
-          end: 2024-11-11T14:00:00.000Z
+          start-time: 12:30:00.000Z
+          end-time: 14:00:00.000Z
           location: Samyan Mitrtown
         - title: "Fireside Chat: Juan Benet on DePIN and AI"
           description:
@@ -401,12 +401,12 @@ schedule:
               company: Protocol Labs
             - name: Jonathan Victor
               company: Ansa Research
-          start: 2024-11-11T17:30:00.000Z
-          end: 2024-11-11T18:00:00.000Z
+          start-time: 17:30:00.000Z
+          end-time: 18:00:00.000Z
           location: "Samyan Mitrtown: Main Hall"
         - title: The Role of People in Our DePIN Future
-          start: 2024-11-11T15:21:00.000Z
-          end: 2024-11-11T15:29:00.000Z
+          start-time: 15:21:00.000Z
+          end-time: 15:29:00.000Z
           location: "Samyan Mitrtown: Main Hall"
           speakers:
             - name: Konstantin Tkachuk
@@ -427,12 +427,12 @@ schedule:
           speakers:
             - company: Huddle01
               name: Ayush Ranjan
-          start: 2024-11-11T17:15:00.000Z
-          end: 2024-11-11T17:30:00.000Z
+          start-time: 17:15:00.000Z
+          end-time: 17:30:00.000Z
           location: "Samyan Mitrtown: Main Hall"
         - location: "Samyan Mitrtown: Main Hall"
-          start: 2024-11-11T17:00:00.000Z
-          end: 2024-11-11T17:15:00.000Z
+          start-time: 17:00:00.000Z
+          end-time: 17:15:00.000Z
           title:
             " Calling All Developers: What to Build on Filecoin and How to Start
             Today"

--- a/apps/site/src/content/events/filecoin-consensus-hong-kong.md
+++ b/apps/site/src/content/events/filecoin-consensus-hong-kong.md
@@ -34,7 +34,7 @@ schedule:
           speakers:
             - name: Clara Tsao
               company: Filecoin Foundation
-          start: 2025-02-19T15:30:00.000Z
+          start-time: 15:30:00.000Z
           location: Hashkey Capital Headquarters
           url: https://lu.ma/deaisummitHK
       date: 2025-02-19
@@ -45,7 +45,7 @@ schedule:
           speakers:
             - name: Clara Tsao
               company: Filecoin Foundation
-          start: 2025-02-20T10:50:00.000Z
+          start-time: 10:50:00.000Z
           location: Hong Kong Convention & Exhibition Centre
           url: https://consensus-hongkong2025.coindesk.com/
         - tag: Registration Needed
@@ -53,7 +53,7 @@ schedule:
           speakers:
             - name: Clara Tsao
               company: Filecoin Foundation
-          start: 2025-02-20T10:00:00.000Z
+          start-time: 10:00:00.000Z
           location: Renaissance Hong Kong Harbour View Hotel
           url: https://lu.ma/hack_hk
       date: 2025-02-20
@@ -66,7 +66,7 @@ schedule:
           speakers:
             - name: Clara Tsao
               company: Filecoin Foundation
-          start: 2025-02-21T13:05:00.000Z
+          start-time: 13:05:00.000Z
           location: Cardinal Point
           url: https://lu.ma/hcge9jg4
       date: 2025-02-21


### PR DESCRIPTION
## 📝 Description

This PR updates the event's schedule's `start` & `end` fields by removing the date portion. This will improve the CMS UX for the content team, standardize the data, and clarify things for us.

> [!NOTE]
> Times are now parsed as strings, and only converted to Date instance when needed, for comparison or formatting for example.

## 🛠️ Key Changes

- Updates `config.yml` with new `time_iso_format` format
- Renames `start` to `start-time` and `end` to `end-time`
- Adds `IsoTimeSchema`
- Updates Markdown entries accordingly

## 🧪 How to Test

Run the CMS locally, create an event and ensure the `start-time` and `end-time` fields are only times, not dates:
`Event > Schedule > Day > Event`

## 📸 Screenshots

![CleanShot 2025-02-19 at 11 46 16@2x](https://github.com/user-attachments/assets/5937febe-99b5-46b2-9871-ffc167dc9194)


## 🔖 Resources

https://decapcms.org/docs/widgets/datetime/