### PR TITLE
[FFDW][UXIT-2218] Include Meta Title and Description to pages [skip percy]

### DIFF
--- a/apps/ffdweb-site/src/app/(homepage)/page.tsx
+++ b/apps/ffdweb-site/src/app/(homepage)/page.tsx
@@ -1,3 +1,5 @@
+import type { Metadata } from 'next'
+
 export default function Home() {
   return (
     <>
@@ -103,4 +105,10 @@ export default function Home() {
       </section>
     </>
   )
+}
+
+export const metadata: Metadata = {
+  title: 'FFDW | Rebuilding the Internet for Good',
+  description:
+    'Filecoin Foundation for the Decentralized Web is a nonprofit organization committed to preserving humanity’s most important information by funding the development of open-source tools',
 }

--- a/apps/ffdweb-site/src/app/about/page.tsx
+++ b/apps/ffdweb-site/src/app/about/page.tsx
@@ -1,3 +1,5 @@
+import type { Metadata } from 'next'
+
 export default function About() {
   return (
     <>
@@ -134,4 +136,10 @@ export default function About() {
       </section>
     </>
   )
+}
+
+export const metadata: Metadata = {
+  title: 'About FFDW | Building and Supporting the Decentralized Community',
+  description:
+    'Discover how Filecoin Foundation for the Decentralized Web (FFDW) accelerates open, decentralized technologies and safeguards vital data. Learn about our mission to empower communities, preserve cultural knowledge, and shape a fairer, more resilient internet for everyone.',
 }

--- a/apps/ffdweb-site/src/app/blog/[slug]/page.tsx
+++ b/apps/ffdweb-site/src/app/blog/[slug]/page.tsx
@@ -1,3 +1,5 @@
+import type { Metadata } from 'next'
+
 export default function BlogPost() {
   return (
     <>
@@ -8,4 +10,9 @@ export default function BlogPost() {
       </article>
     </>
   )
+}
+
+export const metadata: Metadata = {
+  title: '', // [Headline of Blog] | FFDW
+  description: '', // [Blog Standfirst]
 }

--- a/apps/ffdweb-site/src/app/blog/page.tsx
+++ b/apps/ffdweb-site/src/app/blog/page.tsx
@@ -1,3 +1,5 @@
+import type { Metadata } from 'next'
+
 export default function Blog() {
   return (
     <>
@@ -10,4 +12,10 @@ export default function Blog() {
       </section>
     </>
   )
+}
+
+export const metadata: Metadata = {
+  title: 'FFDW Blog | Latest Web3 Insights & Updates',
+  description:
+    'Stay informed on the newest advancements in decentralized tech, human rights data preservation, and social impact. Discover fresh perspectives from FFDW.',
 }

--- a/apps/ffdweb-site/src/app/digest/[slug]/page.tsx
+++ b/apps/ffdweb-site/src/app/digest/[slug]/page.tsx
@@ -1,3 +1,4 @@
+import type { Metadata } from 'next'
 export default function DigestArticle() {
   return (
     <>
@@ -8,4 +9,9 @@ export default function DigestArticle() {
       </article>
     </>
   )
+}
+
+export const metadata: Metadata = {
+  title: '', // [Headline of Article] | FFDW
+  description: '', // [Article Standfirst]
 }

--- a/apps/ffdweb-site/src/app/digest/page.tsx
+++ b/apps/ffdweb-site/src/app/digest/page.tsx
@@ -1,3 +1,5 @@
+import type { Metadata } from 'next'
+
 export default function Digest() {
   return (
     <>
@@ -17,4 +19,10 @@ export default function Digest() {
       </section>
     </>
   )
+}
+
+export const metadata: Metadata = {
+  title: 'FFDW DWeb Digest | In-Depth Exploration of the Decentralized Web',
+  description:
+    'Explore FFDW DWeb Digest for expert insights on cognitive liberty, privacy, and crypto policy. Discover the evolving landscape of digital autonomy and blockchain.',
 }

--- a/apps/ffdweb-site/src/app/faqs/page.tsx
+++ b/apps/ffdweb-site/src/app/faqs/page.tsx
@@ -1,3 +1,4 @@
+import type { Metadata } from 'next'
 export default function FAQ() {
   return (
     <>
@@ -107,4 +108,10 @@ export default function FAQ() {
       </section>
     </>
   )
+}
+
+export const metadata: Metadata = {
+  title: 'FFDW FAQs | Answers About Our Mission & the Decentralized Web',
+  description:
+    'Discover how FFDW supports open, decentralized tech, funds projects, and fosters a resilient internet. Get quick answers to your pressing questions.',
 }

--- a/apps/ffdweb-site/src/app/learning-resources/page.tsx
+++ b/apps/ffdweb-site/src/app/learning-resources/page.tsx
@@ -1,3 +1,5 @@
+import type { Metadata } from 'next'
+
 export default function LearningResources() {
   return (
     <>
@@ -13,4 +15,10 @@ export default function LearningResources() {
       </section>
     </>
   )
+}
+
+export const metadata: Metadata = {
+  title: 'FFDW Learning Resources | Decentralized Tech & Social Impact',
+  description:
+    'Discover case studies, tutorials, and tools on decentralized technologies driving social change. Learn, share, and help shape the future with FFDW.',
 }

--- a/apps/ffdweb-site/src/app/projects/[slug]/page.tsx
+++ b/apps/ffdweb-site/src/app/projects/[slug]/page.tsx
@@ -1,3 +1,5 @@
+import type { Metadata } from 'next'
+
 export default function Project() {
   return (
     <>
@@ -21,4 +23,9 @@ export default function Project() {
       </div>
     </>
   )
+}
+
+export const metadata: Metadata = {
+  title: '', // [Name of Project] | FFDW
+  description: '', //[Description of project]
 }

--- a/apps/ffdweb-site/src/app/projects/page.tsx
+++ b/apps/ffdweb-site/src/app/projects/page.tsx
@@ -1,3 +1,5 @@
+import type { Metadata } from 'next'
+
 export default function Projects() {
   return (
     <>
@@ -13,4 +15,10 @@ export default function Projects() {
       </section>
     </>
   )
+}
+
+export const metadata: Metadata = {
+  title: 'FFDW Projects | Explore Partnerships Advancing the Decentralized Web',
+  description:
+    'Explore how FFDW collaborates with nonprofits to build open-source solutions, preserve vital data, and shape a decentralized internet. See our partners in action.',
 }


### PR DESCRIPTION
## 📝 Description

This PR adds metadata (title and description) to various pages of the FFDW website using Next.js `Metadata` type. This improves SEO and enhances the visibility of pages by providing relevant descriptions in search engine results.

- **Type:** New feature

## 🛠️ Key Changes

- Added `Metadata` type import from Next.js to multiple pages.
- Defined `title` and `description` metadata for:
  - Homepage
  - About page
  - Blog listing and individual blog posts
  - Digest listing and individual digest articles
  - FAQs page
  - Learning Resources page
  - Projects listing and individual project pages
- Used placeholders (`''`) for dynamically generated titles in blog posts, digest articles, and projects.

## 🧪 How to Test

- **Setup:** Ensure the Next.js project is running locally (`npm run dev`).
- **Steps to Test:**
  1. Navigate to different pages (`/`, `/about`, `/blog`, etc.).
  2. Inspect the page metadata in the browser's DevTools (`Elements` tab → `<head>` section).
  3. Verify that each page has the correct `title` and `description` values.
- **Expected Results:** 
  - Each page should have a meaningful title and description in the `<head>` section.
  - No errors related to missing metadata should be present.

## 🔖 Resources

- [Next.js Metadata Documentation](https://nextjs.org/docs/app/api-reference/functions/generate-metadata)
- [SEO Best Practices for Metadata](https://moz.com/learn/seo/title-tag)