### PR TITLE
[UXIT-2095] Create an Image Sitemap from public assets folder

### DIFF
--- a/apps/ff-site/src/app/sitemap.ts
+++ b/apps/ff-site/src/app/sitemap.ts
@@ -79,6 +79,6 @@ function extractAssetImagesFromContent(content: GenericEntryData['content']) {
   if (!content) return []
 
   const assetImageMarkdownRegex = /!\[.*?\]\((assets\/images\/.*?)\)/g
-  const assetImageMatches = [...content.matchAll(assetImageMarkdownRegex)]
+  const assetImageMatches = content.matchAll(assetImageMarkdownRegex)
   return assetImageMatches.map((match) => match[1])
 }


### PR DESCRIPTION
## 📝 Description

This PR adds image entries to the sitemap, enriching SEO by making image assets discoverable by search engines.

- **Type:** New feature

## 🧪 How to Test

  1. Open `localhost:3000/sitemap.xml`
  2. Verify that image URLs are properly included in the sitemap.xml
  3. Validate the sitemap structure using a [sitemap validation tool](https://www.xml-sitemaps.com/validate-xml-sitemap.html)

## 📸 Screenshots

<img width="1014" alt="Screenshot 2025-02-24 at 09 51 16" src="https://github.com/user-attachments/assets/76acf4c8-a9f5-4992-834b-1f17671d45e4" />

## 🔖 Resources

- [Nextjs Docs](https://nextjs.org/docs/app/api-reference/file-conventions/metadata/sitemap)
- [Google Developer Docs](https://developers.google.com/search/docs/crawling-indexing/sitemaps/image-sitemaps)

