### PR TITLE
[FF][FFDW][UXIT-2244] Move TextLink components to shared UI library [skip percy]

### DIFF
--- a/apps/ff-site/src/app/_components/Footer.tsx
+++ b/apps/ff-site/src/app/_components/Footer.tsx
@@ -1,10 +1,12 @@
+import { ExternalTextLink } from '@filecoin-foundation/ui/TextLink/ExternalTextLink'
+import { SmartTextLink } from '@filecoin-foundation/ui/TextLink/SmartTextLink'
+
 import { footerNavigationItems } from '@/constants/navigation'
+import { BASE_DOMAIN } from '@/constants/siteMetadata'
 
 import { Logo } from '@/components/Logo'
 import { NewsletterForm } from '@/components/NewsletterForm'
 import { Social } from '@/components/Social'
-import { ExternalTextLink } from '@/components/TextLink/ExternalTextLink'
-import { SmartTextLink } from '@/components/TextLink/SmartTextLink'
 
 export function Footer() {
   return (
@@ -40,7 +42,9 @@ export function Footer() {
             <ul className="flex w-max flex-col gap-3">
               {items.map(({ href, label }) => (
                 <li key={href}>
-                  <SmartTextLink href={href}>{label}</SmartTextLink>
+                  <SmartTextLink href={href} baseDomain={BASE_DOMAIN}>
+                    {label}
+                  </SmartTextLink>
                 </li>
               ))}
             </ul>

--- a/apps/ff-site/src/app/_components/MarkdownContent.tsx
+++ b/apps/ff-site/src/app/_components/MarkdownContent.tsx
@@ -1,5 +1,6 @@
 import Image from 'next/image'
 
+import { SmartTextLink } from '@filecoin-foundation/ui/TextLink/SmartTextLink'
 import rehypeToc, { type HtmlElementNode } from '@jsdevtools/rehype-toc'
 import * as Sentry from '@sentry/node'
 import ReactMarkdown, { type Components } from 'react-markdown'
@@ -7,11 +8,11 @@ import rehypeRaw from 'rehype-raw'
 import rehypeSlug from 'rehype-slug'
 import remarkGfm from 'remark-gfm'
 
+import { BASE_DOMAIN } from '@/constants/siteMetadata'
+
 import { graphicsData } from '@/data/graphicsData'
 
 import { buildImageSizeProp } from '@/utils/buildImageSizeProp'
-
-import { SmartTextLink } from '@/components/TextLink/SmartTextLink'
 
 type PluggableList = Parameters<typeof ReactMarkdown>[0]['rehypePlugins']
 
@@ -63,7 +64,11 @@ const MarkdownLink: Components['a'] = ({ href, children }) => {
 
     return <>{children}</>
   }
-  return <SmartTextLink href={href} className="not-prose">{children}</SmartTextLink>
+  return (
+    <SmartTextLink href={href} baseDomain={BASE_DOMAIN} className="not-prose">
+      {children}
+    </SmartTextLink>
+  )
 }
 
 const markdownComponents: Components = {

--- a/apps/ff-site/src/app/_components/Navigation/DesktopNavigation/ExternalLink.tsx
+++ b/apps/ff-site/src/app/_components/Navigation/DesktopNavigation/ExternalLink.tsx
@@ -1,8 +1,17 @@
+import type { AnchorHTMLAttributes } from 'react'
+
 import { Icon } from '@filecoin-foundation/ui/Icon'
 import { ArrowUpRight } from '@phosphor-icons/react'
 
-
-import type { LinkProps } from './SubNavItem'
+type ExternalLinkProps = Omit<
+  AnchorHTMLAttributes<HTMLAnchorElement>,
+  'children'
+> & {
+  href: string
+  label: string
+  description?: string
+  ariaLabel?: string
+}
 
 export function ExternalLink({
   href,
@@ -10,13 +19,16 @@ export function ExternalLink({
   description,
   ariaLabel,
   className,
-}: LinkProps) {
+  ...rest
+}: ExternalLinkProps) {
   return (
     <a
       aria-label={ariaLabel}
       href={href}
       rel="noopener noreferrer"
       className={className}
+      target="_blank"
+      {...rest}
     >
       <div className="inline-flex items-center gap-1">
         <p className="font-bold">{label}</p>

--- a/apps/ff-site/src/app/_components/Navigation/DesktopNavigation/ExternalLink.tsx
+++ b/apps/ff-site/src/app/_components/Navigation/DesktopNavigation/ExternalLink.tsx
@@ -18,7 +18,6 @@ export function ExternalLink({
   label,
   description,
   ariaLabel,
-  className,
   ...rest
 }: ExternalLinkProps) {
   return (
@@ -26,7 +25,6 @@ export function ExternalLink({
       aria-label={ariaLabel}
       href={href}
       rel="noopener noreferrer"
-      className={className}
       target="_blank"
       {...rest}
     >

--- a/apps/ff-site/src/app/_components/Navigation/DesktopNavigation/InternalLink.tsx
+++ b/apps/ff-site/src/app/_components/Navigation/DesktopNavigation/InternalLink.tsx
@@ -1,8 +1,18 @@
+import type { ComponentProps } from 'react'
+
 import Link from 'next/link'
 
 import type { Route } from 'next'
 
-import type { LinkProps } from './SubNavItem'
+type InternalLinkProps = Omit<
+  ComponentProps<typeof Link>,
+  'href' | 'children'
+> & {
+  href: Route
+  label: string
+  description?: string
+  ariaLabel?: string
+}
 
 export function InternalLink({
   href,
@@ -10,9 +20,10 @@ export function InternalLink({
   description,
   ariaLabel,
   className,
-}: LinkProps) {
+  ...rest
+}: InternalLinkProps) {
   return (
-    <Link href={href as Route} aria-label={ariaLabel} className={className}>
+    <Link href={href} aria-label={ariaLabel} className={className} {...rest}>
       <p className="mb-1 font-bold">{label}</p>
       {description && <p className="text-brand-300">{description}</p>}
     </Link>

--- a/apps/ff-site/src/app/_components/Navigation/DesktopNavigation/SubNavItem.tsx
+++ b/apps/ff-site/src/app/_components/Navigation/DesktopNavigation/SubNavItem.tsx
@@ -15,11 +15,6 @@ export type SubNavItemProps = {
     | 'externalSecondary'
 }
 
-export type LinkProps = Omit<SubNavItemProps, 'linkType'> & {
-  className: string
-  ariaLabel: string
-}
-
 const baseStyles = 'group w-full rounded-lg focus:brand-outline'
 const extendedStyles = {
   internal: 'inline-block bg-brand-800 p-4 hover:bg-brand-700',
@@ -35,20 +30,23 @@ export function SubNavItem({
   label,
   description,
   linkType = 'internal',
+  ...rest
 }: SubNavItemProps) {
   const external = linkType !== 'internal'
   const linkClasses = clsx(baseStyles, extendedStyles[linkType])
   const ariaLabel = `${label} page (${external ? 'external link' : 'internal link'})`
 
-  const Link = external ? ExternalLink : InternalLink
+  const commonProps = {
+    label,
+    description,
+    className: linkClasses,
+    ariaLabel,
+    ...rest,
+  }
 
-  return (
-    <Link
-      href={href}
-      label={label}
-      description={description}
-      className={linkClasses}
-      ariaLabel={ariaLabel}
-    />
-  )
+  if (external) {
+    return <ExternalLink href={href as string} {...commonProps} />
+  }
+
+  return <InternalLink href={href as Route} {...commonProps} />
 }

--- a/apps/ff-site/src/app/ecosystem-explorer/[slug]/components/Article.tsx
+++ b/apps/ff-site/src/app/ecosystem-explorer/[slug]/components/Article.tsx
@@ -4,6 +4,8 @@ import { ExternalTextLink } from '@filecoin-foundation/ui/TextLink/ExternalTextL
 import { SmartTextLink } from '@filecoin-foundation/ui/TextLink/SmartTextLink'
 import { BookOpen, GitFork, Globe, XLogo } from '@phosphor-icons/react/dist/ssr'
 
+import { BASE_DOMAIN } from '@/constants/siteMetadata'
+
 import { MarkdownContent } from '@/components/MarkdownContent'
 import { TagLabel } from '@/components/TagComponents/TagLabel'
 import { YouTubeVideoEmbed } from '@/components/YouTubeVideoEmbed'

--- a/apps/ff-site/src/app/ecosystem-explorer/[slug]/components/Article.tsx
+++ b/apps/ff-site/src/app/ecosystem-explorer/[slug]/components/Article.tsx
@@ -1,11 +1,11 @@
 import { Heading } from '@filecoin-foundation/ui/Heading'
 import { Icon } from '@filecoin-foundation/ui/Icon'
+import { ExternalTextLink } from '@filecoin-foundation/ui/TextLink/ExternalTextLink'
+import { SmartTextLink } from '@filecoin-foundation/ui/TextLink/SmartTextLink'
 import { BookOpen, GitFork, Globe, XLogo } from '@phosphor-icons/react/dist/ssr'
 
 import { MarkdownContent } from '@/components/MarkdownContent'
 import { TagLabel } from '@/components/TagComponents/TagLabel'
-import { ExternalTextLink } from '@/components/TextLink/ExternalTextLink'
-import { SmartTextLink } from '@/components/TextLink/SmartTextLink'
 import { YouTubeVideoEmbed } from '@/components/YouTubeVideoEmbed'
 
 type ArticleProps = {
@@ -50,7 +50,9 @@ export function Article({
           {website && (
             <li className="inline-flex gap-2 whitespace-nowrap text-brand-300">
               <Icon component={Globe} />
-              <SmartTextLink href={website}>Website</SmartTextLink>
+              <SmartTextLink href={website} baseDomain={BASE_DOMAIN}>
+                Website
+              </SmartTextLink>
             </li>
           )}
           {repo && (
@@ -68,7 +70,7 @@ export function Article({
           {featuredContent && (
             <li className="inline-flex gap-2 whitespace-nowrap text-brand-300">
               <Icon component={BookOpen} />
-              <SmartTextLink href={featuredContent}>
+              <SmartTextLink href={featuredContent} baseDomain={BASE_DOMAIN}>
                 Featured Content
               </SmartTextLink>
             </li>

--- a/apps/ff-site/src/app/ecosystem-explorer/[slug]/page.tsx
+++ b/apps/ff-site/src/app/ecosystem-explorer/[slug]/page.tsx
@@ -1,3 +1,5 @@
+import { ExternalTextLink } from '@filecoin-foundation/ui/TextLink/ExternalTextLink'
+
 import { type SlugParams } from '@/types/paramsTypes'
 
 import { type DynamicPathValues, PATHS } from '@/constants/paths'
@@ -13,7 +15,6 @@ import { CTASection } from '@/components/CTASection'
 import { PageLayout } from '@/components/PageLayout'
 import { ShareArticle } from '@/components/ShareArticle'
 import { StructuredDataScript } from '@/components/StructuredDataScript'
-import { ExternalTextLink } from '@/components/TextLink/ExternalTextLink'
 
 import { getEcosystemCMSCategories } from '../utils/getEcosystemCMSCategories'
 import {

--- a/apps/ff-site/src/app/ecosystem-explorer/project-form/components/EcosystemProjectForm.tsx
+++ b/apps/ff-site/src/app/ecosystem-explorer/project-form/components/EcosystemProjectForm.tsx
@@ -1,5 +1,6 @@
 'use client'
 
+import { ExternalTextLink } from '@filecoin-foundation/ui/TextLink/ExternalTextLink'
 import { Field } from '@headlessui/react'
 import { zodResolver } from '@hookform/resolvers/zod'
 import prettyBytes from 'pretty-bytes'
@@ -17,7 +18,6 @@ import { FormError } from '@/components/Form/FormError'
 import { formFieldStyle } from '@/components/Form/FormField'
 import { FormLabel } from '@/components/Form/FormLabel'
 import { type GroupedOption } from '@/components/Form/FormListboxWithGroups'
-import { ExternalTextLink } from '@/components/TextLink/ExternalTextLink'
 
 import {
   ALLOWED_IMAGE_FORMATS,

--- a/apps/ff-site/src/app/ecosystem-explorer/project-form/components/SuccessMessage.tsx
+++ b/apps/ff-site/src/app/ecosystem-explorer/project-form/components/SuccessMessage.tsx
@@ -2,13 +2,13 @@ import Link from 'next/link'
 
 import { Heading } from '@filecoin-foundation/ui/Heading'
 import { Icon } from '@filecoin-foundation/ui/Icon'
+import { ExternalTextLink } from '@filecoin-foundation/ui/TextLink/ExternalTextLink'
 import { CheckCircle } from '@phosphor-icons/react/dist/ssr'
 
 import { PATHS } from '@/constants/paths'
 import { FILECOIN_FOUNDATION_URLS } from '@/constants/siteMetadata'
 
 import { Button } from '@/components/Button'
-import { ExternalTextLink } from '@/components/TextLink/ExternalTextLink'
 
 type SuccessMessageProps = {
   prNumber: number

--- a/apps/ff-site/src/app/ecosystem-explorer/project-form/constants/projectFormDescription.tsx
+++ b/apps/ff-site/src/app/ecosystem-explorer/project-form/constants/projectFormDescription.tsx
@@ -1,8 +1,9 @@
+import { ExternalTextLink } from '@filecoin-foundation/ui/TextLink/ExternalTextLink'
+
 import { FILECOIN_FOUNDATION_URLS } from '@/constants/siteMetadata'
 
 import { extractEmailAddress } from '@/utils/extractEmailAddress'
 
-import { ExternalTextLink } from '@/components/TextLink/ExternalTextLink'
 
 export const PROJECT_FORM_DESCRIPTION = [
   <>

--- a/apps/ff-site/src/app/events/[slug]/components/ScheduleSection/EventDetails.tsx
+++ b/apps/ff-site/src/app/events/[slug]/components/ScheduleSection/EventDetails.tsx
@@ -1,10 +1,12 @@
 'use client'
 
 import { Heading } from '@filecoin-foundation/ui/Heading'
+import { SmartTextLink } from '@filecoin-foundation/ui/TextLink/SmartTextLink'
+
+import { BASE_DOMAIN } from '@/constants/siteMetadata'
 
 import { BasicCard } from '@/components/BasicCard'
 import { TagLabel } from '@/components/TagComponents/TagLabel'
-import { SmartTextLink } from '@/components/TextLink/SmartTextLink'
 
 import type { Event } from '../../../types/eventType'
 import { formatTime } from '../../utils/dateUtils'
@@ -56,7 +58,11 @@ export function EventDetails({
             )}
           </div>
 
-          {url && <SmartTextLink href={url}>View Details</SmartTextLink>}
+          {url && (
+            <SmartTextLink href={url} baseDomain={BASE_DOMAIN}>
+              View Details
+            </SmartTextLink>
+          )}
         </div>
       </div>
     </BasicCard>

--- a/apps/ff-site/src/app/filecoin-plus/data/applicationData.tsx
+++ b/apps/ff-site/src/app/filecoin-plus/data/applicationData.tsx
@@ -1,6 +1,7 @@
+import { ExternalTextLink } from '@filecoin-foundation/ui/TextLink/ExternalTextLink'
+
 import { FIL_PLUS_URLS } from '@/constants/siteMetadata'
 
-import { ExternalTextLink } from '@/components/TextLink/ExternalTextLink'
 
 export const applicationData = [
   {

--- a/apps/ff-site/src/app/filecoin-plus/page.tsx
+++ b/apps/ff-site/src/app/filecoin-plus/page.tsx
@@ -1,3 +1,5 @@
+import { ExternalTextLink } from '@filecoin-foundation/ui/TextLink/ExternalTextLink'
+
 import { PATHS } from '@/constants/paths'
 import { FIL_PLUS_URLS } from '@/constants/siteMetadata'
 
@@ -22,7 +24,6 @@ import { PageHeader } from '@/components/PageHeader'
 import { PageLayout } from '@/components/PageLayout'
 import { PageSection } from '@/components/PageSection'
 import { StructuredDataScript } from '@/components/StructuredDataScript'
-import { ExternalTextLink } from '@/components/TextLink/ExternalTextLink'
 
 import { aboutData } from './data/aboutData'
 import { applicationData } from './data/applicationData'

--- a/apps/ff-site/src/app/governance/components/CTAPageSection.tsx
+++ b/apps/ff-site/src/app/governance/components/CTAPageSection.tsx
@@ -1,7 +1,8 @@
+import { ExternalTextLink } from '@filecoin-foundation/ui/TextLink/ExternalTextLink'
+
 import { FILECOIN_FOUNDATION_URLS } from '@/constants/siteMetadata'
 
 import { CTASection } from '@/components/CTASection'
-import { ExternalTextLink } from '@/components/TextLink/ExternalTextLink'
 
 export function CTAPageSection() {
   return (

--- a/apps/ff-site/src/app/grants/data/applicationProcessData.tsx
+++ b/apps/ff-site/src/app/grants/data/applicationProcessData.tsx
@@ -1,4 +1,4 @@
-import { ExternalTextLink } from '@/components/TextLink/ExternalTextLink'
+import { ExternalTextLink } from '@filecoin-foundation/ui/TextLink/ExternalTextLink'
 
 export const applicationProcessData = [
   {

--- a/apps/ff-site/src/app/grants/data/submissionCriteriaData.tsx
+++ b/apps/ff-site/src/app/grants/data/submissionCriteriaData.tsx
@@ -1,6 +1,6 @@
+import { ExternalTextLink } from '@filecoin-foundation/ui/TextLink/ExternalTextLink'
 import { Code, BracketsAngle, Users } from '@phosphor-icons/react/dist/ssr'
 
-import { ExternalTextLink } from '@/components/TextLink/ExternalTextLink'
 
 export const submissionCriteriaData = [
   {

--- a/apps/ff-site/src/app/grants/page.tsx
+++ b/apps/ff-site/src/app/grants/page.tsx
@@ -1,3 +1,5 @@
+import { ExternalTextLink } from '@filecoin-foundation/ui/TextLink/ExternalTextLink'
+
 import { PATHS } from '@/constants/paths'
 import { FILECOIN_FOUNDATION_URLS } from '@/constants/siteMetadata'
 
@@ -18,8 +20,6 @@ import { PageHeader } from '@/components/PageHeader'
 import { PageLayout } from '@/components/PageLayout'
 import { PageSection } from '@/components/PageSection'
 import { StructuredDataScript } from '@/components/StructuredDataScript'
-import { ExternalTextLink } from '@/components/TextLink/ExternalTextLink'
-
 
 import { FeaturedGrantGraduates } from './components/FeaturedGrantGraduates'
 import { applicationProcessData } from './data/applicationProcessData'

--- a/apps/ff-site/src/app/orbit/data/ambassadorsData.tsx
+++ b/apps/ff-site/src/app/orbit/data/ambassadorsData.tsx
@@ -1,8 +1,9 @@
 import type { JSX } from 'react'
 
+import { ExternalTextLink } from '@filecoin-foundation/ui/TextLink/ExternalTextLink'
+
 import type { StaticImageProps } from '@/types/imageType'
 
-import { ExternalTextLink } from '@/components/TextLink/ExternalTextLink'
 
 import austinImg from '@/assets/orbit/ambassadors/austin-web3-filecoin-meetup.jpg'
 import barcelonaImg from '@/assets/orbit/ambassadors/barcelona-web3fc-event.jpg'

--- a/apps/ff-site/src/app/orbit/page.tsx
+++ b/apps/ff-site/src/app/orbit/page.tsx
@@ -1,3 +1,5 @@
+import { ExternalTextLink } from '@filecoin-foundation/ui/TextLink/ExternalTextLink'
+
 import type { AsyncNextServerSearchParams } from '@/types/searchParams'
 
 import { PATHS } from '@/constants/paths'
@@ -24,7 +26,6 @@ import { PageLayout } from '@/components/PageLayout'
 import { PageSection } from '@/components/PageSection'
 import { StatisticCard } from '@/components/StatisticCard'
 import { StructuredDataScript } from '@/components/StructuredDataScript'
-import { ExternalTextLink } from '@/components/TextLink/ExternalTextLink'
 
 import { OrbitEventsSection } from './components/EventsSection'
 import { ambassadorsData } from './data/ambassadorsData'

--- a/apps/ff-site/src/app/security/data/developerSupportData.tsx
+++ b/apps/ff-site/src/app/security/data/developerSupportData.tsx
@@ -1,11 +1,11 @@
 import type { IconProps } from '@filecoin-foundation/ui/Icon'
+import { ExternalTextLink } from '@filecoin-foundation/ui/TextLink/ExternalTextLink'
 import { FileText, UserCircle } from '@phosphor-icons/react/dist/ssr'
 
 import { FILECOIN_FOUNDATION_URLS } from '@/constants/siteMetadata'
 
 import { extractEmailAddress } from '@/utils/extractEmailAddress'
 
-import { ExternalTextLink } from '@/components/TextLink/ExternalTextLink'
 
 type DeveloperSupportData = {
   heading: {

--- a/apps/ff-site/src/app/security/maturity-model/components/Article.tsx
+++ b/apps/ff-site/src/app/security/maturity-model/components/Article.tsx
@@ -7,7 +7,6 @@ import { LinkSimple } from '@phosphor-icons/react/dist/ssr'
 import type { Route } from 'next'
 import { useIntersectionObserver } from 'usehooks-ts'
 
-
 import { scrollToSection } from '../utils/scrollToSection'
 import { useUrlHash } from '../utils/useUrlHash'
 

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -11,7 +11,8 @@
     "./BreakpointDebugger": "./src/BreakpointDebugger.tsx",
     "./DescriptionText": "./src/DescriptionText.tsx",
     "./Heading": "./src/Heading.tsx",
-    "./Icon": "./src/Icon.tsx"
+    "./Icon": "./src/Icon.tsx",
+    "./TextLink/*": "./src/TextLink/*.tsx"
   },
   "scripts": {
     "lint": "eslint . --fix"

--- a/packages/ui/src/BaseLink.tsx
+++ b/packages/ui/src/BaseLink.tsx
@@ -1,12 +1,12 @@
 import Link from 'next/link'
-
+import type { AnchorHTMLAttributes } from 'react'
 import { isInternalLink } from '@filecoin-foundation/utils/linkUtils'
 import type { Route } from 'next'
 
 export type BaseLinkProps = {
   href: string | Route
   baseDomain: string
-} & Omit<React.ComponentProps<'a'>, 'href'>
+} & Omit<AnchorHTMLAttributes<HTMLAnchorElement>, 'href'>
 
 export function BaseLink({ href, baseDomain, ...rest }: BaseLinkProps) {
   const isInternal = isInternalLink(href, baseDomain)

--- a/packages/ui/src/TextLink/ExternalTextLink.tsx
+++ b/packages/ui/src/TextLink/ExternalTextLink.tsx
@@ -1,7 +1,7 @@
 import { Icon } from '@filecoin-foundation/ui/Icon'
 import { ArrowUpRight } from '@phosphor-icons/react/dist/ssr'
 import { clsx } from 'clsx'
-import type { AnchorHTMLAttributes } from 'react'
+
 type ExternalTextLinkProps = React.AnchorHTMLAttributes<HTMLAnchorElement> & {
   href: string
 }

--- a/packages/ui/src/TextLink/ExternalTextLink.tsx
+++ b/packages/ui/src/TextLink/ExternalTextLink.tsx
@@ -1,10 +1,8 @@
-import { type BaseLinkProps } from '@filecoin-foundation/ui/BaseLink'
 import { Icon } from '@filecoin-foundation/ui/Icon'
 import { ArrowUpRight } from '@phosphor-icons/react/dist/ssr'
 import { clsx } from 'clsx'
-
-
-type ExternalLinkProps = Omit<BaseLinkProps, 'href' | 'baseDomain'> & {
+import type { AnchorHTMLAttributes } from 'react'
+type ExternalTextLinkProps = React.AnchorHTMLAttributes<HTMLAnchorElement> & {
   href: string
 }
 
@@ -12,7 +10,7 @@ export function ExternalTextLink({
   className,
   children,
   ...rest
-}: ExternalLinkProps) {
+}: ExternalTextLinkProps) {
   return (
     <a
       className={clsx('text-link inline-block text-pretty', className)}

--- a/packages/ui/src/TextLink/InternalTextLink.tsx
+++ b/packages/ui/src/TextLink/InternalTextLink.tsx
@@ -1,10 +1,9 @@
 import Link from 'next/link'
-
-import { type BaseLinkProps } from '@filecoin-foundation/ui/BaseLink'
 import { clsx } from 'clsx'
 import type { Route } from 'next'
+import type { ComponentProps } from 'react'
 
-type InternalLinkProps = Omit<BaseLinkProps, 'href' | 'baseDomain'> & {
+type InternalTextLinkProps = Omit<ComponentProps<typeof Link>, 'href'> & {
   href: Route
 }
 
@@ -12,7 +11,7 @@ export function InternalTextLink({
   className,
   children,
   ...rest
-}: InternalLinkProps) {
+}: InternalTextLinkProps) {
   return (
     <Link className={clsx('text-link', className)} {...rest}>
       {children}

--- a/packages/ui/src/TextLink/SmartTextLink.tsx
+++ b/packages/ui/src/TextLink/SmartTextLink.tsx
@@ -2,15 +2,11 @@ import { type BaseLinkProps } from '@filecoin-foundation/ui/BaseLink'
 import { isExternalLink } from '@filecoin-foundation/utils/linkUtils'
 import type { Route } from 'next'
 
-import { BASE_DOMAIN } from '@/constants/siteMetadata'
-
 import { ExternalTextLink } from './ExternalTextLink'
 import { InternalTextLink } from './InternalTextLink'
 
-type SmartTextLinkProps = Omit<BaseLinkProps, 'baseDomain'>
-
-export function SmartTextLink({ href, ...rest }: SmartTextLinkProps) {
-  const isExternal = isExternalLink(href, BASE_DOMAIN)
+export function SmartTextLink({ href, baseDomain, ...rest }: BaseLinkProps) {
+  const isExternal = isExternalLink(href, baseDomain)
 
   return isExternal ? (
     <ExternalTextLink href={href} {...rest} />


### PR DESCRIPTION
## 📝 Description

This PR moves the `TextLink` components to the shared UI library to improve reusability and maintainability. Imports across the codebase have been updated accordingly, and types have been improved.