### PR TITLE
[FF][FFDW][UXIT-2247] Adapt ErrorMessage component for shared UI library

### DIFF
--- a/apps/ff-site/src/app/global-error.tsx
+++ b/apps/ff-site/src/app/global-error.tsx
@@ -4,11 +4,11 @@ import { useEffect } from 'react'
 
 import Error from 'next/error'
 
+import { ErrorMessage } from '@filecoin-foundation/ui/ErrorMessage'
 import * as Sentry from '@sentry/nextjs'
 
-import { FILECOIN_FOUNDATION_URLS } from '@/constants/siteMetadata'
+import { BASE_DOMAIN, FILECOIN_FOUNDATION_URLS } from '@/constants/siteMetadata'
 
-import ErrorMessage from '@/components/ErrorMessage'
 import { SiteLayout } from '@/components/SiteLayout'
 
 type GlobalErrorProps = {
@@ -25,6 +25,7 @@ export default function GlobalError({ error }: GlobalErrorProps) {
       <ErrorMessage
         kicker="500"
         title="Internal Server Error"
+        baseDomain={BASE_DOMAIN}
         cta={{
           href: FILECOIN_FOUNDATION_URLS.techSupportEmail.href,
           text: 'Contact Us',

--- a/apps/ff-site/src/app/not-found.tsx
+++ b/apps/ff-site/src/app/not-found.tsx
@@ -1,4 +1,6 @@
-import ErrorMessage from '@/components/ErrorMessage'
+import { ErrorMessage } from '@filecoin-foundation/ui/ErrorMessage'
+
+import { BASE_DOMAIN } from '@/constants/siteMetadata'
 
 import { NotFoundAnalytics } from './not-found-analytics'
 
@@ -6,7 +8,11 @@ export default function NotFound() {
   return (
     <>
       <NotFoundAnalytics />
-      <ErrorMessage kicker="404" title="Page Not Found">
+      <ErrorMessage
+        kicker="404"
+        title="Page Not Found"
+        baseDomain={BASE_DOMAIN}
+      >
         We&apos;re sorry, but the page you were looking for is not here.
       </ErrorMessage>
     </>

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -11,6 +11,7 @@
     "./Button": "./src/Button.tsx",
     "./BreakpointDebugger": "./src/BreakpointDebugger.tsx",
     "./DescriptionText": "./src/DescriptionText.tsx",
+    "./ErrorMessage": "./src/ErrorMessage.tsx",
     "./Heading": "./src/Heading.tsx",
     "./Icon": "./src/Icon.tsx",
     "./TextLink/*": "./src/TextLink/*.tsx"

--- a/packages/ui/src/ErrorMessage.tsx
+++ b/packages/ui/src/ErrorMessage.tsx
@@ -1,27 +1,32 @@
 import { Button } from '@filecoin-foundation/ui/Button'
 import { DescriptionText } from '@filecoin-foundation/ui/DescriptionText'
 import { Heading } from '@filecoin-foundation/ui/Heading'
+import { type IconProps } from '@filecoin-foundation/ui/Icon'
 
-import { type CTAProps } from '@/types/ctaType'
-
-import { PATHS } from '@/constants/paths'
-import { BASE_DOMAIN } from '@/constants/siteMetadata'
+type CTAProps = {
+  href: string
+  text: string
+  icon?: IconProps['component']
+  ariaLabel?: string
+}
 
 type ErrorMessageProps = {
   kicker: string
   title: string
+  baseDomain: string
   cta?: CTAProps
   children: string
 }
 
-export default function ErrorMessage({
+export function ErrorMessage({
   kicker,
   title,
+  baseDomain,
   cta,
   children,
 }: ErrorMessageProps) {
   const { href, text } = cta || {
-    href: PATHS.HOME.path,
+    href: '/',
     text: 'Return Home',
   }
 
@@ -32,7 +37,7 @@ export default function ErrorMessage({
         {title}
       </Heading>
       <DescriptionText>{children}</DescriptionText>
-      <Button href={href} baseDomain={BASE_DOMAIN}>
+      <Button href={href} baseDomain={baseDomain}>
         {text}
       </Button>
     </div>


### PR DESCRIPTION
## 📝 Description

This PR moves the `ErrorMessage` component to the shared UI library to improve reusability and maintainability. Imports across the codebase have been updated accordingly, and types have been improved.

