### PR TITLE
[FFDW][UXIT-2255] Implement TextLink component and styles [skip percy]

### DIFF
--- a/apps/ffdweb-site/src/app/(homepage)/page.tsx
+++ b/apps/ffdweb-site/src/app/(homepage)/page.tsx
@@ -1,4 +1,4 @@
-import Link from 'next/link'
+import { InternalTextLink } from '@filecoin-foundation/ui/TextLink/InternalTextLink'
 
 import { PATHS } from '@/constants/paths'
 import { FFDW_URLS } from '@/constants/siteMetadata'
@@ -12,7 +12,9 @@ export default function Home() {
     <>
       <section>
         <h1>A Better Web for Everyone</h1>
-        <Link href={PATHS.PROJECTS.path}>View Projects</Link>
+        <InternalTextLink href={PATHS.PROJECTS.path}>
+          View Projects
+        </InternalTextLink>
       </section>
 
       <section>
@@ -33,7 +35,9 @@ export default function Home() {
           vulnerable information by leveraging the resilience of decentralized
           storage.
         </p>
-        <Link href={PATHS.ABOUT.path}>More About FFDW</Link>
+        <InternalTextLink href={PATHS.ABOUT.path}>
+          More About FFDW
+        </InternalTextLink>
       </section>
 
       <section>
@@ -50,7 +54,9 @@ export default function Home() {
             </div>
           ))}
         </div>
-        <Link href={PATHS.PROJECTS.path}>View All Projects</Link>
+        <InternalTextLink href={PATHS.PROJECTS.path}>
+          View All Projects
+        </InternalTextLink>
       </section>
 
       <section>
@@ -65,20 +71,20 @@ export default function Home() {
         <div>
           <div>
             <h3>Use Cases</h3>
-            <a href="#">Explore</a>
+            <InternalTextLink href="#">Explore</InternalTextLink>
           </div>
           <div>
             <h3>Interactive Tutorials</h3>
-            <a href="#">Explore</a>
+            <InternalTextLink href="#">Explore</InternalTextLink>
           </div>
           <div>
             <h3>Videos</h3>
-            <a href="#">Explore</a>
+            <InternalTextLink href="#">Explore</InternalTextLink>
           </div>
         </div>
-        <Link href={PATHS.LEARNING_RESOURCES.path}>
+        <InternalTextLink href={PATHS.LEARNING_RESOURCES.path}>
           View All Learning Resources
-        </Link>
+        </InternalTextLink>
       </section>
 
       <section>
@@ -91,7 +97,9 @@ export default function Home() {
           for digital future developers to build up the community inside DWeb to
           create a decentralized future.
         </p>
-        <Link href={PATHS.DIGEST.path}>Read FFDW Digest</Link>
+        <InternalTextLink href={PATHS.DIGEST.path}>
+          Read FFDW Digest
+        </InternalTextLink>
       </section>
 
       <section>
@@ -106,11 +114,11 @@ export default function Home() {
                 Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed
                 do...
               </p>
-              <a href="#">Read more</a>
+              <InternalTextLink href="#">Read more</InternalTextLink>
             </div>
           ))}
         </div>
-        <Link href={PATHS.BLOG.path}>View All</Link>
+        <InternalTextLink href={PATHS.BLOG.path}>View All</InternalTextLink>
       </section>
 
       <CTASection

--- a/apps/ffdweb-site/src/app/_styles/globals.css
+++ b/apps/ffdweb-site/src/app/_styles/globals.css
@@ -47,6 +47,10 @@
 }
 
 @layer components {
+  .text-link {
+    @apply text-brand-secondary-300 hover:text-brand-primary-300 focus:brand-outline hover:underline;
+  }
+
   .button-base {
     @apply border-2 font-bold;
   }

--- a/apps/ffdweb-site/src/app/faqs/page.tsx
+++ b/apps/ffdweb-site/src/app/faqs/page.tsx
@@ -1,4 +1,7 @@
-import Link from 'next/link'
+import {
+  ExternalTextLink,
+  InternalTextLink,
+} from '@filecoin-foundation/ui/TextLink'
 
 import { PATHS } from '@/constants/paths'
 import { FFDW_URLS } from '@/constants/siteMetadata'
@@ -41,8 +44,10 @@ export default function FAQs() {
             technologies, initiatives that accelerate their adoption, and
             community building that fosters a network of decentralized web
             advocates and builders. This includes{' '}
-            <Link href={PATHS.PROJECTS.path}>collaborations</Link> with
-            developers, researchers, nonprofit organizations, and others to
+            <InternalTextLink href={PATHS.PROJECTS.path}>
+              collaborations
+            </InternalTextLink>{' '}
+            with developers, researchers, nonprofit organizations, and others to
             build robust decentralized infrastructure and introduce and
             highlight new and impactful use cases for decentralized
             technologies.
@@ -66,9 +71,9 @@ export default function FAQs() {
             activists; Distributed Press is creating alternatives to centralized
             publishing platforms; and Spritely is creating ways to authorize and
             process data without centralized gatekeepers –– see more in the{' '}
-            <Link href="/blog/filecoin-foundation-2024-annual-report">
+            <InternalTextLink href="/blog/filecoin-foundation-2024-annual-report">
               2024 Report
-            </Link>
+            </InternalTextLink>
             . All these projects are designed to drive the development and
             adoption of open, decentralized technologies. FFDW works
             hand-in-hand with funded projects to drive meaningful change.
@@ -82,15 +87,19 @@ export default function FAQs() {
           </h2>
           <p>
             Check out the{' '}
-            <Link href={PATHS.LEARNING_RESOURCES.path}>Learning Resources</Link>{' '}
+            <InternalTextLink href={PATHS.LEARNING_RESOURCES.path}>
+              Learning Resources
+            </InternalTextLink>{' '}
             page! We have a variety of education resources – sourced from FFDW
             and beyond – including reading, research, webinars, and more,
             offering a look into decentralized technologies and its
             applications. These resources start from an introductory level and
             expand upward for more experienced users and builders. The{' '}
-            <Link href={PATHS.DIGEST.path}>DWeb Digest</Link> is also a deep
-            dive into different perspectives from the decentralized web
-            community.
+            <InternalTextLink href={PATHS.DIGEST.path}>
+              DWeb Digest
+            </InternalTextLink>{' '}
+            is also a deep dive into different perspectives from the
+            decentralized web community.
           </p>
         </article>
 
@@ -104,27 +113,41 @@ export default function FAQs() {
             decentralized web ecosystem following the principle that collective
             experience and resources can lead to greater impact! In the past,
             FFDW has co-funded projects with{' '}
-            <a href="https://artizen.fund/">Artizen</a> and{' '}
-            <a href="https://unfinished.com/">Unfinished</a>
+            <ExternalTextLink href="https://artizen.fund/">
+              Artizen
+            </ExternalTextLink>{' '}
+            and{' '}
+            <ExternalTextLink href="https://unfinished.com/">
+              Unfinished
+            </ExternalTextLink>
             co-hosted the Social Impact Summit with Blockchain Law Center for
             Social Good at the{' '}
-            <a href="https://www.usfca.edu/law/engaged-learning/center-law-tech-social-good">
+            <ExternalTextLink href="https://www.usfca.edu/law/engaged-learning/center-law-tech-social-good">
               University of San Francisco
-            </a>
-            ; and participated in
-            <a href="https://dwebcamp.org/">DWeb Camp</a>, among other things.
-            Interested in working together?{' '}
-            <a href={FFDW_URLS.email}>Get in touch with our FFDW team</a>.
+            </ExternalTextLink>
+            ; and participated in{' '}
+            <ExternalTextLink href="https://dwebcamp.org/">
+              DWeb Camp
+            </ExternalTextLink>
+            , among other things. Interested in working together?{' '}
+            <ExternalTextLink href={FFDW_URLS.email}>
+              Get in touch with our FFDW team
+            </ExternalTextLink>
+            .
           </p>
         </article>
 
         <article>
           <h2>Where can I find updates on the progress on FFDW projects?</h2>
           <p>
-            Check out the <Link href={PATHS.PROJECTS.path}>Projects</Link> page.
-            Additionally, updates can be found on our{' '}
-            <Link href={PATHS.BLOG.path}>blog</Link> and across social media
-            channels: <a href={FFDW_URLS.social.twitter}>X</a>,{' '}
+            Check out the{' '}
+            <InternalTextLink href={PATHS.PROJECTS.path}>
+              Projects
+            </InternalTextLink>{' '}
+            page. Additionally, updates can be found on our{' '}
+            <InternalTextLink href={PATHS.BLOG.path}>blog</InternalTextLink> and
+            across social media channels:{' '}
+            <a href={FFDW_URLS.social.twitter}>X</a>,{' '}
             <a href={FFDW_URLS.social.youTube}>YouTube</a>, and{' '}
             <a href={FFDW_URLS.social.linkedIn}>LinkedIn</a>.
           </p>

--- a/apps/ffdweb-site/src/app/projects/[slug]/page.tsx
+++ b/apps/ffdweb-site/src/app/projects/[slug]/page.tsx
@@ -1,3 +1,5 @@
+import { InternalTextLink } from '@filecoin-foundation/ui/TextLink/InternalTextLink'
+
 import { createMetadata } from '@/utils/createMetadata'
 
 export default function Project() {
@@ -18,8 +20,8 @@ export default function Project() {
       </section>
 
       <div>
-        <a href="#">Website</a>
-        <a href="#">Read Blog Post</a>
+        <InternalTextLink href="#">Website</InternalTextLink>
+        <InternalTextLink href="#">Read Blog Post</InternalTextLink>
       </div>
     </>
   )

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -14,6 +14,7 @@
     "./ErrorMessage": "./src/ErrorMessage.tsx",
     "./Heading": "./src/Heading.tsx",
     "./Icon": "./src/Icon.tsx",
+    "./TextLink": "./src/TextLink/index.ts",
     "./TextLink/*": "./src/TextLink/*.tsx"
   },
   "scripts": {

--- a/packages/ui/src/TextLink/index.ts
+++ b/packages/ui/src/TextLink/index.ts
@@ -1,0 +1,3 @@
+export { ExternalTextLink } from './ExternalTextLink'
+export { InternalTextLink } from './InternalTextLink'
+export { SmartTextLink } from './SmartTextLink'


### PR DESCRIPTION
## 📝 Description

This PR replaces native link elements with our custom `TextLink` components across multiple pages. It also adds global styling for text links and improves the component import structure.

Changes

- Refactored several pages to use the `TextLink` components instead of native links
- Added `text-link` styling in global CSS
- Created an `index` file in the `TextLink` directory to enable consolidated imports
- Updated `package.json` exports configuration to support the new import pattern