### PR TITLE
[FFDW] Create MarkdownContent component [skip percy]

### DIFF
--- a/apps/ffdweb-site/package.json
+++ b/apps/ffdweb-site/package.json
@@ -19,8 +19,12 @@
     "next": "15.1.6",
     "postcss": "^8.5.1",
     "react": "^19.0.0",
-    "react-dom": "^19.0.0",
-    "tailwindcss": "^4.0.5"
+    "react-markdown": "^9.0.1",
+    "rehype-raw": "^7.0.0",
+    "rehype-slug": "^6.0.0",
+    "remark-gfm": "^4.0.0",
+    "tailwindcss": "^4.0.5",
+    "@tailwindcss/typography": "^0.5.15"
   },
   "devDependencies": {
     "@filecoin-foundation/eslint-config": "*",

--- a/apps/ffdweb-site/src/app/_components/MarkdownContent.tsx
+++ b/apps/ffdweb-site/src/app/_components/MarkdownContent.tsx
@@ -13,7 +13,6 @@ import { graphicsData } from '@/data/graphicsData'
 
 export type MarkdownContentProps = {
   children: Parameters<typeof ReactMarkdown>[0]['children']
-  addTableOfContents?: boolean
 }
 
 const IMAGE_DIMENSIONS = {
@@ -34,7 +33,6 @@ const MarkdownImage: Components['img'] = ({ src, alt }) => {
 
   if (!src) {
     const errorMessage = 'Invalid markdown: image is missing src attribute'
-
     console.error(errorMessage)
 
     return (
@@ -52,9 +50,7 @@ const MarkdownImage: Components['img'] = ({ src, alt }) => {
 const MarkdownLink: Components['a'] = ({ href, children }) => {
   if (!href) {
     const errorMessage = `Invalid markdown: link is missing href attribute for text "${children}"`
-
     console.error(errorMessage)
-    Sentry.captureException(new Error(errorMessage))
 
     return <>{children}</>
   }

--- a/apps/ffdweb-site/src/app/_components/MarkdownContent.tsx
+++ b/apps/ffdweb-site/src/app/_components/MarkdownContent.tsx
@@ -1,0 +1,86 @@
+import Image from 'next/image'
+
+import { SmartTextLink } from '@filecoin-foundation/ui/TextLink/SmartTextLink'
+import { buildImageSizeProp } from '@filecoin-foundation/utils/buildImageSizeProp'
+import ReactMarkdown, { type Components } from 'react-markdown'
+import rehypeRaw from 'rehype-raw'
+import rehypeSlug from 'rehype-slug'
+import remarkGfm from 'remark-gfm'
+
+import { BASE_DOMAIN } from '@/constants/siteMetadata'
+
+import { graphicsData } from '@/data/graphicsData'
+
+export type MarkdownContentProps = {
+  children: Parameters<typeof ReactMarkdown>[0]['children']
+  addTableOfContents?: boolean
+}
+
+const IMAGE_DIMENSIONS = {
+  containerWidth: 672,
+  aspectRatioHeight: Math.round(672 * (9 / 16)),
+} as const
+
+const MarkdownImage: Components['img'] = ({ src, alt }) => {
+  const commonProps = {
+    quality: 100,
+    width: IMAGE_DIMENSIONS.containerWidth,
+    height: IMAGE_DIMENSIONS.aspectRatioHeight,
+    sizes: buildImageSizeProp({
+      startSize: '100vw',
+      md: `${IMAGE_DIMENSIONS.containerWidth}px`,
+    }),
+  }
+
+  if (!src) {
+    const errorMessage = 'Invalid markdown: image is missing src attribute'
+
+    console.error(errorMessage)
+
+    return (
+      <Image
+        {...commonProps}
+        src={graphicsData.imageFallback.data}
+        alt={graphicsData.imageFallback.alt}
+      />
+    )
+  }
+
+  return <Image {...commonProps} src={src} alt={alt || ''} />
+}
+
+const MarkdownLink: Components['a'] = ({ href, children }) => {
+  if (!href) {
+    const errorMessage = `Invalid markdown: link is missing href attribute for text "${children}"`
+
+    console.error(errorMessage)
+    Sentry.captureException(new Error(errorMessage))
+
+    return <>{children}</>
+  }
+  return (
+    <SmartTextLink href={href} baseDomain={BASE_DOMAIN} className="not-prose">
+      {children}
+    </SmartTextLink>
+  )
+}
+
+const markdownComponents: Components = {
+  img: MarkdownImage,
+  a: MarkdownLink,
+}
+
+export function MarkdownContent({ children }: MarkdownContentProps) {
+  const rehypePlugins = [rehypeRaw, rehypeSlug]
+
+  return (
+    <ReactMarkdown
+      rehypePlugins={rehypePlugins}
+      remarkPlugins={[remarkGfm]}
+      className="prose"
+      components={markdownComponents}
+    >
+      {children}
+    </ReactMarkdown>
+  )
+}

--- a/apps/ffdweb-site/src/app/_styles/globals.css
+++ b/apps/ffdweb-site/src/app/_styles/globals.css
@@ -56,17 +56,17 @@
 }
 
 @utility prose {
-  --tw-prose-body: var(--color-brand-primary-300);
-  --tw-prose-headings: var(--color-brand-primary-300);
-  --tw-prose-bold: var(--color-brand-primary-300);
-  --tw-prose-quotes: var(--color-brand-primary-300);
+  --tw-prose-body: var(--color-neutral-50);
+  --tw-prose-headings: var(--color-neutral-50);
+  --tw-prose-bold: var(--color-neutral-50);
+  --tw-prose-quotes: var(--color-neutral-50);
   --tw-prose-quote-borders: var(--color-brand-primary-300);
-  --tw-prose-counters: var(--color-brand-primary-300);
-  --tw-prose-bullets: var(--color-brand-primary-300);
-  --tw-prose-code: var(--color-brand-primary-300);
-  --tw-prose-pre-bg: var(--text-neutral-950);
-  --tw-prose-pre-code: var(--color-brand-primary-300);
-  --tw-prose-captions: var(--color-brand-primary-300);
+  --tw-prose-counters: var(----color-neutral-50);
+  --tw-prose-bullets: var(----color-neutral-50);
+  --tw-prose-code: var(--color-neutral-50);
+  --tw-prose-pre-bg: var(--color-neutral-950);
+  --tw-prose-pre-code: var(--color-neutral-50);
+  --tw-prose-captions: var(--color-neutral-50);
   --tw-prose-td-borders: var(--color-brand-primary-300);
   --tw-prose-th-borders: var(--color-brand-primary-300);
 

--- a/apps/ffdweb-site/src/app/_styles/globals.css
+++ b/apps/ffdweb-site/src/app/_styles/globals.css
@@ -4,7 +4,7 @@
 @plugin "@tailwindcss/typography";
 
 :root {
-  --outline-brand: 4px solid var(--color-brand-primary-300);
+  --outline-brand: 2px solid var(--color-neutral-50);
   --outline-brand-offset: 0px;
   --outline-brand-border-color: transparent;
 }
@@ -30,12 +30,12 @@
   --color-brand-secondary-800: #002d00;
   --color-brand-secondary-900: #001100;
 
-  --color-avatar-background: var(--color-brand-primary-800);
-  --color-avatar-full-name: var(--color-brand-primary-100);
-  --color-avatar-initials: var(--color-brand-primary-200);
-  --color-avatar-ring: var(--color-neutral-100);
+  --color-avatar-background: var(--color-brand-primary-800); /* CHECK */
+  --color-avatar-full-name: var(--color-neutral-50);
+  --color-avatar-initials: var(--color-neutral-50); /* CHECK */
+  --color-avatar-ring: var(--color-neutral-50);
 
-  --color-icon-subtle: var(--color-neutral-300);
+  --color-icon-subtle: var(--color-neutral-300); /* CHECK */
 }
 
 @utility brand-outline {
@@ -78,7 +78,7 @@
   }
 
   & pre {
-    @apply border-brand-primary-600 border border-solid;
+    @apply border-brand-primary-300 border border-solid; /* CHECK */
   }
 
   & iframe {
@@ -104,7 +104,7 @@
 
 @layer components {
   .text-link {
-    @apply text-brand-secondary-300 hover:text-brand-primary-300 focus:brand-outline hover:underline;
+    @apply text-brand-primary-300 hover:text-brand-primary-500 focus:brand-outline hover:underline; /* CHECK */
   }
 
   .button-base {
@@ -112,15 +112,15 @@
   }
 
   .button-primary {
-    @apply border-brand-primary-300 bg-brand-primary-300 text-neutral-950 hover:border-neutral-100 hover:bg-neutral-100 focus:bg-neutral-100;
+    @apply border-brand-primary-300 bg-brand-primary-300 text-neutral-950 hover:border-neutral-100 hover:bg-neutral-100 focus:bg-neutral-100; /* CHECK */
   }
 
   .button-ghost {
-    @apply text-brand-primary-300 border-brand-primary-300 focus:text-brand-primary-300 bg-neutral-950 hover:border-neutral-100 hover:text-neutral-100;
+    @apply text-brand-primary-300 border-brand-primary-300 focus:text-brand-primary-300 bg-neutral-950 hover:border-neutral-100 hover:text-neutral-100; /* CHECK */
   }
 
   .button-disabled {
-    @apply bg-neutral-300;
+    @apply bg-neutral-300; /* CHECK */
   }
 
   .tag-label-base {
@@ -128,18 +128,18 @@
   }
 
   .tag-label-primary {
-    @apply border-brand-secondary-300 bg-brand-secondary-300 text-brand-secondary-800;
+    @apply border-brand-secondary-300 bg-brand-secondary-300 text-brand-secondary-800; /* CHECK */
   }
 
   .tag-label-secondary {
-    @apply border-neutral-200 bg-neutral-950 text-neutral-200;
+    @apply border-neutral-200 bg-neutral-950 text-neutral-200; /* CHECK */
   }
 
   .breadcrumbs-inactive {
-    @apply text-neutral-200;
+    @apply text-neutral-50;
   }
 
   .breadcrumbs-active {
-    @apply text-brand-primary-400;
+    @apply text-brand-primary-300;
   }
 }

--- a/apps/ffdweb-site/src/app/_styles/globals.css
+++ b/apps/ffdweb-site/src/app/_styles/globals.css
@@ -1,6 +1,8 @@
 @import 'tailwindcss';
 @source "../../../../../node_modules/@filecoin-foundation/ui";
 
+@plugin "@tailwindcss/typography";
+
 :root {
   --outline-brand: 4px solid var(--color-brand-primary-300);
   --outline-brand-offset: 0px;
@@ -50,6 +52,53 @@
   h5,
   h6 {
     @apply leading-relaxed;
+  }
+}
+
+@utility prose {
+  --tw-prose-body: var(--color-brand-primary-300);
+  --tw-prose-headings: var(--color-brand-primary-300);
+  --tw-prose-bold: var(--color-brand-primary-300);
+  --tw-prose-quotes: var(--color-brand-primary-300);
+  --tw-prose-quote-borders: var(--color-brand-primary-300);
+  --tw-prose-counters: var(--color-brand-primary-300);
+  --tw-prose-bullets: var(--color-brand-primary-300);
+  --tw-prose-code: var(--color-brand-primary-300);
+  --tw-prose-pre-bg: var(--text-neutral-950);
+  --tw-prose-pre-code: var(--color-brand-primary-300);
+  --tw-prose-captions: var(--color-brand-primary-300);
+  --tw-prose-td-borders: var(--color-brand-primary-300);
+  --tw-prose-th-borders: var(--color-brand-primary-300);
+
+  & code {
+    &::before,
+    &::after {
+      @apply content-none!;
+    }
+  }
+
+  & pre {
+    @apply border-brand-primary-600 border border-solid;
+  }
+
+  & iframe {
+    @apply w-full;
+
+    &[src*='youtube.com'] {
+      @apply aspect-video h-auto w-full;
+    }
+  }
+
+  & figure {
+    @apply text-center;
+  }
+
+  & figcaption {
+    @apply text-left text-sm;
+  }
+
+  & table thead th {
+    @apply text-brand-primary-300;
   }
 }
 

--- a/apps/ffdweb-site/src/app/layout.tsx
+++ b/apps/ffdweb-site/src/app/layout.tsx
@@ -33,7 +33,7 @@ export default function RootLayout({
 }>) {
   return (
     <html lang="en" className={manrope.className}>
-      <body className="m-auto flex max-w-[1032px] flex-col justify-between bg-neutral-950 px-6 pb-6 pt-8 tracking-wide text-neutral-100">
+      <body className="m-auto flex max-w-[1032px] flex-col justify-between bg-neutral-950 px-6 pb-6 pt-8 tracking-wide text-neutral-50">
         <Navigation />
         <main>{children}</main>
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -109,11 +109,15 @@
         "@filecoin-foundation/utils": "*",
         "@phosphor-icons/react": "^2.1.7",
         "@tailwindcss/postcss": "^4.0.5",
+        "@tailwindcss/typography": "^0.5.15",
         "clsx": "^2.1.1",
         "next": "15.1.6",
         "postcss": "^8.5.1",
         "react": "^19.0.0",
-        "react-dom": "^19.0.0",
+        "react-markdown": "^9.0.1",
+        "rehype-raw": "^7.0.0",
+        "rehype-slug": "^6.0.0",
+        "remark-gfm": "^4.0.0",
         "tailwindcss": "^4.0.5"
       },
       "devDependencies": {


### PR DESCRIPTION
## 📝 Description

This update introduces Markdown rendering support to the project, enhancing content flexibility and readability. It also includes UI and styling refinements to align with the design system.

- **Type:** New feature / Refactor

## 🛠️ Key Changes

- **Markdown Rendering Support**
  - Added `react-markdown`, `rehype-raw`, `rehype-slug`, and `remark-gfm` as dependencies.
  - Introduced `MarkdownContent.tsx` to handle Markdown rendering with custom components for images and links.

- **Typography & Styling Enhancements**
  - Installed `@tailwindcss/typography` and applied prose styles for improved text formatting.
  - Adjusted CSS variables and utility classes to refine UI consistency.
  - Refined button and text link styles to better align with brand identity.

## Test content

```

const testContent = `# Markdown Style Showcase

## Typography Elements

Normal paragraph text demonstrates the \`--tw-prose-body\` style.

**This bold text** showcases the \`--tw-prose-bold\` style.

## Headings Demonstration

### This is a Level 3 Heading
Level 3 headings use the \`--tw-prose-headings\` style.

#### This is a Level 4 Heading
Level 4 headings also inherit from \`--tw-prose-headings\`.

## Quotes and Citations

> This blockquote demonstrates the \`--tw-prose-quotes\` style.
> It also has a left border using \`--tw-prose-quote-borders\`.
> 
> Multi-paragraph quotes work the same way.

## Lists

### Bulleted List
* This first bullet uses \`--tw-prose-bullets\` style
* Second bullet point
  * Nested bullet point
  * Another nested bullet

### Numbered List
1. This first number uses \`--tw-prose-counters\` style
2. Second numbered item
   1. Nested numbered item
   2. Another nested item

## Code Elements

Inline \`code\` elements use the \`--tw-prose-code\` style and have the ::before and ::after content removed according to your CSS.

\`\`\`javascript
// Code blocks use --tw-prose-pre-bg for background (neutral-950)
// and --tw-prose-pre-code for text color (neutral-100)
// They also have a border in brand-primary-600
function exampleFunction() {
  const message = "Hello world";
  console.log(message);
  return message;
}
\`\`\`

## Tables

Tables use various styles including \`--tw-prose-th-borders\` and \`--tw-prose-td-borders\`.

| Header 1 | Header 2 | Header 3 |
|----------|----------|----------|
| Cell 1   | Cell 2   | Cell 3   |
| Cell 4   | Cell 5   | Cell 6   |

Table headers use the \`--tw-prose-th-borders\` style.

## Media Elements

### Iframe Example

If your markdown renderer supports raw HTML, this demonstrates an iframe with your custom styling:

<iframe src="https://www.youtube.com/embed/dQw4w9WgXcQ" title="YouTube video" allowfullscreen></iframe>

### Figure with Caption

<figure>
  <figcaption>This figcaption demonstrates the left-aligned, smaller text style you've defined.</figcaption>
</figure>

## Links

[This is a link](#) which would typically be styled by your custom SmartTextLink component rather than the prose styles.`
```