### PR TITLE
[FFDW][UXIT-2290] Extend PageHeader with kicker [skip percy]

### DIFF
--- a/apps/ffdweb-site/src/app/(homepage)/page.tsx
+++ b/apps/ffdweb-site/src/app/(homepage)/page.tsx
@@ -24,9 +24,6 @@ export default function Home() {
             text: 'View Projects',
           }}
         />
-        <InternalTextLink href={PATHS.PROJECTS.path}>
-          View Projects
-        </InternalTextLink>
       </section>
 
       <section>

--- a/apps/ffdweb-site/src/app/_components/PageHeader.tsx
+++ b/apps/ffdweb-site/src/app/_components/PageHeader.tsx
@@ -23,6 +23,7 @@ type PageHeaderImageProps = (StaticImageProps | ImageProps) & {
 type PageHeaderProps = {
   title: TitleProps['children']
   image: PageHeaderImageProps
+  kicker?: string
   cta?: CTAProps
   isHomepage?: boolean
 }
@@ -30,11 +31,12 @@ type PageHeaderProps = {
 export function PageHeader({
   title,
   image,
+  kicker,
   cta,
   isHomepage = false,
 }: PageHeaderProps) {
   return (
-    <header className="grid items-center gap-6 lg:grid-cols-2">
+    <header className="grid items-center gap-16 lg:grid-cols-2">
       <div
         className={clsx(
           'grid grid-cols-1 content-start justify-center gap-8 text-center',
@@ -42,7 +44,10 @@ export function PageHeader({
           isHomepage ? 'order-2' : 'order-1',
         )}
       >
-        <PageHeader.Title isHomepage={isHomepage}>{title}</PageHeader.Title>
+        <div className="flex flex-col gap-8">
+          {kicker && <span>{kicker}</span>}
+          <PageHeader.Title isHomepage={isHomepage}>{title}</PageHeader.Title>
+        </div>
         {cta && <PageHeader.CTAButton {...cta} />}
       </div>
       <div

--- a/apps/ffdweb-site/src/app/_styles/globals.css
+++ b/apps/ffdweb-site/src/app/_styles/globals.css
@@ -30,6 +30,8 @@
 
   --color-icon-primary: theme('colors.brand.primary.300');
   --color-icon-subtle: theme('colors.neutral.300'); /* CHECK */
+
+  --leading-heading: 1.3;
 }
 
 @utility brand-outline {
@@ -45,7 +47,7 @@
   h4,
   h5,
   h6 {
-    @apply leading-relaxed;
+    line-height: var(--leading-heading);
   }
 }
 

--- a/apps/ffdweb-site/src/app/about/page.tsx
+++ b/apps/ffdweb-site/src/app/about/page.tsx
@@ -13,6 +13,7 @@ export default function About() {
   return (
     <PageLayout gap={32}>
       <PageHeader
+        kicker="About"
         title="Building and Supporting the Decentralized Web Community"
         image={graphicsData.about}
       />

--- a/apps/ffdweb-site/src/app/digest/page.tsx
+++ b/apps/ffdweb-site/src/app/digest/page.tsx
@@ -13,6 +13,7 @@ export default function Digest() {
   return (
     <PageLayout gap={32}>
       <PageHeader
+        kicker="Digest"
         title="The Go-to Publication for Exploring DWeb Ideas and Principles"
         image={graphicsData.digest}
       />

--- a/apps/ffdweb-site/src/app/faqs/page.tsx
+++ b/apps/ffdweb-site/src/app/faqs/page.tsx
@@ -12,13 +12,17 @@ import { createMetadata } from '@/utils/createMetadata'
 export default function FAQs() {
   return (
     <PageLayout gap={32}>
-      <>
-        <span>FAQs</span>
-        <h1>
-          Need help with something? Here are our most frequently asked
-          questions.
-        </h1>
-      </>
+      <header>
+        <div className="flex flex-col gap-8">
+          <h1>FAQs</h1>
+          <div className="leading-brand-heading max-w-lg text-4xl font-medium">
+            <p className="">Need help with something?</p>
+            <p className="text-neutral-400">
+              Here are our most frequently asked questions.
+            </p>
+          </div>
+        </div>
+      </header>
 
       <section>
         <article>

--- a/apps/ffdweb-site/src/app/learning-resources/page.tsx
+++ b/apps/ffdweb-site/src/app/learning-resources/page.tsx
@@ -13,6 +13,7 @@ export default function LearningResources() {
   return (
     <PageLayout gap={32}>
       <PageHeader
+        kicker="Learning Resources"
         title="Explore Decentralized Tech with Content from FFDW and Beyond"
         image={graphicsData.learningResources}
       />

--- a/apps/ffdweb-site/src/app/projects/page.tsx
+++ b/apps/ffdweb-site/src/app/projects/page.tsx
@@ -11,6 +11,7 @@ export default function Projects() {
   return (
     <>
       <PageHeader
+        kicker="Projects"
         title="Discover Current and Past FFDW Project Partners"
         image={graphicsData.projects}
       />

--- a/packages/ui/src/Heading.tsx
+++ b/packages/ui/src/Heading.tsx
@@ -23,10 +23,8 @@ export type HeadingProps = {
 }
 
 const variantStyles = {
-  '5xl-fluid':
-    'text-[clamp(theme(fontSize.4xl),10vw,theme(fontSize.5xl))] leading-tight',
-  '4xl-fluid':
-    'text-[clamp(theme(fontSize.3xl),8vw,theme(fontSize.4xl))] leading-tight',
+  '5xl-fluid': 'text-[clamp(theme(fontSize.4xl),10vw,theme(fontSize.5xl))]',
+  '4xl-fluid': 'text-[clamp(theme(fontSize.3xl),8vw,theme(fontSize.4xl))]',
   '4xl': 'text-4xl font-bold',
   '3xl': 'text-3xl font-bold',
   '2xl': 'text-2xl font-bold',


### PR DESCRIPTION
## 📝 Description

This PR contains several UI refinements focused on typography and layout consistency throughout the FFDW site. It introduces a standardized heading `line height`, and adds `kicker` support to page headers.

- **Type:** Bug fix / Refactor

## 🛠️ Key Changes
- Added standardized `--leading-heading` CSS variable for consistent typography
- Removed redundant leading styles from `Heading` component
- Added `kicker` support to `PageHeader` component
- Implemented `kicker` on About, Digest, Learning Resources, and Projects pages
- Fixed FAQs page header structure to match design system
- Removed duplicate "View Projects" link from homepage
- Increased `PageHeader` grid gap per Figma design