### PR TITLE
[FFDW][UXIT-2291][UXIT-2292] Create MarkdownPage component [skip percy]

### DIFF
--- a/apps/ffdweb-site/next.config.ts
+++ b/apps/ffdweb-site/next.config.ts
@@ -2,6 +2,13 @@ import type { NextConfig } from 'next'
 
 const webpackRules = [
   {
+    test: /\.md$/,
+    loader: 'frontmatter-markdown-loader',
+    options: {
+      mode: ['body', 'attributes', 'react-component'],
+    },
+  },
+  {
     test: /\.svg$/,
     use: ['@svgr/webpack'],
   },

--- a/apps/ffdweb-site/package.json
+++ b/apps/ffdweb-site/package.json
@@ -36,6 +36,7 @@
     "@types/node": "^20",
     "@types/react": "^19",
     "@types/react-dom": "^19",
+    "frontmatter-markdown-loader": "^3.7.0",
     "typescript": "^5"
   }
 }

--- a/apps/ffdweb-site/src/app/_components/PageHeader.tsx
+++ b/apps/ffdweb-site/src/app/_components/PageHeader.tsx
@@ -14,7 +14,7 @@ import { BASE_DOMAIN } from '@/constants/siteMetadata'
 
 type TitleProps = {
   children: string
-  isHomepage: PageHeaderProps['isHomepage']
+  isHomepage?: PageHeaderProps['isHomepage']
 }
 
 type PageHeaderImageProps = (StaticImageProps | ImageProps) & {
@@ -62,7 +62,10 @@ export function PageHeader({
   )
 }
 
-PageHeader.Title = function Title({ children, isHomepage }: TitleProps) {
+PageHeader.Title = function Title({
+  children,
+  isHomepage = false,
+}: TitleProps) {
   const titleVariant = isHomepage ? '5xl-fluid' : '4xl-fluid'
 
   return (

--- a/apps/ffdweb-site/src/app/_types/markdown.d.ts
+++ b/apps/ffdweb-site/src/app/_types/markdown.d.ts
@@ -1,0 +1,4 @@
+declare module '*.md' {
+  const react: React.ComponentType
+  export { attributes, body, react }
+}

--- a/apps/ffdweb-site/src/app/privacy-policy/page.tsx
+++ b/apps/ffdweb-site/src/app/privacy-policy/page.tsx
@@ -1,11 +1,29 @@
+import { MarkdownPage } from '@filecoin-foundation/ui/MarkdownPage'
+
 import { createMetadata } from '@/utils/createMetadata'
 
-export default function PrivacyPolicy() {
-  return <h1>Privacy Policy</h1>
-}
+import { MarkdownContent } from '@/components/MarkdownContent'
+import { PageHeader } from '@/components/PageHeader'
 
-export const metadata = createMetadata({
+import privacyPolicyMarkdown from './privacy-policy.md'
+
+const { body } = privacyPolicyMarkdown
+
+const SEO = {
   metaTitle: 'Privacy Policy',
   metaDescription:
     'Discover how Filecoin Foundation safeguards your data. Read our comprehensive Privacy Policy for detailed information.',
+} as const
+
+export default function PrivacyPolicy() {
+  return (
+    <MarkdownPage
+      PageHeaderTitle={<PageHeader.Title>{SEO.metaTitle}</PageHeader.Title>}
+      MarkdownContent={<MarkdownContent>{body}</MarkdownContent>}
+    />
+  )
+}
+
+export const metadata = createMetadata({
+  ...SEO,
 })

--- a/apps/ffdweb-site/src/app/privacy-policy/privacy-policy.md
+++ b/apps/ffdweb-site/src/app/privacy-policy/privacy-policy.md
@@ -1,5 +1,3 @@
-# Privacy Policy
-
 Filecoin Foundation and Filecoin Foundation for the Decentralized Web (collectively, "Filecoin Foundation," "we," "us") provide this Privacy Policy to explain our practices regarding the collection, use, and disclosure of your personal information both online and offline. This Privacy Policy applies to the fil.org and ffdweb.org websites ("Websites") and any websites, apps, or services that link to this Privacy Policy ("Services"), unless otherwise indicated.
 
 **Last Updated: December 31, 2022**

--- a/apps/ffdweb-site/src/app/terms-of-use/page.tsx
+++ b/apps/ffdweb-site/src/app/terms-of-use/page.tsx
@@ -1,15 +1,29 @@
+import { MarkdownPage } from '@filecoin-foundation/ui/MarkdownPage'
+
 import { createMetadata } from '@/utils/createMetadata'
+
+import { MarkdownContent } from '@/components/MarkdownContent'
+import { PageHeader } from '@/components/PageHeader'
+
+import termsOfUseMarkdown from './terms-of-use.md'
+
+const { body } = termsOfUseMarkdown
+
+const SEO = {
+  metaTitle: 'Terms of Use',
+  metaDescription:
+    'Understand the terms and conditions of using Filecoin Foundation services. Read our detailed Terms of Use for more information.',
+} as const
 
 export default function TermsOfUse() {
   return (
-    <>
-      <h1>Terms of Use</h1>
-    </>
+    <MarkdownPage
+      PageHeaderTitle={<PageHeader.Title>{SEO.metaTitle}</PageHeader.Title>}
+      MarkdownContent={<MarkdownContent>{body}</MarkdownContent>}
+    />
   )
 }
 
 export const metadata = createMetadata({
-  metaTitle: 'Terms of Use',
-  metaDescription:
-    'Understand the terms and conditions of using Filecoin Foundation services. Read our detailed Terms of Use for more information.',
+  ...SEO,
 })

--- a/apps/ffdweb-site/src/app/terms-of-use/terms-of-use.md
+++ b/apps/ffdweb-site/src/app/terms-of-use/terms-of-use.md
@@ -1,5 +1,3 @@
-# Terms of Use
-
 Effective Date: December 1, 2021 These Terms of Use (“Terms”) govern your use of Filecoin Foundation for the Decentralized Web website and any other website that FFDW operates and that links to these Terms (collectively, the “Website”).
 
 Please review these Terms carefully before using the Website. We may change these Terms or modify any features of the Website at any time. The most current version of the Terms can be viewed by clicking on the “Terms of Use” link posted through the Website. You accept the Terms by using the Website, and you accept any changes to the Terms by continuing to use the Website after we post the changes.

--- a/package-lock.json
+++ b/package-lock.json
@@ -132,6 +132,7 @@
         "@types/node": "^20",
         "@types/react": "^19",
         "@types/react-dom": "^19",
+        "frontmatter-markdown-loader": "^3.7.0",
         "typescript": "^5"
       }
     },
@@ -17061,7 +17062,7 @@
       "devDependencies": {
         "@filecoin-foundation/eslint-config": "*",
         "@filecoin-foundation/typescript-config": "*",
-        "typescript": "^5"
+        "frontmatter-markdown-loader": "^3.7.0"
       },
       "peerDependencies": {
         "@headlessui/react": "^2.2.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
         "packages/*"
       ],
       "devDependencies": {
+        "frontmatter-markdown-loader": "^3.7.0",
         "turbo": "^2.4.0"
       }
     },

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "test": "turbo run test"
   },
   "devDependencies": {
+    "frontmatter-markdown-loader": "^3.7.0",
     "turbo": "^2.4.0"
   }
 }

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -24,6 +24,7 @@
     "./Heading": "./src/Heading.tsx",
     "./Icon": "./src/Icon.tsx",
     "./IconButton": "./src/IconButton.tsx",
+    "./MarkdownPage": "./src/MarkdownPage.tsx",
     "./NoResultsMessage": "./src/NoResultsMessage.tsx",
     "./NoSearchResultsMessage": "./src/NoSearchResultsMessage.tsx",
     "./PageLayout": "./src/PageLayout.tsx",

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -45,7 +45,7 @@
   "devDependencies": {
     "@filecoin-foundation/eslint-config": "*",
     "@filecoin-foundation/typescript-config": "*",
-    "typescript": "^5"
+    "frontmatter-markdown-loader": "^3.7.0"
   },
   "peerDependencies": {
     "@headlessui/react": "^2.2.0",

--- a/packages/ui/src/MarkdownPage.tsx
+++ b/packages/ui/src/MarkdownPage.tsx
@@ -1,0 +1,22 @@
+// import { StructuredDataScript } from '@filecoin-foundation/ui/StructuredDataScript'
+// import type { WithContext, WebPage } from 'schema-dts'
+
+type MarkdownPageProps = {
+  PageHeaderTitle: React.ReactNode
+  MarkdownContent: React.ReactNode
+  // structuredData: WithContext<WebPage>
+}
+
+export function MarkdownPage({
+  PageHeaderTitle,
+  MarkdownContent,
+  // structuredData,
+}: MarkdownPageProps) {
+  return (
+    <article className="prose">
+      {/* <StructuredDataScript structuredData={structuredData} /> */}
+      <header className="mb-6">{PageHeaderTitle}</header>
+      {MarkdownContent}
+    </article>
+  )
+}


### PR DESCRIPTION
## 📝 Description
This PR adds support for rendering markdown content on the privacy policy and terms of use pages. It extracts a reusable `MarkdownPage` component to the shared UI library and configures Webpack to handle markdown files. This allows for easier maintenance of legal content as plain markdown files rather than embedded HTML.

- **Type:** New feature / Refactor

## 🛠️ Key Changes
- Added markdown-loader configuration in Next.js config
- Created a TypeScript declaration file for markdown imports
- Created a reusable `MarkdownPage` component in the shared UI library
- Refactored Privacy Policy and Terms of Use pages to use markdown content
- Made `isHomepage` optional in `PageHeader.Title` with a default value of `false`
- Removed redundant heading tags from markdown files