### PR TITLE
FIX: Add CaretRight to FFDW Cards [skip percy]

### DIFF
--- a/apps/ff-site/src/app/(homepage)/components/FeaturedEcosystemProjects.tsx
+++ b/apps/ff-site/src/app/(homepage)/components/FeaturedEcosystemProjects.tsx
@@ -28,7 +28,9 @@ export function FeaturedEcosystemProjects({
           cta={{
             href: `${PATHS.ECOSYSTEM_EXPLORER.path}/${slug}`,
             text: 'Learn More',
-            icon: MagnifyingGlass,
+            icon: {
+              component: MagnifyingGlass,
+            },
           }}
           image={{
             ...(image || graphicsData.imageFallback.data),

--- a/apps/ff-site/src/app/about/page.tsx
+++ b/apps/ff-site/src/app/about/page.tsx
@@ -131,7 +131,9 @@ export default function About() {
                   cta={{
                     href: link,
                     text: 'View Report',
-                    icon: Files,
+                    icon: {
+                      component: Files,
+                    },
                   }}
                 />
               </li>

--- a/apps/ff-site/src/app/blog/components/BlogContent.tsx
+++ b/apps/ff-site/src/app/blog/components/BlogContent.tsx
@@ -143,7 +143,9 @@ export function BlogContent({ posts }: BlogContentProps) {
                       cta={{
                         href: `${PATHS.BLOG.path}/${slug}`,
                         text: 'Read Post',
-                        icon: BookOpen,
+                        icon: {
+                          component: BookOpen,
+                        },
                       }}
                       image={{
                         ...(image || graphicsData.imageFallback.data),

--- a/apps/ff-site/src/app/digest/page.tsx
+++ b/apps/ff-site/src/app/digest/page.tsx
@@ -78,7 +78,9 @@ export default async function Digest() {
                 cta={{
                   href: `${PATHS.DIGEST.path}/${slug}`,
                   text: 'Read Article',
-                  icon: BookOpen,
+                  icon: {
+                    component: BookOpen,
+                  },
                 }}
                 image={{
                   ...(image || graphicsData.imageFallback.data),

--- a/apps/ff-site/src/app/ecosystem-explorer/components/EcosystemExplorerContent.tsx
+++ b/apps/ff-site/src/app/ecosystem-explorer/components/EcosystemExplorerContent.tsx
@@ -139,7 +139,9 @@ export function EcosystemExplorerContent({
                       cta={{
                         href: `${PATHS.ECOSYSTEM_EXPLORER.path}/${slug}`,
                         text: 'Learn More',
-                        icon: BookOpen,
+                        icon: {
+                          component: BookOpen,
+                        },
                       }}
                       image={{
                         ...(image || graphicsData.imageFallback.data),

--- a/apps/ff-site/src/app/events/[slug]/components/ProgramSection.tsx
+++ b/apps/ff-site/src/app/events/[slug]/components/ProgramSection.tsx
@@ -28,7 +28,9 @@ export function ProgramSection({ title, kicker, events }: ProgramSectionProps) {
             cta: {
               href: externalLink,
               text: DEFAULT_CTA_TEXT,
-              icon: MagnifyingGlass,
+              icon: {
+                component: MagnifyingGlass,
+              },
             },
           }
 

--- a/apps/ff-site/src/app/events/components/EventsContent.tsx
+++ b/apps/ff-site/src/app/events/components/EventsContent.tsx
@@ -171,7 +171,9 @@ export default function EventsContent({
                           shouldLinkToExternalEventsPage ||
                           `${PATHS.EVENTS.path}/${slug}`,
                         text: DEFAULT_CTA_TEXT,
-                        icon: MagnifyingGlass,
+                        icon: {
+                          component: MagnifyingGlass,
+                        },
                       }}
                     />
                   )

--- a/apps/ff-site/src/app/events/data/getInvolvedData.ts
+++ b/apps/ff-site/src/app/events/data/getInvolvedData.ts
@@ -1,17 +1,26 @@
+import type { CTAProps } from '@filecoin-foundation/utils/types/ctaType'
 import { Clipboard, Envelope, HandWaving } from '@phosphor-icons/react/dist/ssr'
 
 import { FILECOIN_FOUNDATION_URLS } from '@/constants/siteMetadata'
 
 import { extractEmailAddress } from '@/utils/extractEmailAddress'
 
-export const getInvolvedData = [
+type GetInvolvedData = {
+  title: string
+  description: string
+  cta: CTAProps
+}
+
+export const getInvolvedData: GetInvolvedData[] = [
   {
     title: 'Sponsor an Event',
     description: `To be featured partner or sponsor an upcoming Foundation-hosted event, reach out to ${extractEmailAddress(FILECOIN_FOUNDATION_URLS.events.sponsorshipsEmail)}.`,
     cta: {
       href: FILECOIN_FOUNDATION_URLS.events.sponsorshipsEmail,
       text: 'Email Us',
-      icon: Envelope,
+      icon: {
+        component: Envelope,
+      },
     },
   },
   {
@@ -21,7 +30,9 @@ export const getInvolvedData = [
     cta: {
       href: FILECOIN_FOUNDATION_URLS.events.speakerEngagementForm,
       text: 'Submit Form',
-      icon: Clipboard,
+      icon: {
+        component: Clipboard,
+      },
     },
   },
   {
@@ -31,7 +42,9 @@ export const getInvolvedData = [
     cta: {
       href: FILECOIN_FOUNDATION_URLS.events.orbitAmbassadorForm,
       text: 'Apply to Filecoin Orbit',
-      icon: HandWaving,
+      icon: {
+        component: HandWaving,
+      },
     },
   },
 ]

--- a/apps/ff-site/src/app/events/data/getInvolvedData.ts
+++ b/apps/ff-site/src/app/events/data/getInvolvedData.ts
@@ -11,7 +11,7 @@ type GetInvolvedData = {
   cta: CTAProps
 }
 
-export const getInvolvedData: GetInvolvedData[] = [
+export const getInvolvedData: Array<GetInvolvedData> = [
   {
     title: 'Sponsor an Event',
     description: `To be featured partner or sponsor an upcoming Foundation-hosted event, reach out to ${extractEmailAddress(FILECOIN_FOUNDATION_URLS.events.sponsorshipsEmail)}.`,

--- a/apps/ff-site/src/app/grants/components/FeaturedGrantGraduates.tsx
+++ b/apps/ff-site/src/app/grants/components/FeaturedGrantGraduates.tsx
@@ -27,7 +27,9 @@ export function FeaturedGrantGraduates({
           cta={{
             href: `${PATHS.ECOSYSTEM_EXPLORER.path}/${slug}`,
             text: 'Read More',
-            icon: BookOpen,
+            icon: {
+              component: BookOpen,
+            },
           }}
           image={{
             ...(image || graphicsData.imageFallback.data),

--- a/apps/ffdweb-site/src/app/blog/components/BlogContent.tsx
+++ b/apps/ffdweb-site/src/app/blog/components/BlogContent.tsx
@@ -67,10 +67,12 @@ export function BlogContent({ posts }: BlogContentProps) {
               cta={{
                 href: `${PATHS.BLOG.path}/${slug}`,
                 text: 'Read Post',
-                icon: CaretRight,
-                size: 16,
-                position: 'trailing',
-                weight: 'bold',
+                icon: {
+                  component: CaretRight,
+                  size: 16,
+                  position: 'trailing',
+                  weight: 'bold',
+                },
               }}
               image={{
                 ...(image || graphicsData.imageFallback.data),

--- a/apps/ffdweb-site/src/app/blog/components/BlogContent.tsx
+++ b/apps/ffdweb-site/src/app/blog/components/BlogContent.tsx
@@ -68,6 +68,9 @@ export function BlogContent({ posts }: BlogContentProps) {
                 href: `${PATHS.BLOG.path}/${slug}`,
                 text: 'Read Post',
                 icon: CaretRight,
+                size: 16,
+                position: 'trailing',
+                weight: 'bold',
               }}
               image={{
                 ...(image || graphicsData.imageFallback.data),

--- a/apps/ffdweb-site/src/app/blog/components/BlogContent.tsx
+++ b/apps/ffdweb-site/src/app/blog/components/BlogContent.tsx
@@ -12,7 +12,7 @@ import {
 } from '@filecoin-foundation/utils/constants/urlParamsConstants'
 import { formatDate } from '@filecoin-foundation/utils/dateUtils'
 import { normalizeQueryParam } from '@filecoin-foundation/utils/urlUtils'
-import { BookOpen } from '@phosphor-icons/react/dist/ssr'
+import { CaretRight } from '@phosphor-icons/react'
 
 import { PATHS } from '@/constants/paths'
 
@@ -67,7 +67,7 @@ export function BlogContent({ posts }: BlogContentProps) {
               cta={{
                 href: `${PATHS.BLOG.path}/${slug}`,
                 text: 'Read Post',
-                icon: BookOpen,
+                icon: CaretRight,
               }}
               image={{
                 ...(image || graphicsData.imageFallback.data),

--- a/apps/ffdweb-site/src/app/digest/page.tsx
+++ b/apps/ffdweb-site/src/app/digest/page.tsx
@@ -67,7 +67,12 @@ export default async function Digest() {
                 cta={{
                   href: `${PATHS.DIGEST.path}/${slug}`,
                   text: 'Read Article',
-                  icon: CaretRight,
+                  icon: {
+                    component: CaretRight,
+                    size: 16,
+                    position: 'trailing',
+                    weight: 'bold',
+                  },
                 }}
                 image={{
                   ...(image || graphicsData.imageFallback.data),

--- a/apps/ffdweb-site/src/app/digest/page.tsx
+++ b/apps/ffdweb-site/src/app/digest/page.tsx
@@ -3,6 +3,7 @@ import { PageLayout } from '@filecoin-foundation/ui/PageLayout'
 import { Social } from '@filecoin-foundation/ui/Social'
 import { StructuredDataScript } from '@filecoin-foundation/ui/StructuredDataScript'
 import { buildImageSizeProp } from '@filecoin-foundation/utils/buildImageSizeProp'
+import { CaretRight } from '@phosphor-icons/react/dist/ssr'
 
 import { PATHS } from '@/constants/paths'
 
@@ -66,6 +67,7 @@ export default async function Digest() {
                 cta={{
                   href: `${PATHS.DIGEST.path}/${slug}`,
                   text: 'Read Article',
+                  icon: CaretRight,
                 }}
                 image={{
                   ...(image || graphicsData.imageFallback.data),

--- a/packages/ui/src/Card.tsx
+++ b/packages/ui/src/Card.tsx
@@ -18,7 +18,7 @@ import type {
   ImageObjectFit,
   StaticImageProps,
 } from '@filecoin-foundation/utils/types/imageType'
-import { ArrowUpRight, CaretRight } from '@phosphor-icons/react/dist/ssr'
+import { ArrowUpRight } from '@phosphor-icons/react/dist/ssr'
 import { clsx } from 'clsx'
 
 import { Meta, type MetaDataType } from './Meta'

--- a/packages/ui/src/Card.tsx
+++ b/packages/ui/src/Card.tsx
@@ -18,7 +18,7 @@ import type {
   ImageObjectFit,
   StaticImageProps,
 } from '@filecoin-foundation/utils/types/imageType'
-import { ArrowUpRight } from '@phosphor-icons/react/dist/ssr'
+import { ArrowUpRight, CaretRight } from '@phosphor-icons/react/dist/ssr'
 import { clsx } from 'clsx'
 
 import { Meta, type MetaDataType } from './Meta'
@@ -193,6 +193,13 @@ function renderCardLinkContent({
 }: NonNullable<CardProps['cta']>) {
   const isExternal = isExternalLink(href, baseDomain)
   const textElement = <span key="text">{text}</span>
+
+  if (icon === CaretRight) {
+    return [
+      textElement,
+      <Icon key="caret-right" component={icon} size={16} weight="bold" />,
+    ]
+  }
 
   if (icon) {
     return [<Icon key="custom-icon" component={icon} />, textElement]

--- a/packages/ui/src/Card.tsx
+++ b/packages/ui/src/Card.tsx
@@ -194,20 +194,18 @@ function renderCardLinkContent({
   const isExternal = isExternalLink(href, baseDomain)
   const textElement = <span key="text">{text}</span>
 
-  if (icon === CaretRight) {
-    return [
-      textElement,
-      <Icon key="caret-right" component={icon} size={16} weight="bold" />,
-    ]
+  if (!icon) {
+    return isExternal
+      ? [textElement, <Icon key="arrow" component={ArrowUpRight} />]
+      : textElement
   }
 
-  if (icon) {
-    return [<Icon key="custom-icon" component={icon} />, textElement]
-  }
+  const { component, size, position = 'leading', weight } = icon
+  const iconElement = (
+    <Icon key="custom-icon" component={component} size={size} weight={weight} />
+  )
 
-  if (isExternal) {
-    return [textElement, <Icon key="arrow" component={ArrowUpRight} />]
-  }
-
-  return textElement
+  return position === 'leading'
+    ? [iconElement, textElement]
+    : [textElement, iconElement]
 }

--- a/packages/utils/src/types/ctaType.ts
+++ b/packages/utils/src/types/ctaType.ts
@@ -1,8 +1,15 @@
 import { type IconProps } from '@filecoin-foundation/ui/Icon'
 
+type CTAIconProps = {
+  component: IconProps['component']
+  size?: IconProps['size']
+  position?: 'leading' | 'trailing'
+  weight?: IconProps['weight']
+}
+
 export type CTAProps = {
   href: string
   text: string
-  icon?: IconProps['component']
+  icon?: CTAIconProps
   ariaLabel?: string
 }


### PR DESCRIPTION
## 📝 Description

Refactors `Card` `cta` prop in order to customise `Icon` (size, position, weight)

- **Type:** Bug fix

![Screenshot 2025-03-10 at 10 13 44](https://github.com/user-attachments/assets/3b70fe45-5eb3-4a32-be9f-bf1bf0310b3d)
