### PR TITLE
FFDW: Add ShareArticle to Blog Posts [skip percy]

### DIFF
--- a/apps/ffdweb-site/src/app/blog/[slug]/page.tsx
+++ b/apps/ffdweb-site/src/app/blog/[slug]/page.tsx
@@ -1,7 +1,11 @@
 import { ArticleLayout } from '@filecoin-foundation/ui/Article/ArticleLayout'
 import { BlogPostHeader } from '@filecoin-foundation/ui/BlogPostHeader'
 import { PageLayout } from '@filecoin-foundation/ui/PageLayout'
+import { ShareArticle } from '@filecoin-foundation/ui/ShareArticle'
 import { type SlugParams } from '@filecoin-foundation/utils/types/paramsTypes'
+
+import { PATHS } from '@/constants/paths'
+import { BASE_URL } from '@/constants/siteMetadata'
 
 import { graphicsData } from '@/data/graphicsData'
 
@@ -37,8 +41,13 @@ export default async function BlogPost(props: BlogPostProps) {
             alt: '',
           }}
         />
-
         <MarkdownContent>{content}</MarkdownContent>
+        <ShareArticle
+          articleTitle={title}
+          path={`${PATHS.BLOG.path}/${slug}`}
+          baseUrl={BASE_URL}
+          sectionTitle="Share Post"
+        />
       </ArticleLayout>
     </PageLayout>
   )


### PR DESCRIPTION
## 📝 Description

This PR adds `ShareArticle` component to FFDW Blog Posts.

- **Type:** New feature



## 📸 Screenshots
![Screenshot 2025-03-11 at 13 35 01](https://github.com/user-attachments/assets/b0760a01-3812-45bd-a178-59010500e976)
