### PR TITLE
[FFDW][UXIT-2362] Projects · Update active partnerships [skip percy]

### DIFF
--- a/apps/ffdweb-site/public/admin/config.yml
+++ b/apps/ffdweb-site/public/admin/config.yml
@@ -400,11 +400,11 @@ collections:
         widget: "string"
         required: false
         hint: "Optional link to the project's website or repository."
-      - name: "has-collaborations"
-        label: "Has Collaborations"
+      - name: "active-partnership"
+        label: "Active Partnership"
         widget: "boolean"
         default: false
         required: false
-        hint: "Check if this project involved collaborations."
+        hint: "Check if this project has a current active partnership."
       - *image_config
       - *meta_config_with_title_fallback

--- a/apps/ffdweb-site/src/app/projects/schemas/ProjectFrontmatterSchema.ts
+++ b/apps/ffdweb-site/src/app/projects/schemas/ProjectFrontmatterSchema.ts
@@ -6,5 +6,5 @@ export const ProjectFrontmatterSchema = DynamicBaseDataSchema.extend({
   description: z.string(),
   'external-link': z.string().optional(),
   'featured-content': z.string().optional(),
-  'has-collaborations': z.boolean().optional().default(false),
+  'active-partnership': z.boolean().optional().default(false),
 }).strict()

--- a/apps/ffdweb-site/src/content/projects/cc-pk-movement-for-a-better-internet.md
+++ b/apps/ffdweb-site/src/content/projects/cc-pk-movement-for-a-better-internet.md
@@ -10,7 +10,7 @@ description: FFDW supports the Movement for a Better Internet, a collaborative
 image:
   src: /assets/images/partnerlogo_movementbetterinternet.png
 external-link: https://www.movementforabetterinternet.org/
-has-collaborations: true
+active-partnership: true
 seo:
   description: "FFDW supports the Movement for a Better Internet, a collaborative initiative working to shape the future of the internet around public interest values and improve the web for everyone."
 ---

--- a/apps/ffdweb-site/src/content/projects/connect-humanity.md
+++ b/apps/ffdweb-site/src/content/projects/connect-humanity.md
@@ -16,7 +16,7 @@ image:
   src: https://pbs.twimg.com/profile_images/1511746714688016387/EB6IZmuH_400x400.jpg
 featured-content: https://www.ffdweb.org/blog/ffdw-and-connect-humanity-empowering-an-equitable-digital-future
 external-link: https://connecthumanity.fund/
-has-collaborations: true
+active-partnership: true
 seo:
   description: "Connect Humanity conducts global surveys through community organizations to understand internet usage patterns and needs, advancing digital equity worldwide."
 ---

--- a/apps/ffdweb-site/src/content/projects/decentralized-future-council.md
+++ b/apps/ffdweb-site/src/content/projects/decentralized-future-council.md
@@ -13,6 +13,7 @@ description:
 image:
   src: /assets/images/partnerlogo_decentfuturecoucil.png
 external-link: https://www.decentralizedfuturecouncil.org/
+active-partnership: true
 seo:
   description: "The Decentralized Future Council educates policymakers on emerging technologies like blockchain and cryptocurrency, addressing challenges in privacy, security, and digital trust."
 ---

--- a/apps/ffdweb-site/src/content/projects/sacred-stacks.md
+++ b/apps/ffdweb-site/src/content/projects/sacred-stacks.md
@@ -12,7 +12,7 @@ description: Sacred Stacks is an initiative within the Media Design Lab at the
 image:
   src: /assets/images/partnerlogo_boulder.png
 featured-content: https://www.ffdweb.org/blog/ffdw-and-sacred-stacks-building-community-with-decentralized-tools/
-has-collaborations: true
+active-partnership: true
 seo:
   description: "Sacred Stacks explores how decentralized technologies can strengthen communities focused on spiritual experimentation, collective study, and social transformation."
 ---

--- a/apps/ffdweb-site/src/content/projects/stack-shift.md
+++ b/apps/ffdweb-site/src/content/projects/stack-shift.md
@@ -11,6 +11,7 @@ description:
 image:
   src: /assets/images/partnerlogo_stackshift.png
 external-link: https://www.stackshift.com/
+active-partnership: true
 seo:
   description: "Stack Shift connects remote talent in Africa with high-impact jobs at DWeb startups, advancing distributed work opportunities and expanding professional networks."
 ---

--- a/apps/ffdweb-site/src/content/projects/ushahidi.md
+++ b/apps/ffdweb-site/src/content/projects/ushahidi.md
@@ -12,7 +12,6 @@ description:
 image:
   src: /assets/images/ushahidi-logo_black_1x-1-.png
 external-link: https://www.ushahidi.com/
-has-collaborations: true
 seo:
   description: "Ushahidi's Election Data Resilience Initiative uses Filecoin to create a permanent, verifiable repository of election data for researchers and policymakers."
 ---

--- a/apps/ffdweb-site/src/content/projects/world-wide-web-foundation-1.md
+++ b/apps/ffdweb-site/src/content/projects/world-wide-web-foundation-1.md
@@ -14,6 +14,7 @@ description:
   and in what areas a course correction is needed.
 image:
   src: /assets/images/web-foundation-hi-res-logo.jpeg
+active-partnership: true
 seo:
   description: "The Web Foundation advances Tim Berners-Lee's vision of an open web through the Web Index project, monitoring emerging issues and ensuring a safe digital future."
 ---


### PR DESCRIPTION
## Description

- Renamed `has-collaborations` to `active-partnership` in the project schema
- Updated CMS configuration with new field name and description
- Updated all relevant project markdown files to use the new field name
- Added `active-partnership: true` to previously unmarked active partners

This change better reflects the current status of partnerships rather than just indicating if collaborations existed.