### PR TITLE
[UXIT-2372] Delete descriptions fields from Blog Post data

### DIFF
--- a/apps/ff-site/src/app/(homepage)/page.tsx
+++ b/apps/ff-site/src/app/(homepage)/page.tsx
@@ -65,7 +65,7 @@ export default async function Home() {
         <StructuredDataScript structuredData={ORGANIZATION_SCHEMA_BASE} />
         <PageHeader
           title={header.title}
-          description={header.description}
+          description={{ text: header.description }}
           image={graphicsData.home}
         >
           <CTAButtonGroup

--- a/apps/ff-site/src/app/_components/CTASection.tsx
+++ b/apps/ff-site/src/app/_components/CTASection.tsx
@@ -1,16 +1,15 @@
 import { Button } from '@filecoin-foundation/ui/Button'
 import {
   DescriptionText,
-  type DescriptionTextType,
+  type DescriptionProps,
 } from '@filecoin-foundation/ui/DescriptionText'
 import { Heading } from '@filecoin-foundation/ui/Heading'
-
 
 import { BASE_DOMAIN } from '@/constants/siteMetadata'
 
 type CTASectionProps = {
   title: string
-  description: DescriptionTextType
+  description: DescriptionProps['children']
   cta?: {
     href: string
     text: string

--- a/apps/ff-site/src/app/_components/PageSection.tsx
+++ b/apps/ff-site/src/app/_components/PageSection.tsx
@@ -2,7 +2,7 @@ import Image from 'next/image'
 
 import {
   DescriptionText,
-  type DescriptionTextType,
+  type DescriptionProps,
 } from '@filecoin-foundation/ui/DescriptionText'
 import { Heading } from '@filecoin-foundation/ui/Heading'
 import { buildImageSizeProp } from '@filecoin-foundation/utils/buildImageSizeProp'
@@ -21,7 +21,7 @@ import {
 type PageSectionProps = {
   kicker: SectionDividerProps['title']
   title: string
-  description?: DescriptionTextType
+  description?: DescriptionProps['children']
   image?: StaticImageProps
   cta?: CTAButtonGroupProps['cta']
   children?: React.ReactNode

--- a/apps/ff-site/src/app/about/page.tsx
+++ b/apps/ff-site/src/app/about/page.tsx
@@ -47,7 +47,7 @@ export default function About() {
 
       <PageHeader
         title={header.title}
-        description={header.description}
+        description={{ text: header.description }}
         image={graphicsData.about}
       >
         <Button href={FILECOIN_FOUNDATION_URLS.annualReports['2024']}>

--- a/apps/ff-site/src/app/blog/page.tsx
+++ b/apps/ff-site/src/app/blog/page.tsx
@@ -48,7 +48,7 @@ export default async function Blog() {
       <PageHeader
         sectionDividerTitle="Featured"
         title={featuredPost.title}
-        description={featuredPost.description}
+        description={{ text: featuredPost.description }}
         metaData={[formatDate(featuredPost.publishedOn)]}
         image={{
           ...(featuredPost.image || graphicsData.imageFallback.data),

--- a/apps/ff-site/src/app/digest/page.tsx
+++ b/apps/ff-site/src/app/digest/page.tsx
@@ -41,7 +41,7 @@ export default async function Digest() {
       <StructuredDataScript structuredData={generateStructuredData(seo)} />
       <PageHeader
         title={header.title}
-        description={header.description}
+        description={{ text: header.description }}
         image={graphicsData.digest}
       />
 

--- a/apps/ff-site/src/app/ecosystem-explorer/page.tsx
+++ b/apps/ff-site/src/app/ecosystem-explorer/page.tsx
@@ -46,7 +46,7 @@ export default async function EcosystemExplorer(props: Props) {
 
       <PageHeader
         title={header.title}
-        description={header.description}
+        description={{ text: header.description }}
         image={graphicsData.ecosystem}
       >
         <Button href={PATHS.ECOSYSTEM_EXPLORER_PROJECT_FORM.path}>

--- a/apps/ff-site/src/app/events/[slug]/page.tsx
+++ b/apps/ff-site/src/app/events/[slug]/page.tsx
@@ -94,7 +94,7 @@ export default async function EventEntry(props: EventProps) {
 
         <PageHeader
           title={title}
-          description={description}
+          description={{ text: description }}
           metaData={getMetaData({
             startDate,
             endDate,

--- a/apps/ff-site/src/app/events/page.tsx
+++ b/apps/ff-site/src/app/events/page.tsx
@@ -59,7 +59,7 @@ export default async function Events(props: Props) {
       <PageHeader
         sectionDividerTitle="Featured"
         title={featuredEvent.title}
-        description={featuredEvent.description}
+        description={{ text: featuredEvent.description }}
         metaData={getMetaData({
           startDate: featuredEvent.startDate,
           endDate: featuredEvent.endDate,

--- a/apps/ff-site/src/app/filecoin-plus/allocators/page.tsx
+++ b/apps/ff-site/src/app/filecoin-plus/allocators/page.tsx
@@ -31,7 +31,7 @@ export default function Allocators() {
       <StructuredDataScript structuredData={generateStructuredData(seo)} />
       <PageHeader
         title={header.title}
-        description={header.description}
+        description={{ text: header.description }}
         image={graphicsData.filPlusAllocators}
       />
 

--- a/apps/ff-site/src/app/filecoin-plus/page.tsx
+++ b/apps/ff-site/src/app/filecoin-plus/page.tsx
@@ -47,7 +47,7 @@ export default function FilPlus() {
       <StructuredDataScript structuredData={generateStructuredData(seo)} />
       <PageHeader
         title={header.title}
-        description={header.description}
+        description={{ text: header.description }}
         image={graphicsData.filPlus}
       >
         <Button href={FIL_PLUS_URLS.documentation}>

--- a/apps/ff-site/src/app/governance/page.tsx
+++ b/apps/ff-site/src/app/governance/page.tsx
@@ -37,7 +37,7 @@ export default function Governance() {
       <StructuredDataScript structuredData={generateStructuredData(seo)} />
       <PageHeader
         title={header.title}
-        description={header.description}
+        description={{ text: header.description }}
         image={graphicsData.governance2}
       />
 

--- a/apps/ff-site/src/app/grants/page.tsx
+++ b/apps/ff-site/src/app/grants/page.tsx
@@ -56,7 +56,7 @@ export default async function Grants() {
       <StructuredDataScript structuredData={generateStructuredData(seo)} />
       <PageHeader
         title={header.title}
-        description={header.description}
+        description={{ text: header.description }}
         image={graphicsData.grants}
       >
         <Button href={FILECOIN_FOUNDATION_URLS.grants.github}>Apply Now</Button>

--- a/apps/ff-site/src/app/orbit/page.tsx
+++ b/apps/ff-site/src/app/orbit/page.tsx
@@ -58,7 +58,7 @@ export default async function Orbit(props: Props) {
       <StructuredDataScript structuredData={generateStructuredData(seo)} />
       <PageHeader
         title={header.title}
-        description={header.description}
+        description={{ text: header.description }}
         image={graphicsData.orbit}
       >
         <CTAButtonGroup

--- a/apps/ff-site/src/app/security/bug-bounty/page.tsx
+++ b/apps/ff-site/src/app/security/bug-bounty/page.tsx
@@ -35,7 +35,7 @@ export default function BugBounty() {
       <StructuredDataScript structuredData={generateStructuredData(seo)} />
       <PageHeader
         title={header.title}
-        description={header.description}
+        description={{ text: header.description }}
         image={graphicsData.security4}
       >
         <Button href={FILECOIN_FOUNDATION_URLS.security.bugBountyProgram}>

--- a/apps/ff-site/src/app/security/maturity-model/page.tsx
+++ b/apps/ff-site/src/app/security/maturity-model/page.tsx
@@ -39,7 +39,7 @@ export default function MaturityModel() {
       <StructuredDataScript structuredData={generateStructuredData(seo)} />
       <PageHeader
         title={header.title}
-        description={header.description}
+        description={{ text: header.description }}
         image={graphicsData.security5}
       />
 

--- a/apps/ff-site/src/app/security/page.tsx
+++ b/apps/ff-site/src/app/security/page.tsx
@@ -39,7 +39,7 @@ export default function Security() {
       <StructuredDataScript structuredData={generateStructuredData(seo)} />
       <PageHeader
         title={header.title}
-        description={header.description}
+        description={{ text: header.description }}
         image={graphicsData.security}
       >
         <CTAButtonGroup

--- a/apps/ffdweb-site/src/app/_components/PageSection.tsx
+++ b/apps/ffdweb-site/src/app/_components/PageSection.tsx
@@ -1,6 +1,6 @@
 import {
   DescriptionText,
-  type DescriptionTextType,
+  type DescriptionProps,
 } from '@filecoin-foundation/ui/DescriptionText'
 import { Heading } from '@filecoin-foundation/ui/Heading'
 import { clsx } from 'clsx'
@@ -9,7 +9,7 @@ export type PageSectionProps = {
   kicker: string
   title: string
   children?: React.ReactNode
-  description?: DescriptionTextType
+  description?: DescriptionProps['children']
   isCentered?: boolean
   as?: React.ElementType
 }

--- a/apps/ffdweb-site/src/app/blog/page.tsx
+++ b/apps/ffdweb-site/src/app/blog/page.tsx
@@ -40,7 +40,7 @@ export default async function Blog() {
         isFeatured
         title={featuredPost.title}
         metaData={[formatDate(featuredPost.publishedOn)]}
-        description={featuredPost.description}
+        description={{ text: featuredPost.description, isClamped: true }}
         image={{
           ...(featuredPost.image || graphicsData.imageFallback.data),
           alt: '',

--- a/apps/ffdweb-site/src/app/blog/schemas/BlogPostFrontmatterSchema.ts
+++ b/apps/ffdweb-site/src/app/blog/schemas/BlogPostFrontmatterSchema.ts
@@ -14,6 +14,5 @@ const CategorySchema = createEnumSchema(validCategoryIds)
 export const BlogPostFrontmatterSchema = DynamicBaseDataSchema.extend({
   title: z.string(),
   category: CategorySchema,
-  description: z.string(),
   content: z.string(),
 }).strict()

--- a/apps/ffdweb-site/src/app/blog/utils/getBlogPostData.ts
+++ b/apps/ffdweb-site/src/app/blog/utils/getBlogPostData.ts
@@ -1,5 +1,6 @@
 import { getAllMarkdownData } from '@filecoin-foundation/utils/getAllMarkdownData'
 import { getMarkdownData } from '@filecoin-foundation/utils/getMarkdownData'
+import removeMarkdown from 'remove-markdown'
 
 import { PATHS } from '@/constants/paths'
 
@@ -34,6 +35,7 @@ function transformBlogPostData(
 ) {
   return {
     ...post,
+    description: removeMarkdown(post.content),
     seo: {
       ...post.seo,
       title: post.seo.title || post.title,

--- a/apps/ffdweb-site/src/content/blog/2022-ffdw-report.md
+++ b/apps/ffdweb-site/src/content/blog/2022-ffdw-report.md
@@ -4,9 +4,6 @@ created-on: "2023-04-21T07:15:29.818Z"
 updated-on: "2023-04-21T07:15:29.818Z"
 published-on: "2023-04-21T08:01:04.314Z"
 category: updates
-description: >-
-  The following pages highlight FFDW's project partners and provide updates on
-  our work together in 2022.
 image:
   src: >-
     https://uploads-ssl.webflow.com/643e92b3a344778457270525/64423811e3c08f0a484e3bc4_0206-22-annual-report.png

--- a/apps/ffdweb-site/src/content/blog/accelerating-the-makers-of-civil-society.md
+++ b/apps/ffdweb-site/src/content/blog/accelerating-the-makers-of-civil-society.md
@@ -4,7 +4,6 @@ created-on: 2023-05-18T10:01:01.297Z
 updated-on: 2023-05-18T10:01:00.000Z
 published-on: 2023-05-18T10:01:00.000Z
 category: projects
-description: ""
 image:
   src: /assets/images/051723-techsoup.png
 seo:

--- a/apps/ffdweb-site/src/content/blog/announcing-filecoin-foundation-for-the-decentralized-web-s-first-open-request-for-proposals.md
+++ b/apps/ffdweb-site/src/content/blog/announcing-filecoin-foundation-for-the-decentralized-web-s-first-open-request-for-proposals.md
@@ -6,11 +6,6 @@ created-on: "2023-04-21T07:15:31.358Z"
 updated-on: "2023-04-21T07:18:12.889Z"
 published-on: "2023-04-21T08:01:04.314Z"
 category: projects
-description: >-
-  Filecoin Foundation for the Decentralized Web (FFDW) is launching an open
-  request for proposals (RFP). We’re looking for projects that support our core
-  mission — to ensure the permanent preservation of humanity’s most important
-  information.
 image:
   src: >-
     https://uploads-ssl.webflow.com/643e92b3a344778457270525/64423813d1b0259171f6ef5e_ffdw-request-for-proposals.png

--- a/apps/ffdweb-site/src/content/blog/announcing-the-decentralized-future-council.md
+++ b/apps/ffdweb-site/src/content/blog/announcing-the-decentralized-future-council.md
@@ -4,11 +4,6 @@ updated-on: "2023-04-21T07:18:14.180Z"
 created-on: "2023-04-21T07:15:32.959Z"
 published-on: "2023-04-21T08:01:04.314Z"
 category: projects
-description: >-
-  The Decentralized Future Council (DFC) is a new organization dedicated to
-  advocacy and education for the emerging decentralized web and related
-  technologies.
-
 image:
   src: >-
     https://uploads-ssl.webflow.com/643e92b3a344778457270525/644238143db3a057d266cecd_1-dxorkqq-jlhbhjiqkehiig.png

--- a/apps/ffdweb-site/src/content/blog/announcing-the-social-impact-summit-2024.md
+++ b/apps/ffdweb-site/src/content/blog/announcing-the-social-impact-summit-2024.md
@@ -4,7 +4,6 @@ created-on: 2023-12-12T18:49:11.746Z
 updated-on: 2023-12-12T18:49:11.759Z
 published-on: 2023-12-12T18:49:11.767Z
 category: projects
-description: ""
 image:
   src: /assets/images/eventbrite-header.png
 seo:

--- a/apps/ffdweb-site/src/content/blog/announcing-the-starling-lab.md
+++ b/apps/ffdweb-site/src/content/blog/announcing-the-starling-lab.md
@@ -4,11 +4,6 @@ created-on: "2023-04-21T07:15:34.887Z"
 updated-on: "2023-04-21T07:18:15.412Z"
 published-on: "2023-04-21T08:01:04.314Z"
 category: projects
-description: >-
-  The Filecoin Foundation for the Decentralized Web (FFDW) and Protocol Labs are
-  thrilled to announce a multi-year commitment to The Starling Lab, a new
-  research center tackling the technical and ethical challenges of establishing
-  trust in the most sensitive digital records of our human history.
 image:
   src: >-
     https://uploads-ssl.webflow.com/643e92b3a344778457270525/64423816edebc4ceb27492e7_starling-lab-image.jpeg

--- a/apps/ffdweb-site/src/content/blog/authors-alliance-and-filecoin-foundation-for-the-decentralized-web-supporting-public-interest-authors-with-decentralized-tools.md
+++ b/apps/ffdweb-site/src/content/blog/authors-alliance-and-filecoin-foundation-for-the-decentralized-web-supporting-public-interest-authors-with-decentralized-tools.md
@@ -4,11 +4,6 @@ created-on: 2024-05-14T16:49:15.493Z
 updated-on: 2024-05-14T16:49:15.502Z
 published-on: 2024-05-14T16:49:15.507Z
 category: projects
-description: "This is a guest post from FFDW project partner, Authors
-  Alliance, written by Dave Hansen, Authors Alliance Executive Director. Founded
-  in 2014, Authors Alliance is a 501(c)(3) nonprofit that advocates for the
-  interests of authors who want to serve the public good by sharing their
-  creations broadly."
 image:
   src: /assets/images/021024-guest-authorsalliance.png
 seo:

--- a/apps/ffdweb-site/src/content/blog/big-ideas-driving-the-decentralized-web.md
+++ b/apps/ffdweb-site/src/content/blog/big-ideas-driving-the-decentralized-web.md
@@ -4,14 +4,6 @@ updated-on: "2023-04-21T07:18:16.763Z"
 created-on: "2023-04-21T07:15:36.863Z"
 published-on: "2023-04-21T08:01:04.314Z"
 category: technology
-description: >-
-  We are at a fork in the road when it comes to building an internet that
-  enhances trust, allows users to maintain privacy, incentivizes entrepreneurs
-  to build safe and secure systems, and enables the preservation of the world's
-  most important information for future generations. At Filecoin Foundation for
-  the Decentralized Web (FFDW), we believe that the Internet must return to its
-  original – more decentralized – architecture. Some call this direction "Web3";
-  some call it the decentralized web or"DWeb."
 image:
   src: >-
     https://uploads-ssl.webflow.com/643e92b3a344778457270525/64423818a6ec41950428fad8_0928-ffdw-glossary.png

--- a/apps/ffdweb-site/src/content/blog/building-distributed-press-a-publishing-tool-for-the-decentralized-web.md
+++ b/apps/ffdweb-site/src/content/blog/building-distributed-press-a-publishing-tool-for-the-decentralized-web.md
@@ -4,15 +4,11 @@ updated-on: "2023-04-21T07:15:38.854Z"
 created-on: "2023-04-21T07:15:38.854Z"
 published-on: "2023-04-21T08:01:04.314Z"
 category: projects
-description: >-
-  FFDW works with Hypha Worker Co-operative and Sutty to foster decentralized
-  web publishing tools that offer creators an alternative to centralized
-  publishing platforms.
 image:
   src: >-
     https://uploads-ssl.webflow.com/643e92b3a344778457270525/6442381aaf6e60375caa347a_0208-distributedpress.png
 seo:
-  description: ""
+  description: "FFDW partners with Hypha and Sutty to develop Distributed Press, an open-source publishing platform empowering creators with decentralized alternatives to traditional publishing."
 ---
 
 **_FFDW works with Hypha Worker Co-operative and Sutty to foster decentralized web publishing tools that offer creators an alternative to centralized publishing platforms._**

--- a/apps/ffdweb-site/src/content/blog/can-filecoin-be-the-storage-network-for-human-rights-data.md
+++ b/apps/ffdweb-site/src/content/blog/can-filecoin-be-the-storage-network-for-human-rights-data.md
@@ -4,7 +4,6 @@ updated-on: "2023-04-21T07:15:40.535Z"
 created-on: "2023-04-21T07:15:40.535Z"
 published-on: "2023-04-21T08:01:04.314Z"
 category: use-cases
-description: ""
 image:
   src: >-
     https://uploads-ssl.webflow.com/643e92b3a344778457270525/6442381ce3c08ff22a4e3c10_0308-hrdag-spotlight.png

--- a/apps/ffdweb-site/src/content/blog/check-out-our-docuseries-exploring-the-decentralized-web.md
+++ b/apps/ffdweb-site/src/content/blog/check-out-our-docuseries-exploring-the-decentralized-web.md
@@ -4,12 +4,6 @@ created-on: "2023-04-21T07:15:42.087Z"
 updated-on: "2023-04-21T07:18:17.975Z"
 published-on: "2023-04-21T08:01:04.314Z"
 category: interviews
-description: >-
-  We recently launched Exploring the Decentralized Web, a 12-part documentary
-  series produced by Filecoin Foundation for the Decentralized Web (FFDW).
-  Featuring leaders and visionaries from top projects across the space, these
-  videos explore the history of decentralized technology and its benefits for
-  users and organizations.
 image:
   src: >-
     https://uploads-ssl.webflow.com/643e92b3a344778457270525/6442381d1fe00b261574bc1d_0-w2tmph7o7z-pisg8-2.png

--- a/apps/ffdweb-site/src/content/blog/collect-preserve-democratize-a-q-a-with-democracy-s-library.md
+++ b/apps/ffdweb-site/src/content/blog/collect-preserve-democratize-a-q-a-with-democracy-s-library.md
@@ -4,7 +4,6 @@ created-on: 2023-05-09T10:05:25.820Z
 updated-on: 2023-05-09T10:05:00.000Z
 published-on: 2023-05-09T10:05:00.000Z
 category: use-cases
-description: ""
 image:
   src: /assets/images/0509-demo-qa.png
 seo:

--- a/apps/ffdweb-site/src/content/blog/decentralization-in-all-the-things.md
+++ b/apps/ffdweb-site/src/content/blog/decentralization-in-all-the-things.md
@@ -4,9 +4,6 @@ created-on: "2023-04-21T07:15:43.794Z"
 updated-on: "2023-04-21T07:15:43.794Z"
 published-on: "2023-04-21T08:01:04.314Z"
 category: technology
-description: >-
-  This is a guest post by Mike Masnick, the founder and CEO of Floor64 and
-  editor of the Techdirt blog, about decentralization.
 image:
   src: >-
     https://uploads-ssl.webflow.com/643e92b3a344778457270525/6442381fb068b055975a464f_013023-ffdw-mikemasnick.png

--- a/apps/ffdweb-site/src/content/blog/empowering-a-more-informed-transparent-society-with-decentralized-technology.md
+++ b/apps/ffdweb-site/src/content/blog/empowering-a-more-informed-transparent-society-with-decentralized-technology.md
@@ -4,10 +4,6 @@ created-on: "2023-04-21T07:15:45.476Z"
 updated-on: "2023-04-21T07:15:45.476Z"
 published-on: "2023-04-21T08:01:04.314Z"
 category: use-cases
-description: >-
-  Since 2010, Michael Morisy and his team at MuckRock have been working to solve
-  this problem: how do we help newsrooms and leaders build trust in an age of
-  growing misinformation?
 image:
   src: >-
     https://uploads-ssl.webflow.com/643e92b3a344778457270525/64423821fcf3ec505f7f19bd_0202-muckrock-spotlight.png

--- a/apps/ffdweb-site/src/content/blog/empowering-creators-with-decentralized-web-technology.md
+++ b/apps/ffdweb-site/src/content/blog/empowering-creators-with-decentralized-web-technology.md
@@ -4,11 +4,6 @@ created-on: 2023-10-18T19:13:30.217Z
 updated-on: 2023-10-18T19:13:30.267Z
 published-on: 2023-10-18T19:13:30.320Z
 category: projects
-description: "Filecoin Foundation for the Decentralized Web (FFDW) started
-  working with Gray Area—a San Francisco-based nonprofit cultural incubator—to
-  support the development of curriculum empowering creators working at the
-  intersections of arts and technology to incorporate the decentralized web into
-  their creative practices. "
 image:
   src: /assets/images/181023-grayarea.png
 seo:

--- a/apps/ffdweb-site/src/content/blog/empowering-the-open-web-a-q-a-with-lia-holland-campaign-and-communications-director-at-fight-for-the-future.md
+++ b/apps/ffdweb-site/src/content/blog/empowering-the-open-web-a-q-a-with-lia-holland-campaign-and-communications-director-at-fight-for-the-future.md
@@ -5,10 +5,6 @@ created-on: 2024-11-22T12:56:38.123Z
 updated-on: 2024-11-22T12:56:38.133Z
 published-on: 2024-11-22T12:56:38.144Z
 category: use-cases
-description: In this Q&A, we sit down with Lia Holland, campaigns and
-  communications director at Fight for the Future, to explore the significance
-  of this collaboration, their vision for a decentralized web, and how
-  storytelling can help change the future of technology.
 image:
   src: /assets/images/103124-qa-fftf.png
 seo:

--- a/apps/ffdweb-site/src/content/blog/exploring-the-decentralized-web-episodes-5-8.md
+++ b/apps/ffdweb-site/src/content/blog/exploring-the-decentralized-web-episodes-5-8.md
@@ -4,10 +4,6 @@ created-on: "2023-04-21T07:15:46.748Z"
 updated-on: "2023-04-21T07:18:19.495Z"
 published-on: "2023-04-21T08:01:04.314Z"
 category: interviews
-description: >-
-  Episodes 5–8 dive into some of the most impactful topics in the Web3 space
-  –from privacy, identity, and user control, to blockchain economics, dApps, and
-  open-source development.
 seo:
   description: "Episodes 5-8 of FFDW's documentary series explore Web3 privacy, open-source development, blockchain economics, and decentralized browsers with industry experts."
 ---

--- a/apps/ffdweb-site/src/content/blog/exploring-the-decentralized-web-episodes-9-12.md
+++ b/apps/ffdweb-site/src/content/blog/exploring-the-decentralized-web-episodes-9-12.md
@@ -4,10 +4,6 @@ created-on: "2023-04-21T07:15:48.576Z"
 updated-on: "2023-04-21T07:18:20.707Z"
 published-on: "2023-04-21T08:01:04.314Z"
 category: interviews
-description: >-
-  Decentralized web technology is enabling web developers and users alike to
-  solve some of the issues that arose during the Web2 era, such as a lack of
-  community governance and the stripping of web content’s value.
 image:
   src: >-
     https://uploads-ssl.webflow.com/643e92b3a344778457270525/64423824686a077ccd90a61e_0-ghsro14ivrabstg6.png

--- a/apps/ffdweb-site/src/content/blog/ffdw-2024-annual-report.md
+++ b/apps/ffdweb-site/src/content/blog/ffdw-2024-annual-report.md
@@ -4,10 +4,6 @@ created-on: 2025-01-29T16:21:20.281Z
 updated-on: 2025-01-29T16:21:20.291Z
 published-on: 2025-01-29T16:21:20.299Z
 category: updates
-description: "Filecoin Foundation for the Decentralized Web (FFDW) is the
-  sister nonprofit of Filecoin Foundation. FFDW is a 501(c)(3) nonprofit
-  committed to preserving humanity's most important information and supporting
-  the development and adoption of decentralized technologies."
 image:
   src: /assets/images/hero-ffdw.webp
 seo:

--- a/apps/ffdweb-site/src/content/blog/ffdw-and-connect-humanity-empowering-an-equitable-digital-future.md
+++ b/apps/ffdweb-site/src/content/blog/ffdw-and-connect-humanity-empowering-an-equitable-digital-future.md
@@ -4,9 +4,6 @@ created-on: "2023-04-21T07:15:50.533Z"
 updated-on: "2023-04-21T07:15:50.533Z"
 published-on: "2023-04-21T08:01:04.314Z"
 category: projects
-description: >
-  Largest ever survey of civil society's digital haves and have-nots shines
-  light on one of the biggest barriers facing NGOs
 image:
   src: >-
     https://uploads-ssl.webflow.com/643e92b3a344778457270525/644238263db3a0680966e3ab_0321-ch.png

--- a/apps/ffdweb-site/src/content/blog/ffdw-and-easier-data-initiative-collaborate-to-upload-spatial-data-to-filecoin-network.md
+++ b/apps/ffdweb-site/src/content/blog/ffdw-and-easier-data-initiative-collaborate-to-upload-spatial-data-to-filecoin-network.md
@@ -6,13 +6,6 @@ created-on: "2023-04-21T07:15:52.152Z"
 updated-on: "2023-04-21T07:15:52.152Z"
 published-on: "2023-04-21T08:01:04.314Z"
 category: projects
-description: >-
-  Filecoin Foundation for the Decentralized Web (FFDW) is excited to announce
-  our collaboration with the EASIER Data Initiative at the University of
-  Maryland, College Park (UMD). In partnership with researchers from UMD’s
-  Department of Geographical Sciences, the Initiative will ensure that large
-  geospatial datasets are accessible by research organizations and the general
-  public.
 image:
   src: >-
     https://uploads-ssl.webflow.com/643e92b3a344778457270525/64423827686a07ac0f90ac2f_1005-ffdw-edi.png

--- a/apps/ffdweb-site/src/content/blog/ffdw-and-human-rights-data-analysis-group-hrdag-collaborate-to-advance-decentralized-storage.md
+++ b/apps/ffdweb-site/src/content/blog/ffdw-and-human-rights-data-analysis-group-hrdag-collaborate-to-advance-decentralized-storage.md
@@ -6,9 +6,6 @@ created-on: "2023-04-21T07:15:54.027Z"
 updated-on: "2023-04-21T07:18:21.985Z"
 published-on: "2023-04-21T08:01:04.314Z"
 category: projects
-description: >-
-  Collaboration will support outreach and training to accelerate market research
-  for and adoption of decentralized web technologies
 image:
   src: >-
     https://uploads-ssl.webflow.com/643e92b3a344778457270525/64423829fcf3ec16737f20d9_hrdag.png

--- a/apps/ffdweb-site/src/content/blog/ffdw-and-muckrock-collaborate-to-bring-flagship-web-resource-to-the-decentralized-web.md
+++ b/apps/ffdweb-site/src/content/blog/ffdw-and-muckrock-collaborate-to-bring-flagship-web-resource-to-the-decentralized-web.md
@@ -6,10 +6,6 @@ created-on: "2023-04-21T07:15:55.677Z"
 updated-on: "2023-04-21T07:18:23.253Z"
 published-on: "2023-04-21T08:01:04.314Z"
 category: projects
-description: >-
-  Filecoin Foundation for the Decentralized Web (FFDW) is proud to announce its
-  award to MuckRock, a non-profit, collaborative news site that gives people the
-  tools to keep their government transparent and accountable.
 image:
   src: >-
     https://uploads-ssl.webflow.com/643e92b3a344778457270525/6442382b3db3a05fc766ec87_1-jduzu4kyyygqfyan9dl6da.png

--- a/apps/ffdweb-site/src/content/blog/ffdw-and-openarchive-collaborate-to-deploy-decentralized-archive-for-human-rights-data.md
+++ b/apps/ffdweb-site/src/content/blog/ffdw-and-openarchive-collaborate-to-deploy-decentralized-archive-for-human-rights-data.md
@@ -6,14 +6,6 @@ created-on: "2023-04-21T07:15:57.492Z"
 updated-on: "2023-04-21T07:18:24.468Z"
 published-on: "2023-04-21T08:01:04.314Z"
 category: projects
-description: >-
-  Filecoin Foundation for the Decentralized Web (FFDW) is proud to announce our
-  award to OpenArchive, a nonprofit dedicated to advancing human rights by
-  empowering people to collect, verify, and securely preserve mobile media using
-  distributed backends. Through this collaboration, OpenArchive will be able to
-  support decentralized backends for the Save app. This will enable people on
-  the ground capturing images and footage of world events to leverage IPFS and
-  Filecoin and other decentralized storage options via their mobile device.
 image:
   src: >-
     https://uploads-ssl.webflow.com/643e92b3a344778457270525/6442382def619d14d6b54705_openarchive.png

--- a/apps/ffdweb-site/src/content/blog/ffdw-and-rohingya-project-working-together-to-empower-cultural-preservation-and-digital-legacy.md
+++ b/apps/ffdweb-site/src/content/blog/ffdw-and-rohingya-project-working-together-to-empower-cultural-preservation-and-digital-legacy.md
@@ -4,12 +4,6 @@ created-on: 2024-10-08T11:12:16.087Z
 updated-on: 2024-10-08T11:12:16.096Z
 published-on: 2024-10-08T11:12:16.103Z
 category: projects
-description: "Filecoin Foundation for the Decentralized Web (FFDW) is proud to
-  announce a collaboration with Rohingya Project. With FFDW’s support, Rohingya
-  Project will digitally preserve an array of cultural heritage documents that
-  capture the essence of the Rohingya people – including audio recordings,
-  photographs, videos, and written materials – to safeguard the cultural
-  heritage of the Rohingya community."
 image:
   src: /assets/images/091924-rohingyaproject.png
 seo:

--- a/apps/ffdweb-site/src/content/blog/ffdw-and-sacred-stacks-building-community-with-decentralized-tools.md
+++ b/apps/ffdweb-site/src/content/blog/ffdw-and-sacred-stacks-building-community-with-decentralized-tools.md
@@ -4,9 +4,6 @@ created-on: 2023-05-30T09:57:39.743Z
 updated-on: 2023-05-30T09:57:00.000Z
 published-on: 2023-05-30T09:57:00.000Z
 category: projects
-description: Can decentralization really help build community? And how can
-  healthier social relations emerge around our technology, particularly in terms
-  of self-governance, autonomy, and accessibility?
 image:
   src: /assets/images/051723-ucboulder.png
 seo:

--- a/apps/ffdweb-site/src/content/blog/ffdw-and-witness-collaborate-to-preserve-authentic-human-rights-records.md
+++ b/apps/ffdweb-site/src/content/blog/ffdw-and-witness-collaborate-to-preserve-authentic-human-rights-records.md
@@ -4,9 +4,6 @@ created-on: "2023-04-21T07:15:59.414Z"
 updated-on: "2023-04-21T07:18:25.714Z"
 published-on: "2023-04-21T08:01:04.314Z"
 category: projects
-description: >-
-  FFDW’s commitment to WITNESS will support the creation, authentication, and
-  preservation of trusted documentation
 image:
   src: >-
     https://uploads-ssl.webflow.com/643e92b3a344778457270525/6442382e3db3a0857c66f093_witness.png

--- a/apps/ffdweb-site/src/content/blog/ffdw-supports-mit-open-learning-in-preserving-humanity-s-most-important-information.md
+++ b/apps/ffdweb-site/src/content/blog/ffdw-supports-mit-open-learning-in-preserving-humanity-s-most-important-information.md
@@ -6,10 +6,6 @@ created-on: "2023-04-21T07:16:01.068Z"
 updated-on: "2023-04-21T07:16:01.068Z"
 published-on: "2023-04-21T08:01:04.314Z"
 category: projects
-description: >-
-  Filecoin Foundation for the Decentralized Web (FFDW) is proud to support MIT
-  Open Learning, an organization focused on transforming teaching and learning
-  through the innovative use of digital technologies.
 image:
   src: >-
     https://uploads-ssl.webflow.com/643e92b3a344778457270525/64423830e3c08f43474e3c40_0202-mit.png

--- a/apps/ffdweb-site/src/content/blog/ffdw-supports-spritely-networked-communities-institute-to-develop-decentralized-social-media.md
+++ b/apps/ffdweb-site/src/content/blog/ffdw-supports-spritely-networked-communities-institute-to-develop-decentralized-social-media.md
@@ -6,9 +6,6 @@ created-on: "2023-04-21T07:16:03.198Z"
 updated-on: "2023-04-21T07:18:26.993Z"
 published-on: "2023-04-21T08:01:04.314Z"
 category: projects
-description: >-
-  Award will further efforts to give people control over identity and
-  relationships online
 image:
   src: >-
     https://uploads-ssl.webflow.com/643e92b3a344778457270525/644238321fe00b575d74cba1_0816-ffdw-spritely.png

--- a/apps/ffdweb-site/src/content/blog/ffdw-works-with-prelinger-archives-to-make-rare-historic-films-more-accessible-using-the-decentralized-web.md
+++ b/apps/ffdweb-site/src/content/blog/ffdw-works-with-prelinger-archives-to-make-rare-historic-films-more-accessible-using-the-decentralized-web.md
@@ -6,11 +6,6 @@ created-on: "2023-04-21T07:16:04.865Z"
 updated-on: "2023-04-21T07:18:28.291Z"
 published-on: "2023-04-21T08:01:04.314Z"
 category: projects
-description: >-
-  Filecoin Foundation for the Decentralized Web (FFDW) is proud to announce its
-  collaboration with Prelinger Archives, a San Francisco-based historical film
-  archive, to make rare and one-of-a-kind films accessible to the general
-  public.
 image:
   src: >-
     https://uploads-ssl.webflow.com/643e92b3a344778457270525/644238341fe00b0f4374cbf2_1-yn2c8c8ey2qr9anuyu5xyq.png

--- a/apps/ffdweb-site/src/content/blog/filecoin-foundation-for-the-decentralized-web-2023-annual-report.md
+++ b/apps/ffdweb-site/src/content/blog/filecoin-foundation-for-the-decentralized-web-2023-annual-report.md
@@ -4,10 +4,6 @@ created-on: 2024-02-27T14:38:33.527Z
 updated-on: 2024-02-27T14:38:33.545Z
 published-on: 2024-02-27T14:38:33.552Z
 category: updates
-description: In this report, you’ll see the progress achieved by FFDW and our
-  exceptional roster of project partners in creating profound and wide-reaching
-  impact in a moment of growing interest and appreciation for decentralized
-  values.
 image:
   src: /assets/images/022624-ffdw-annualreport.png
 seo:

--- a/apps/ffdweb-site/src/content/blog/filecoin-foundation-for-the-decentralized-web-and-techcongress-will-work-together-to-place-more-technologists-on-capitol-hill.md
+++ b/apps/ffdweb-site/src/content/blog/filecoin-foundation-for-the-decentralized-web-and-techcongress-will-work-together-to-place-more-technologists-on-capitol-hill.md
@@ -6,10 +6,6 @@ created-on: "2023-04-21T07:16:06.513Z"
 updated-on: "2023-04-21T07:18:29.556Z"
 published-on: "2023-04-21T08:01:04.314Z"
 category: projects
-description: >-
-  Filecoin Foundation for the Decentralized Web (FFDW) is proud to announce our
-  award to TechCongress, an organization that provides fellowships to bridge the
-  informational gap between technologists and policymakers in Congress.
 image:
   src: >-
     https://uploads-ssl.webflow.com/643e92b3a344778457270525/64423836a6ec419f1a28faed_1-by_cgybu5ago6_yxuh93g.png

--- a/apps/ffdweb-site/src/content/blog/filecoin-foundation-for-the-decentralized-web-boosts-harvard-library-innovation-lab-s-work-to-democratize-open-knowledge.md
+++ b/apps/ffdweb-site/src/content/blog/filecoin-foundation-for-the-decentralized-web-boosts-harvard-library-innovation-lab-s-work-to-democratize-open-knowledge.md
@@ -6,10 +6,6 @@ updated-on: "2023-04-21T07:18:30.774Z"
 created-on: "2023-04-21T07:16:08.045Z"
 published-on: "2023-04-21T08:01:04.314Z"
 category: projects
-description: >-
-  Filecoin Foundation for the Decentralized Web (FFDW) is proud to announce an
-  award to the Library Innovation Lab (LIL) at Harvard University to support its
-  Democratizing Open Knowledge program.
 image:
   src: >-
     https://uploads-ssl.webflow.com/643e92b3a344778457270525/64423837922f062c19150fda_1-sqxvnk6dltsa3a9ec1fbyg.png

--- a/apps/ffdweb-site/src/content/blog/guardian-project-annoucement.md
+++ b/apps/ffdweb-site/src/content/blog/guardian-project-annoucement.md
@@ -6,9 +6,6 @@ created-on: "2023-04-21T07:16:09.669Z"
 updated-on: "2023-04-21T07:18:32.063Z"
 published-on: "2023-04-21T08:01:04.314Z"
 category: projects
-description: >-
-  FFDW’s commitment to Guardian Project will accelerate adoption of
-  decentralized storage technology on smartphones through ProofMode and F-Droid
 image:
   src: >-
     https://uploads-ssl.webflow.com/643e92b3a344778457270525/64423839922f06c7b3150fdd_guardian-project.png

--- a/apps/ffdweb-site/src/content/blog/how-decentralized-technology-is-driving-the-future-of-social-impact-a-recap-from-the-social-impact-summit-2024.md
+++ b/apps/ffdweb-site/src/content/blog/how-decentralized-technology-is-driving-the-future-of-social-impact-a-recap-from-the-social-impact-summit-2024.md
@@ -5,12 +5,6 @@ created-on: 2024-03-28T17:04:06.076Z
 updated-on: 2024-03-28T17:04:06.083Z
 published-on: 2024-03-28T17:04:06.088Z
 category: updates
-description: This month, the Social Impact Summit 2024, co-hosted by
-  Blockchain Law for Social Good Center and Filecoin Foundation for the
-  Decentralized Web (FFDW), brought together changemakers to explore how
-  emerging technologies can influence trust in the web. Read on to learn more
-  about the sessions and themes that emerged from the inaugural Social Impact
-  Summit 2024.
 image:
   src: /assets/images/031224-sis-retro.png
 seo:

--- a/apps/ffdweb-site/src/content/blog/how-to-make-an-impact-on-tech-policy-a-q-a-with-travis-moore-founder-of-techcongress.md
+++ b/apps/ffdweb-site/src/content/blog/how-to-make-an-impact-on-tech-policy-a-q-a-with-travis-moore-founder-of-techcongress.md
@@ -4,7 +4,6 @@ created-on: 2023-08-16T18:51:13.562Z
 updated-on: 2023-08-16T18:51:13.580Z
 published-on: 2023-08-16T18:51:13.590Z
 category: interviews
-description: ""
 image:
   src: /assets/images/091523-qa-techcongress.png
 seo:

--- a/apps/ffdweb-site/src/content/blog/increasing-accessibility-and-representation-for-underrepresented-founders-across-the-dweb-a-q-a-with-preston-james-ceo-of-divinc.md
+++ b/apps/ffdweb-site/src/content/blog/increasing-accessibility-and-representation-for-underrepresented-founders-across-the-dweb-a-q-a-with-preston-james-ceo-of-divinc.md
@@ -5,7 +5,6 @@ created-on: 2023-07-12T19:47:37.201Z
 updated-on: 2023-07-12T19:47:37.214Z
 published-on: 2023-07-12T19:47:37.228Z
 category: interviews
-description: ""
 image:
   src: /assets/images/0711-divinc.png
 seo:

--- a/apps/ffdweb-site/src/content/blog/increasing-the-longevity-of-digital-preservation-a-q-a-with-megan-and-rick-prelinger-co-directors-of-the-prelinger-archives.md
+++ b/apps/ffdweb-site/src/content/blog/increasing-the-longevity-of-digital-preservation-a-q-a-with-megan-and-rick-prelinger-co-directors-of-the-prelinger-archives.md
@@ -5,7 +5,6 @@ created-on: 2024-09-06T15:14:39.910Z
 updated-on: 2024-09-06T15:14:39.918Z
 published-on: 2024-09-06T15:14:39.924Z
 category: interviews
-description: ""
 image:
   src: /assets/images/09262024-qa-prelinger.png
 seo:

--- a/apps/ffdweb-site/src/content/blog/insights-from-7-experts-the-future-of-emerging-technologies-for-positive-societal-change.md
+++ b/apps/ffdweb-site/src/content/blog/insights-from-7-experts-the-future-of-emerging-technologies-for-positive-societal-change.md
@@ -5,14 +5,6 @@ created-on: 2024-02-22T18:09:50.533Z
 updated-on: 2024-02-22T18:09:50.550Z
 published-on: 2024-02-22T18:09:50.562Z
 category: updates
-description: Artificial intelligence (AI) and decentralized technologies have
-  reached a pivotal stage of development, permeating the fabric of daily life in
-  our increasingly digital world. These rapidly evolving technologies,
-  characterized by decentralized power structures and powered by troves of data,
-  are poised to revolutionize various sectors. Forecasts indicate that these
-  advancements will improve financial access for all, elevate productivity,
-  catalyze economic expansion, embolden individuals across artistic and
-  scientific domains, and potentially tackle formidable global challenges.
 image:
   src: /assets/images/022124-sis.png
 seo:

--- a/apps/ffdweb-site/src/content/blog/introducing-the-first-international-affiliated-scholars-cohort.md
+++ b/apps/ffdweb-site/src/content/blog/introducing-the-first-international-affiliated-scholars-cohort.md
@@ -4,7 +4,6 @@ created-on: 2023-09-14T15:01:30.562Z
 updated-on: 2023-09-14T15:01:30.580Z
 published-on: 2023-09-14T15:01:30.593Z
 category: projects
-description: ""
 image:
   src: /assets/images/091223-bl4sg-header.png
 seo:

--- a/apps/ffdweb-site/src/content/blog/leveraging-the-dweb-to-enhance-free-speech.md
+++ b/apps/ffdweb-site/src/content/blog/leveraging-the-dweb-to-enhance-free-speech.md
@@ -4,11 +4,6 @@ created-on: "2023-04-21T07:16:11.429Z"
 updated-on: "2023-04-21T07:18:33.376Z"
 published-on: "2023-04-21T08:01:04.314Z"
 category: projects
-description: >-
-  On September 28, the Filecoin Foundation for the Decentralized Web (FFDW)
-  announced a $5.8 million award to the Freedom of the Press Foundation (FPF) to
-  support the further leveraging of the decentralized web to enhance freedom of
-  speech for journalists.
 image:
   src: >-
     https://uploads-ssl.webflow.com/643e92b3a344778457270525/6442383bfcf3ec00b87f30ee_leveraging-the-dweb-to-enhance-free-speech.png

--- a/apps/ffdweb-site/src/content/blog/melba-roy-mouton-a-hidden-figure-whose-legacy-paved-the-way-for-web3.md
+++ b/apps/ffdweb-site/src/content/blog/melba-roy-mouton-a-hidden-figure-whose-legacy-paved-the-way-for-web3.md
@@ -4,11 +4,6 @@ created-on: "2023-04-21T07:16:12.922Z"
 updated-on: "2023-04-21T07:18:34.828Z"
 published-on: "2023-04-21T08:01:04.314Z"
 category: technology
-description: >-
-  Melba Roy Mouton was a statistician and computer scientist whose contributions
-  to the scientific community during her tenure at NASA not only shaped modern
-  programming uses and documentation practices, but also how it is taught to
-  future generations.
 image:
   src: >-
     https://uploads-ssl.webflow.com/643e92b3a344778457270525/6442383cfcf3ec3f5b7f32c6_melba-roy.jpeg

--- a/apps/ffdweb-site/src/content/blog/preserving-human-rights-data-with-the-filecoin-network-a-journey-into-the-decentralized-web-with-hrdag.md
+++ b/apps/ffdweb-site/src/content/blog/preserving-human-rights-data-with-the-filecoin-network-a-journey-into-the-decentralized-web-with-hrdag.md
@@ -5,13 +5,6 @@ created-on: 2024-04-18T16:50:24.039Z
 updated-on: 2024-04-18T16:50:24.046Z
 published-on: 2024-04-18T16:50:24.051Z
 category: projects
-description: >
-  This is a guest post from FFDW project partner Human Rights Data Analysis
-  Group (HRDAG), written by Patrick Ball, HRDAG’s Director of Research. HRDAG
-  began working with Filecoin Foundation for the Decentralized Web (FFDW) in
-  2021 to explore how decentralized technologies can support efforts to
-  safeguard this critical data and promote accountability for human rights
-  abuse.
 image:
   src: /assets/images/041524-guest-hrdag.png
 seo:

--- a/apps/ffdweb-site/src/content/blog/preserving-the-past-empowering-the-future-a-q-a-with-billy-bicket-head-of-maker-labs-at-techsoup.md
+++ b/apps/ffdweb-site/src/content/blog/preserving-the-past-empowering-the-future-a-q-a-with-billy-bicket-head-of-maker-labs-at-techsoup.md
@@ -5,10 +5,6 @@ created-on: 2025-02-06T21:12:58.463Z
 updated-on: 2025-02-06T21:12:58.480Z
 published-on: 2025-02-06T21:12:58.493Z
 category: interviews
-description: In this Q&A, we sit down with Billy Bicket, Head of Maker Labs at
-  TechSoup, to discuss the goals of the CML, its implications for cultural
-  preservation, and how this initiative is building a more inclusive and
-  equitable future for archiving.
 image:
   src: /assets/images/techsoup-q-a.webp
 seo:

--- a/apps/ffdweb-site/src/content/blog/seeding-sustainable-growth-for-public-goods-in-tech-insights-from-funding-the-commons.md
+++ b/apps/ffdweb-site/src/content/blog/seeding-sustainable-growth-for-public-goods-in-tech-insights-from-funding-the-commons.md
@@ -1,6 +1,5 @@
 ---
 title: "Seeding Sustainable Growth for Public Goods in Tech: Insights from Funding the Commons"
-description: At Funding the Commons, leaders from tech, research, and philanthropy explored sustainable funding for public goods like OSS. Discussions covered trust in OSS, decentralized funding, and tech for human rights and the arts. Speakers highlighted community-driven solutions, activist-centered tools, and artist data trusts.
 created-on: 2024-05-03T18:12:47.365Z
 updated-on: 2024-05-03T18:12:47.379Z
 published-on: 2024-05-03T18:12:47.391Z

--- a/apps/ffdweb-site/src/content/blog/the-future-of-decentralized-apps-a-q-a-with-guardian-project.md
+++ b/apps/ffdweb-site/src/content/blog/the-future-of-decentralized-apps-a-q-a-with-guardian-project.md
@@ -1,9 +1,6 @@
 ---
 title: "The Future of Decentralized Apps: A Q&A with Guardian Project "
 category: interviews
-description: >-
-  A Q&A series with an FFDW project partner focusing on different aspects of the
-  building blocks of the decentralized web
 image:
   src: >-
     https://uploads-ssl.webflow.com/643e92b3a344778457270525/6442383eef619d076eb5472e_0228-guardian-qa.png

--- a/apps/ffdweb-site/src/content/blog/the-starling-lab-framework.md
+++ b/apps/ffdweb-site/src/content/blog/the-starling-lab-framework.md
@@ -4,11 +4,6 @@ created-on: 2024-03-06T16:46:52.600Z
 updated-on: 2024-03-06T16:46:52.611Z
 published-on: 2024-03-06T16:46:52.620Z
 category: technology
-description: "Starling Lab develops technology and protocols for digital
-  records that can establish provenance and authenticity, using a framework of
-  Capture, Store, Verify with fellows and collaborators in journalism, law,
-  history, and technology. The purpose of its work is to establish trust in
-  digital assets such as photographs, websites, audio, and video. "
 image:
   src: /assets/images/081123-starling-1.png
 seo:

--- a/apps/ffdweb-site/src/content/blog/web3-sci-fi-christopher-kulendran-thomas-s-another-world-to-debut-at-london-s-institute-of-contemporary-arts.md
+++ b/apps/ffdweb-site/src/content/blog/web3-sci-fi-christopher-kulendran-thomas-s-another-world-to-debut-at-london-s-institute-of-contemporary-arts.md
@@ -6,11 +6,6 @@ updated-on: "2023-04-21T07:18:36.074Z"
 created-on: "2023-04-21T07:16:15.905Z"
 published-on: "2023-04-21T08:01:04.314Z"
 category: projects
-description: >-
-  Filecoin Foundation for the Decentralized Web (FFDW) and the Institute of
-  Contemporary Arts (ICA) London today announced that Christopher Kulendran
-  Thomas's latest exhibition, Another World, will debut at the ICA on October
-  11.
 image:
   src: >-
     https://uploads-ssl.webflow.com/643e92b3a344778457270525/6442383fef619d8564b54739_ckt-ffdw-ica.png

--- a/packages/ui/src/DescriptionText.tsx
+++ b/packages/ui/src/DescriptionText.tsx
@@ -1,31 +1,16 @@
 import clsx from 'clsx'
 
-type DescriptionProps = {
+export type DescriptionProps = {
   isClamped?: boolean
-  children: DescriptionTextType
+  children: React.ReactNode
 }
 
-export type DescriptionTextType = React.ReactNode
-
 export function DescriptionText({ children, isClamped }: DescriptionProps) {
-  if (Array.isArray(children)) {
-    return (
-      <>
-        {children.map((item, index) => (
-          <p
-            className={clsx(isClamped && 'line-clamp-3 text-ellipsis')}
-            key={index}
-          >
-            {item}
-          </p>
-        ))}
-      </>
-    )
-  }
+  const childrenArray = Array.isArray(children) ? children : [children]
 
-  return (
-    <p className={clsx(isClamped && 'line-clamp-3 text-ellipsis')}>
-      {children}
+  return childrenArray.map((item, index) => (
+    <p key={index} className={clsx(isClamped && 'line-clamp-3 text-ellipsis')}>
+      {item}
     </p>
-  )
+  ))
 }

--- a/packages/ui/src/DescriptionText.tsx
+++ b/packages/ui/src/DescriptionText.tsx
@@ -1,16 +1,21 @@
+import clsx from 'clsx'
+
 type DescriptionProps = {
-  className?: string
+  isClamped?: boolean
   children: DescriptionTextType
 }
 
 export type DescriptionTextType = React.ReactNode
 
-export function DescriptionText({ className, children }: DescriptionProps) {
+export function DescriptionText({ children, isClamped }: DescriptionProps) {
   if (Array.isArray(children)) {
     return (
       <>
         {children.map((item, index) => (
-          <p className={className} key={index}>
+          <p
+            className={clsx(isClamped && 'line-clamp-3 text-ellipsis')}
+            key={index}
+          >
             {item}
           </p>
         ))}
@@ -18,5 +23,9 @@ export function DescriptionText({ className, children }: DescriptionProps) {
     )
   }
 
-  return <p className={className}>{children}</p>
+  return (
+    <p className={clsx(isClamped && 'line-clamp-3 text-ellipsis')}>
+      {children}
+    </p>
+  )
 }

--- a/packages/ui/src/PageHeader.tsx
+++ b/packages/ui/src/PageHeader.tsx
@@ -18,12 +18,13 @@ type TitleProps = {
   children: string
 }
 
-type PageHeaderDescriptionProp =
-  | DescriptionProps['children']
-  | { text: string; isClamped?: boolean }
-
 type PageHeaderImageProps = (StaticImageProps | ImageProps) & {
   objectFit?: ImageObjectFit
+}
+
+type PageHeaderDescriptionProps = {
+  text: DescriptionProps['children']
+  isClamped?: DescriptionProps['isClamped']
 }
 
 export type PageHeaderProps = {
@@ -31,7 +32,7 @@ export type PageHeaderProps = {
   image: PageHeaderImageProps
   isFeatured?: boolean
   metaData?: MetaDataType
-  description?: PageHeaderDescriptionProp
+  description?: PageHeaderDescriptionProps
   children?: React.ReactElement
 }
 
@@ -50,7 +51,11 @@ export function PageHeader({
           {isFeatured && <TagLabel variant="secondary">Featured</TagLabel>}
           <PageHeader.Title>{title}</PageHeader.Title>
           {metaData && <Meta metaData={metaData} />}
-          {description && <PageHeaderDescription description={description} />}
+          {description && (
+            <DescriptionText isClamped={description.isClamped}>
+              {description.text}
+            </DescriptionText>
+          )}
           {children}
         </div>
         {image && <PageHeader.Image image={image} />}
@@ -100,20 +105,4 @@ PageHeader.Image = function PageHeaderImage({
       <Image fill {...commonProps} src={image.src} />
     </div>
   )
-}
-
-function PageHeaderDescription({
-  description,
-}: {
-  description: NonNullable<PageHeaderDescriptionProp>
-}) {
-  if (typeof description === 'object' && 'text' in description) {
-    return (
-      <DescriptionText isClamped={description.isClamped}>
-        {description.text}
-      </DescriptionText>
-    )
-  }
-
-  return <DescriptionText>{description}</DescriptionText>
 }

--- a/packages/ui/src/PageHeader.tsx
+++ b/packages/ui/src/PageHeader.tsx
@@ -51,7 +51,7 @@ export function PageHeader({
           {isFeatured && <TagLabel variant="secondary">Featured</TagLabel>}
           <PageHeader.Title>{title}</PageHeader.Title>
           {metaData && <Meta metaData={metaData} />}
-          {description && <Description description={description} />}
+          <Description description={description} />
           {children}
         </div>
         {image && <PageHeader.Image image={image} />}
@@ -108,13 +108,17 @@ function Description({
 }: {
   description: PageHeaderProps['description']
 }) {
-  if (typeof description === 'string') {
-    return <DescriptionText>{description}</DescriptionText>
+  if (!description) return null
+
+  if (typeof description === 'object' && 'text' in description) {
+    return (
+      <p
+        className={clsx(description.isClamped && 'line-clamp-3 text-ellipsis')}
+      >
+        {description.text}
+      </p>
+    )
   }
 
-  const { text, isClamped } = description as PageHeaderDescriptionProps
-
-  return (
-    <p className={clsx(isClamped && 'line-clamp-3 text-ellipsis')}>{text}</p>
-  )
+  return <DescriptionText>{description}</DescriptionText>
 }

--- a/packages/ui/src/PageHeader.tsx
+++ b/packages/ui/src/PageHeader.tsx
@@ -113,9 +113,7 @@ function Description({
     'text' in description
   ) {
     return (
-      <DescriptionText
-        className={clsx(description.isClamped && 'line-clamp-3 text-ellipsis')}
-      >
+      <DescriptionText isClamped={description.isClamped}>
         {description.text}
       </DescriptionText>
     )

--- a/packages/ui/src/PageHeader.tsx
+++ b/packages/ui/src/PageHeader.tsx
@@ -2,7 +2,7 @@ import Image, { type ImageProps } from 'next/image'
 
 import {
   DescriptionText,
-  type DescriptionTextType,
+  type DescriptionProps,
 } from '@filecoin-foundation/ui/DescriptionText'
 import { Heading } from '@filecoin-foundation/ui/Heading'
 import { Meta, type MetaDataType } from '@filecoin-foundation/ui/Meta'
@@ -18,8 +18,8 @@ type TitleProps = {
   children: string
 }
 
-export type PageHeaderDescriptionProp =
-  | DescriptionTextType
+type PageHeaderDescriptionProp =
+  | DescriptionProps['children']
   | { text: string; isClamped?: boolean }
 
 type PageHeaderImageProps = (StaticImageProps | ImageProps) & {
@@ -50,7 +50,7 @@ export function PageHeader({
           {isFeatured && <TagLabel variant="secondary">Featured</TagLabel>}
           <PageHeader.Title>{title}</PageHeader.Title>
           {metaData && <Meta metaData={metaData} />}
-          {description && <Description description={description} />}
+          {description && <PageHeaderDescription description={description} />}
           {children}
         </div>
         {image && <PageHeader.Image image={image} />}
@@ -102,16 +102,12 @@ PageHeader.Image = function PageHeaderImage({
   )
 }
 
-function Description({
+function PageHeaderDescription({
   description,
 }: {
   description: NonNullable<PageHeaderDescriptionProp>
 }) {
-  if (
-    typeof description === 'object' &&
-    !Array.isArray(description) &&
-    'text' in description
-  ) {
+  if (typeof description === 'object' && 'text' in description) {
     return (
       <DescriptionText isClamped={description.isClamped}>
         {description.text}

--- a/packages/ui/src/PageHeader.tsx
+++ b/packages/ui/src/PageHeader.tsx
@@ -109,17 +109,12 @@ function Description({
   description: PageHeaderProps['description']
 }) {
   if (typeof description === 'string') {
-    const text = description as DescriptionTextType
-    return <DescriptionText>{text}</DescriptionText>
+    return <DescriptionText>{description}</DescriptionText>
   }
 
-  if (typeof description === 'object') {
-    const { text, isClamped } = description as PageHeaderDescriptionProps
+  const { text, isClamped } = description as PageHeaderDescriptionProps
 
-    return (
-      <p className={clsx(isClamped && 'line-clamp-3 text-ellipsis')}>{text}</p>
-    )
-  }
-
-  return null
+  return (
+    <p className={clsx(isClamped && 'line-clamp-3 text-ellipsis')}>{text}</p>
+  )
 }

--- a/packages/ui/src/PageHeader.tsx
+++ b/packages/ui/src/PageHeader.tsx
@@ -18,10 +18,9 @@ type TitleProps = {
   children: string
 }
 
-type PageHeaderDescriptionProps = {
-  text: string
-  isClamped?: boolean
-}
+export type PageHeaderDescriptionProp =
+  | DescriptionTextType
+  | { text: string; isClamped?: boolean }
 
 type PageHeaderImageProps = (StaticImageProps | ImageProps) & {
   objectFit?: ImageObjectFit
@@ -32,7 +31,7 @@ export type PageHeaderProps = {
   image: PageHeaderImageProps
   isFeatured?: boolean
   metaData?: MetaDataType
-  description?: DescriptionTextType | PageHeaderDescriptionProps
+  description?: PageHeaderDescriptionProp
   children?: React.ReactElement
 }
 
@@ -51,7 +50,7 @@ export function PageHeader({
           {isFeatured && <TagLabel variant="secondary">Featured</TagLabel>}
           <PageHeader.Title>{title}</PageHeader.Title>
           {metaData && <Meta metaData={metaData} />}
-          <Description description={description} />
+          {description && <Description description={description} />}
           {children}
         </div>
         {image && <PageHeader.Image image={image} />}
@@ -106,17 +105,19 @@ PageHeader.Image = function PageHeaderImage({
 function Description({
   description,
 }: {
-  description: PageHeaderProps['description']
+  description: NonNullable<PageHeaderDescriptionProp>
 }) {
-  if (!description) return null
-
-  if (typeof description === 'object' && 'text' in description) {
+  if (
+    typeof description === 'object' &&
+    !Array.isArray(description) &&
+    'text' in description
+  ) {
     return (
-      <p
+      <DescriptionText
         className={clsx(description.isClamped && 'line-clamp-3 text-ellipsis')}
       >
         {description.text}
-      </p>
+      </DescriptionText>
     )
   }
 

--- a/packages/ui/src/PageHeader.tsx
+++ b/packages/ui/src/PageHeader.tsx
@@ -18,6 +18,11 @@ type TitleProps = {
   children: string
 }
 
+type PageHeaderDescriptionProps = {
+  text: string
+  isClamped?: boolean
+}
+
 type PageHeaderImageProps = (StaticImageProps | ImageProps) & {
   objectFit?: ImageObjectFit
 }
@@ -27,7 +32,7 @@ export type PageHeaderProps = {
   image: PageHeaderImageProps
   isFeatured?: boolean
   metaData?: MetaDataType
-  description?: DescriptionTextType
+  description?: DescriptionTextType | PageHeaderDescriptionProps
   children?: React.ReactElement
 }
 
@@ -46,7 +51,7 @@ export function PageHeader({
           {isFeatured && <TagLabel variant="secondary">Featured</TagLabel>}
           <PageHeader.Title>{title}</PageHeader.Title>
           {metaData && <Meta metaData={metaData} />}
-          {description && <DescriptionText>{description}</DescriptionText>}
+          {description && <Description description={description} />}
           {children}
         </div>
         {image && <PageHeader.Image image={image} />}
@@ -96,4 +101,25 @@ PageHeader.Image = function PageHeaderImage({
       <Image fill {...commonProps} src={image.src} />
     </div>
   )
+}
+
+function Description({
+  description,
+}: {
+  description: PageHeaderProps['description']
+}) {
+  if (typeof description === 'string') {
+    const text = description as DescriptionTextType
+    return <DescriptionText>{text}</DescriptionText>
+  }
+
+  if (typeof description === 'object') {
+    const { text, isClamped } = description as PageHeaderDescriptionProps
+
+    return (
+      <p className={clsx(isClamped && 'line-clamp-3 text-ellipsis')}>{text}</p>
+    )
+  }
+
+  return null
 }


### PR DESCRIPTION
## 📝 Description
 
This PR removes descriptions fields from Blog Post data and truncates description in `PageHeader` and Blog Post cards.

P.S. We could probably do some refactoring since we do a similar thing in the `Card` component. But maybe for another PR...

- **Type:** Refactor

![Screenshot 2025-03-17 at 09 45 15](https://github.com/user-attachments/assets/e37168f5-3104-41cb-9d2f-04aa15308cea)
![Screenshot 2025-03-17 at 12 08 22](https://github.com/user-attachments/assets/324c984a-7517-40ec-841b-86020ee69b17)

