### PR TITLE
Add generateStaticParams to /blog/slug on FFDW

### DIFF
--- a/apps/ff-site/src/app/blog/[slug]/page.tsx
+++ b/apps/ff-site/src/app/blog/[slug]/page.tsx
@@ -19,7 +19,6 @@ import { getBlogPostData, getBlogPostsData } from '../utils/getBlogPostData'
 
 import { generateStructuredData } from './utils/generateStructuredData'
 
-
 type BlogPostProps = {
   params: Promise<SlugParams>
 }

--- a/apps/ffdweb-site/src/app/blog/[slug]/page.tsx
+++ b/apps/ffdweb-site/src/app/blog/[slug]/page.tsx
@@ -15,7 +15,7 @@ import { getCategoryLabel } from '@/utils/getCategoryLabel'
 
 import { MarkdownContent } from '@/components/MarkdownContent'
 
-import { getBlogPostData } from '../utils/getBlogPostData'
+import { getBlogPostData, getBlogPostsData } from '../utils/getBlogPostData'
 
 import { generateStructuredData } from './utils/generateStructuredData'
 
@@ -55,6 +55,11 @@ export default async function BlogPost(props: BlogPostProps) {
       </ArticleLayout>
     </PageLayout>
   )
+}
+
+export async function generateStaticParams() {
+  const entries = await getBlogPostsData()
+  return entries.map(({ slug }) => ({ slug }))
 }
 
 export async function generateMetadata(props: BlogPostProps) {


### PR DESCRIPTION
## 📝 Description

This PR adds `generateStaticParams` to FFDWEB `blog/[slug]/page.tsx` and solves the 404 bug on `/blog/:slug`.

This bug happens because `fileExists` returns false when calling `getMarkdownData` on FFDW. I don't know why that is. I noticed that functions run on different Node versions, which could be the source of the problem?

```ts
export async function generateStaticParams() {
  const entries = await getBlogPostsData()
  return entries.map(({ slug }) => ({ slug }))
}
```