### PR TITLE
 [FFDW][UXIT-2385] Rethink and update data for External Link and Featured Content [skip percy]]

### DIFF
--- a/apps/ffdweb-site/public/admin/config.yml
+++ b/apps/ffdweb-site/public/admin/config.yml
@@ -395,8 +395,8 @@ collections:
         widget: "markdown"
         required: false
         hint: "Optional featured content for this project on fil.org or ffdweb.org."
-      - name: "external-link"
-        label: "External Link"
+      - name: "website"
+        label: "Website"
         widget: "string"
         hint: "Link to the project's website or repository."
       - name: "active-partnership"

--- a/apps/ffdweb-site/public/admin/config.yml
+++ b/apps/ffdweb-site/public/admin/config.yml
@@ -398,8 +398,7 @@ collections:
       - name: "external-link"
         label: "External Link"
         widget: "string"
-        required: false
-        hint: "Optional link to the project's website or repository."
+        hint: "Link to the project's website or repository."
       - name: "active-partnership"
         label: "Active Partnership"
         widget: "boolean"

--- a/apps/ffdweb-site/src/app/projects/[slug]/page.tsx
+++ b/apps/ffdweb-site/src/app/projects/[slug]/page.tsx
@@ -27,7 +27,7 @@ type ProjectProps = {
 export default async function Project(props: ProjectProps) {
   const { slug } = await props.params
   const data = await getProjectData(slug)
-  const { title, image, description, externalLink, featuredContent } = data
+  const { title, image, description, website, featuredContent } = data
 
   return (
     <PageLayout gap="large">
@@ -55,9 +55,7 @@ export default async function Project(props: ProjectProps) {
           </div>
 
           <div className="mt-8 inline-flex flex-col gap-8 sm:flex-row sm:gap-12">
-            {externalLink && (
-              <CTALink href={externalLink}>Visit Project Website</CTALink>
-            )}
+            <CTALink href={website}>Visit Project Website</CTALink>
 
             {featuredContent && (
               <CTALink href={featuredContent} icon={Newspaper}>

--- a/apps/ffdweb-site/src/app/projects/schemas/ProjectFrontmatterSchema.ts
+++ b/apps/ffdweb-site/src/app/projects/schemas/ProjectFrontmatterSchema.ts
@@ -4,7 +4,7 @@ import { z } from 'zod'
 export const ProjectFrontmatterSchema = DynamicBaseDataSchema.extend({
   title: z.string(),
   description: z.string(),
-  'external-link': z.string(),
+  website: z.string(),
   'featured-content': z.string().optional(),
   'active-partnership': z.boolean().optional().default(false),
 }).strict()

--- a/apps/ffdweb-site/src/app/projects/schemas/ProjectFrontmatterSchema.ts
+++ b/apps/ffdweb-site/src/app/projects/schemas/ProjectFrontmatterSchema.ts
@@ -4,7 +4,7 @@ import { z } from 'zod'
 export const ProjectFrontmatterSchema = DynamicBaseDataSchema.extend({
   title: z.string(),
   description: z.string(),
-  'external-link': z.string().optional(),
+  'external-link': z.string(),
   'featured-content': z.string().optional(),
   'active-partnership': z.boolean().optional().default(false),
 }).strict()

--- a/apps/ffdweb-site/src/content/projects/blockchain-law-center-for-social-good.md
+++ b/apps/ffdweb-site/src/content/projects/blockchain-law-center-for-social-good.md
@@ -10,7 +10,7 @@ description: Promote blockchain technology’s potential to benefit all members 
   government staff.
 image:
   src: /assets/images/partnerlogo_blsgc.png
-external-link: https://www.blockchainlawsg.org/
+website: https://www.blockchainlawsg.org/
 seo:
   description: "Educational initiative promoting blockchain technology for social good through research, policy development, and training programs for community college professors and CA government staff."
 ---

--- a/apps/ffdweb-site/src/content/projects/cc-pk-movement-for-a-better-internet.md
+++ b/apps/ffdweb-site/src/content/projects/cc-pk-movement-for-a-better-internet.md
@@ -9,7 +9,7 @@ description: FFDW supports the Movement for a Better Internet, a collaborative
   the web is better for people everywhere.
 image:
   src: /assets/images/partnerlogo_movementbetterinternet.png
-external-link: https://www.movementforabetterinternet.org/
+website: https://www.movementforabetterinternet.org/
 active-partnership: true
 seo:
   description: "FFDW supports the Movement for a Better Internet, a collaborative initiative working to shape the future of the internet around public interest values and improve the web for everyone."

--- a/apps/ffdweb-site/src/content/projects/connect-humanity.md
+++ b/apps/ffdweb-site/src/content/projects/connect-humanity.md
@@ -15,7 +15,7 @@ description: As we pursue our goal of supporting an internet for everyone, it is
 image:
   src: https://pbs.twimg.com/profile_images/1511746714688016387/EB6IZmuH_400x400.jpg
 featured-content: https://ffdweb.org/blog/ffdw-and-connect-humanity-empowering-an-equitable-digital-future
-external-link: https://connecthumanity.fund/
+website: https://connecthumanity.fund/
 active-partnership: true
 seo:
   description: "Connect Humanity conducts global surveys through community organizations to understand internet usage patterns and needs, advancing digital equity worldwide."

--- a/apps/ffdweb-site/src/content/projects/decentralized-future-council.md
+++ b/apps/ffdweb-site/src/content/projects/decentralized-future-council.md
@@ -12,7 +12,7 @@ description:
   including privacy, security, democracy, online trust and safety, and more.
 image:
   src: /assets/images/partnerlogo_decentfuturecoucil.png
-external-link: https://www.decentralizedfuturecouncil.org/
+website: https://www.decentralizedfuturecouncil.org/
 active-partnership: true
 seo:
   description: "The Decentralized Future Council educates policymakers on emerging technologies like blockchain and cryptocurrency, addressing challenges in privacy, security, and digital trust."

--- a/apps/ffdweb-site/src/content/projects/digital-public-library-of-america-dpla.md
+++ b/apps/ffdweb-site/src/content/projects/digital-public-library-of-america-dpla.md
@@ -15,7 +15,7 @@ description: Together, DPLA's partners hold 50 million items that represent our
   and share the results with their community.
 image:
   src: /assets/images/dplalogovector-1-.svg
-external-link: https://dp.la/
+website: https://dp.la/
 seo:
   description: "DPLA partners hold 50M cultural heritage items. This project explores preserving these collections on Filecoin to enhance public access and ensure long-term preservation."
 ---

--- a/apps/ffdweb-site/src/content/projects/distributed-press.md
+++ b/apps/ffdweb-site/src/content/projects/distributed-press.md
@@ -14,7 +14,7 @@ description: Distributed Press is an initiative to build an open source, no-code
 image:
   src: /assets/images/partnerlogo_distributedpress.png
 featured-content: https://ffdweb.org/blog/building-distributed-press-a-publishing-tool-for-the-decentralized-web
-external-link: https://distributed.press/
+website: https://distributed.press/
 seo:
   description: "An open source, no-code publishing tool for Web and DWeb that empowers authors and amplifies free expression by enabling creators to publish content across decentralized networks."
 ---

--- a/apps/ffdweb-site/src/content/projects/easier-data-initiative.md
+++ b/apps/ffdweb-site/src/content/projects/easier-data-initiative.md
@@ -13,7 +13,7 @@ description: In partnership with researchers from the University of Maryland’s
 image:
   src: /assets/images/partnerlogo_easier.png
 featured-content: https://ffdweb.org/blog/ffdw-and-easier-data-initiative-collaborate-to-upload-spatial-data-to-filecoin-network
-external-link: https://easierdata.org/
+website: https://easierdata.org/
 seo:
   description: "FFDW partners with UMD researchers to make large geospatial datasets accessible using decentralized storage technologies like Filecoin and IPFS."
 ---

--- a/apps/ffdweb-site/src/content/projects/easier-data-initiative.md
+++ b/apps/ffdweb-site/src/content/projects/easier-data-initiative.md
@@ -13,6 +13,7 @@ description: In partnership with researchers from the University of Maryland’s
 image:
   src: /assets/images/partnerlogo_easier.png
 featured-content: https://ffdweb.org/blog/ffdw-and-easier-data-initiative-collaborate-to-upload-spatial-data-to-filecoin-network
+external-link: https://easierdata.org/
 seo:
   description: "FFDW partners with UMD researchers to make large geospatial datasets accessible using decentralized storage technologies like Filecoin and IPFS."
 ---

--- a/apps/ffdweb-site/src/content/projects/electronic-frontier-foundation.md
+++ b/apps/ffdweb-site/src/content/projects/electronic-frontier-foundation.md
@@ -14,7 +14,7 @@ description: "EFF is an essential champion of user privacy, free expression, and
   security."
 image:
   src: /assets/images/eff_short.png
-external-link: https://www.eff.org/
+website: https://www.eff.org/
 seo:
   description: "EFF champions digital rights through litigation, policy analysis, and activism. They protect privacy, free speech, and innovation as technology's role grows worldwide."
 ---

--- a/apps/ffdweb-site/src/content/projects/food-for-crisis.md
+++ b/apps/ffdweb-site/src/content/projects/food-for-crisis.md
@@ -17,7 +17,7 @@ description:
   traditional bank transfers, e-vouchers, and mobile money).
 image:
   src: /assets/images/food-for-crisis-logo.svg
-external-link: www.gbbc.io/food-for-crisis
+website: www.gbbc.io/food-for-crisis
 seo:
   description: "Food for Crisis leverages blockchain technology to trace humanitarian aid from donation to beneficiary, ensuring transparency while integrating with local payment systems."
 ---

--- a/apps/ffdweb-site/src/content/projects/freedom-of-the-press-foundation.md
+++ b/apps/ffdweb-site/src/content/projects/freedom-of-the-press-foundation.md
@@ -16,7 +16,7 @@ description:
 image:
   src: /assets/images/partnerlogo_freedompress.png
 featured-content: https://decrypt.co/82056/filecoin-group-grants-million-edward-snowden-press-freedom-foundation
-external-link: https://freedom.press/news/filecoin-foundation-for-the-decentralized-web-funds-freedom-of-the-press-foundation-with-largest-grant-in-our-history
+website: https://freedom.press/news/filecoin-foundation-for-the-decentralized-web-funds-freedom-of-the-press-foundation-with-largest-grant-in-our-history
 seo:
   description: "FFDW supports Freedom of the Press Foundation's infrastructure and security enhancements for SecureDrop, helping journalists worldwide communicate securely with anonymous sources."
 ---

--- a/apps/ffdweb-site/src/content/projects/freedom-of-the-press-foundation.md
+++ b/apps/ffdweb-site/src/content/projects/freedom-of-the-press-foundation.md
@@ -15,8 +15,8 @@ description:
   belongs in the public sphere.
 image:
   src: /assets/images/partnerlogo_freedompress.png
-featured-content: https://freedom.press/news/filecoin-foundation-for-the-decentralized-web-funds-freedom-of-the-press-foundation-with-largest-grant-in-our-history
-external-link: https://decrypt.co/82056/filecoin-group-grants-million-edward-snowden-press-freedom-foundation
+featured-content: https://decrypt.co/82056/filecoin-group-grants-million-edward-snowden-press-freedom-foundation
+external-link: https://freedom.press/news/filecoin-foundation-for-the-decentralized-web-funds-freedom-of-the-press-foundation-with-largest-grant-in-our-history
 seo:
   description: "FFDW supports Freedom of the Press Foundation's infrastructure and security enhancements for SecureDrop, helping journalists worldwide communicate securely with anonymous sources."
 ---

--- a/apps/ffdweb-site/src/content/projects/grayarea-foundation-for-the-arts.md
+++ b/apps/ffdweb-site/src/content/projects/grayarea-foundation-for-the-arts.md
@@ -13,7 +13,7 @@ description: Gray Area is a 21st-century countercultural hub catalyzing creative
   technology into their creative practices.
 image:
   src: /assets/images/partnerlogo_grayarea.png
-external-link: https://grayarea.org/
+website: https://grayarea.org/
 seo:
   description: "Gray Area is a countercultural hub fostering creative action at the intersection of art and technology, developing DWeb curriculum to empower creators in their practices."
 ---

--- a/apps/ffdweb-site/src/content/projects/guardian-project.md
+++ b/apps/ffdweb-site/src/content/projects/guardian-project.md
@@ -16,7 +16,7 @@ description:
 image:
   src: /assets/images/partnerlogo_gaurdian.png
 featured-content: https://ffdweb.org/blog/the-future-of-decentralized-apps-a-q-a-with-guardian-project
-external-link: https://guardianproject.info/
+website: https://guardianproject.info/
 seo:
   description: "FFDW and Guardian Project collaborate to integrate decentralized storage into ProofMode for secure content verification and F-Droid for open-source app distribution."
 ---

--- a/apps/ffdweb-site/src/content/projects/harvard-library-innovation-lab.md
+++ b/apps/ffdweb-site/src/content/projects/harvard-library-innovation-lab.md
@@ -15,7 +15,7 @@ description:
 image:
   src: /assets/images/partnerlogo_harvardlibrary.png
 featured-content: https://ffdweb.org/blog/filecoin-foundation-for-the-decentralized-web-boosts-harvard-library-innovation-lab-s-work-to-democratize-open-knowledge
-external-link: https://lil.law.harvard.edu/
+website: https://lil.law.harvard.edu/
 seo:
   description: "Harvard Law Library's innovation lab explores decentralized tech like Filecoin and IPFS to advance knowledge preservation and discovery, supported by FFDW."
 ---

--- a/apps/ffdweb-site/src/content/projects/human-rights-data-analysis-group.md
+++ b/apps/ffdweb-site/src/content/projects/human-rights-data-analysis-group.md
@@ -11,7 +11,7 @@ description: HRDAG has been turning raw data into analyzable data for nearly 30
 image:
   src: /assets/images/partnerlogo_hrdag.png
 featured-content: https://ffdweb.org/blog/can-filecoin-be-the-storage-network-for-human-rights-data
-external-link: https://hrdag.org/
+website: https://hrdag.org/
 seo:
   description: "HRDAG collaborates with FFDW to explore decentralized web storage solutions for human rights organizations, building on 30 years of data analysis expertise."
 ---

--- a/apps/ffdweb-site/src/content/projects/internet-archive.md
+++ b/apps/ffdweb-site/src/content/projects/internet-archive.md
@@ -18,7 +18,7 @@ description:
   valuable information and improve access to information online."
 image:
   src: /assets/images/partnerlogo_internetarchive.png
-external-link: https://archive.org/
+website: https://archive.org/
 seo:
   description: "The Internet Archive preserves digital history through projects like the Wayback Machine, OpenLibrary.org, and Software Collections, partnering with Filecoin to protect vital information."
 ---

--- a/apps/ffdweb-site/src/content/projects/muckrock-documentcloud.md
+++ b/apps/ffdweb-site/src/content/projects/muckrock-documentcloud.md
@@ -14,7 +14,7 @@ description: FFDW and MuckRock are teaming up to integrate decentralized storage
 image:
   src: /assets/images/partnerlogo_muckrock.png
 featured-content: https://ffdweb.org/blog/empowering-a-more-informed-transparent-society-with-decentralized-technology
-external-link: https://www.muckrock.com/news/archives/2022/may/04/ffdw-and-muckrock-collaborate-to-bring-documentclo/
+website: https://www.muckrock.com/news/archives/2022/may/04/ffdw-and-muckrock-collaborate-to-bring-documentclo/
 seo:
   description: "FFDW and MuckRock are integrating Filecoin's decentralized storage with DocumentCloud to expand preservation and accessibility of over 8 million verified public interest documents."
 ---

--- a/apps/ffdweb-site/src/content/projects/openarchive.md
+++ b/apps/ffdweb-site/src/content/projects/openarchive.md
@@ -11,7 +11,8 @@ description: OpenArchive is a nonprofit dedicated to advancing human rights by
   Filecoin and other decentralized storage options via their mobile device.
 image:
   src: /assets/images/partnerlogo_openarchive.png
-featured-content: https://ffdweb.org/blog/ffdw-and-openarchive-collaborate-to-deploy-decentralized-archive-for-human-rights-data/
+featured-content: https://ffdweb.org/blog/ffdw-and-openarchive-collaborate-to-deploy-decentralized-archive-for-human-rights-data
+external-link: https://openarchive.org/
 seo:
   description: "OpenArchive partners with FFDW to enable secure, decentralized preservation of human rights media through their Save app, leveraging IPFS and Filecoin for mobile-first documentation."
 ---

--- a/apps/ffdweb-site/src/content/projects/openarchive.md
+++ b/apps/ffdweb-site/src/content/projects/openarchive.md
@@ -12,7 +12,7 @@ description: OpenArchive is a nonprofit dedicated to advancing human rights by
 image:
   src: /assets/images/partnerlogo_openarchive.png
 featured-content: https://ffdweb.org/blog/ffdw-and-openarchive-collaborate-to-deploy-decentralized-archive-for-human-rights-data
-external-link: https://openarchive.org/
+website: https://openarchive.org/
 seo:
   description: "OpenArchive partners with FFDW to enable secure, decentralized preservation of human rights media through their Save app, leveraging IPFS and Filecoin for mobile-first documentation."
 ---

--- a/apps/ffdweb-site/src/content/projects/prelinger-archive.md
+++ b/apps/ffdweb-site/src/content/projects/prelinger-archive.md
@@ -12,7 +12,7 @@ description:
 image:
   src: /assets/images/partnerlogo_prelinger.png
 featured-content: https://ffdweb.org/blog/ffdw-works-with-prelinger-archives-to-make-rare-historic-films-more-accessible-using-the-decentralized-web
-external-link: https://help.archive.org/help/prelinger-archive/
+website: https://help.archive.org/help/prelinger-archive/
 seo:
   description: "Prelinger Archives is digitizing rare historical films and preserving them on decentralized storage, making unique 8mm, 16mm, and 35mm footage accessible to the public."
 ---

--- a/apps/ffdweb-site/src/content/projects/prelinger-archive.md
+++ b/apps/ffdweb-site/src/content/projects/prelinger-archive.md
@@ -11,7 +11,8 @@ description:
   in order to increase the resilience and longevity of digital preservation.
 image:
   src: /assets/images/partnerlogo_prelinger.png
-featured-content: https://ffdweb.org/blog/ffdw-works-with-prelinger-archives-to-make-rare-historic-films-more-accessible-using-the-decentralized-web/
+featured-content: https://ffdweb.org/blog/ffdw-works-with-prelinger-archives-to-make-rare-historic-films-more-accessible-using-the-decentralized-web
+external-link: https://help.archive.org/help/prelinger-archive/
 seo:
   description: "Prelinger Archives is digitizing rare historical films and preserving them on decentralized storage, making unique 8mm, 16mm, and 35mm footage accessible to the public."
 ---

--- a/apps/ffdweb-site/src/content/projects/rust-foundation.md
+++ b/apps/ffdweb-site/src/content/projects/rust-foundation.md
@@ -9,7 +9,7 @@ description:
   supporting the set of maintainers governing and developing the project.
 image:
   src: /assets/images/rust-foundation-logo-new-black.png
-external-link: https://foundation.rust-lang.org/
+website: https://foundation.rust-lang.org/
 seo:
   description: "The Rust Foundation stewards the Rust programming language and ecosystem, supporting maintainers and developers while fostering the growth of this secure systems programming language."
 ---

--- a/apps/ffdweb-site/src/content/projects/sacred-stacks.md
+++ b/apps/ffdweb-site/src/content/projects/sacred-stacks.md
@@ -12,6 +12,7 @@ description: Sacred Stacks is an initiative within the Media Design Lab at the
 image:
   src: /assets/images/partnerlogo_boulder.png
 featured-content: https://ffdweb.org/blog/ffdw-and-sacred-stacks-building-community-with-decentralized-tools/
+external-link: https://www.colorado.edu/lab/medlab/sacred-stacks
 active-partnership: true
 seo:
   description: "Sacred Stacks explores how decentralized technologies can strengthen communities focused on spiritual experimentation, collective study, and social transformation."

--- a/apps/ffdweb-site/src/content/projects/sacred-stacks.md
+++ b/apps/ffdweb-site/src/content/projects/sacred-stacks.md
@@ -12,7 +12,7 @@ description: Sacred Stacks is an initiative within the Media Design Lab at the
 image:
   src: /assets/images/partnerlogo_boulder.png
 featured-content: https://ffdweb.org/blog/ffdw-and-sacred-stacks-building-community-with-decentralized-tools/
-external-link: https://www.colorado.edu/lab/medlab/sacred-stacks
+website: https://www.colorado.edu/lab/medlab/sacred-stacks
 active-partnership: true
 seo:
   description: "Sacred Stacks explores how decentralized technologies can strengthen communities focused on spiritual experimentation, collective study, and social transformation."

--- a/apps/ffdweb-site/src/content/projects/shift-collective.md
+++ b/apps/ffdweb-site/src/content/projects/shift-collective.md
@@ -13,7 +13,7 @@ description: Shift Collective is a nonprofit that helps cultural memory
   non-extractive, affordable, and accessible long-term, decentralized storage.
 image:
   src: /assets/images/partnerlogo_shift.png
-external-link: https://www.shiftcollective.us/ffdw
+website: https://www.shiftcollective.us/ffdw
 seo:
   description: "Shift Collective partners with cultural memory organizations to build community-centered decentralized storage solutions, making archives more accessible and sustainable."
 ---

--- a/apps/ffdweb-site/src/content/projects/spritely-networked-communities-institute.md
+++ b/apps/ffdweb-site/src/content/projects/spritely-networked-communities-institute.md
@@ -13,6 +13,7 @@ description:
 image:
   src: /assets/images/partnerlogo_spritely.png
 featured-content: https://ffdweb.org/blog/ffdw-supports-spritely-networked-communities-institute-to-develop-decentralized-social-media
+external-link: https://spritely.institute/
 seo:
   description: "Spritely develops open-source technology for decentralized identity and social networks, empowering users to control their online presence without corporate gatekeepers."
 ---

--- a/apps/ffdweb-site/src/content/projects/spritely-networked-communities-institute.md
+++ b/apps/ffdweb-site/src/content/projects/spritely-networked-communities-institute.md
@@ -13,7 +13,7 @@ description:
 image:
   src: /assets/images/partnerlogo_spritely.png
 featured-content: https://ffdweb.org/blog/ffdw-supports-spritely-networked-communities-institute-to-develop-decentralized-social-media
-external-link: https://spritely.institute/
+website: https://spritely.institute/
 seo:
   description: "Spritely develops open-source technology for decentralized identity and social networks, empowering users to control their online presence without corporate gatekeepers."
 ---

--- a/apps/ffdweb-site/src/content/projects/stack-shift.md
+++ b/apps/ffdweb-site/src/content/projects/stack-shift.md
@@ -10,7 +10,7 @@ description:
   accelerator participants at DWeb startups. "
 image:
   src: /assets/images/partnerlogo_stackshift.png
-external-link: https://www.stackshift.com/
+website: https://www.stackshift.com/
 active-partnership: true
 seo:
   description: "Stack Shift connects remote talent in Africa with high-impact jobs at DWeb startups, advancing distributed work opportunities and expanding professional networks."

--- a/apps/ffdweb-site/src/content/projects/starling-lab.md
+++ b/apps/ffdweb-site/src/content/projects/starling-lab.md
@@ -15,7 +15,7 @@ description: >-
 image:
   src: >-
     https://uploads-ssl.webflow.com/643e92b3a344778457270525/649c81d53d6f2b384d2aa16e_image.png
-external-link: https://www.starlinglab.org/
+website: https://www.starlinglab.org/
 seo:
   description: "Starling Lab develops open-source tools and best practices to document human rights violations and war crimes, leveraging Web3 and Filecoin for verifiable preservation."
 ---

--- a/apps/ffdweb-site/src/content/projects/techcongress-growing-the-congressional-innovation-fellowship.md
+++ b/apps/ffdweb-site/src/content/projects/techcongress-growing-the-congressional-innovation-fellowship.md
@@ -11,7 +11,7 @@ description:
 image:
   src: /assets/images/partnerlogo_techcongress.png
 featured-content: https://ffdweb.org/blog/filecoin-foundation-for-the-decentralized-web-and-techcongress-will-work-together-to-place-more-technologists-on-capitol-hill/
-external-link: https://www.youtube.com/watch?v=biI1sR859xE&t=1s
+website: https://www.youtube.com/watch?v=biI1sR859xE&t=1s
 seo:
   description: "TechCongress bridges the tech-policy gap by placing technologists as advisors to Congress, helping legislators make informed decisions on technology policy issues."
 ---

--- a/apps/ffdweb-site/src/content/projects/techsoup.md
+++ b/apps/ffdweb-site/src/content/projects/techsoup.md
@@ -13,7 +13,7 @@ description: >-
 image:
   src: >-
     https://uploads-ssl.webflow.com/643e92b3a344778457270525/649c81faf4d7738ba43cceaa_image%20(1).png
-external-link: https://www.techsoup.org/
+website: https://www.techsoup.org/
 seo:
   description: "TechSoup's Accelerating Makers project supports early-stage creators in understanding and adopting decentralized technologies for civil society applications."
 ---

--- a/apps/ffdweb-site/src/content/projects/ushahidi.md
+++ b/apps/ffdweb-site/src/content/projects/ushahidi.md
@@ -11,7 +11,7 @@ description:
   public and help ensure it cannot be altered. "
 image:
   src: /assets/images/ushahidi-logo_black_1x-1-.png
-external-link: https://www.ushahidi.com/
+website: https://www.ushahidi.com/
 seo:
   description: "Ushahidi's Election Data Resilience Initiative uses Filecoin to create a permanent, verifiable repository of election data for researchers and policymakers."
 ---

--- a/apps/ffdweb-site/src/content/projects/witness.md
+++ b/apps/ffdweb-site/src/content/projects/witness.md
@@ -13,7 +13,7 @@ description:
   they live and work.
 image:
   src: /assets/images/partnerlogo_witness.png
-external-link: https://www.witness.org/
+website: https://www.witness.org/
 featured-content: https://ffdweb.org/blog/ffdw-and-witness-collaborate-to-preserve-authentic-human-rights-records
 seo:
   description: "WITNESS empowers activists and civic journalists to document human rights through video technology, exploring decentralized web solutions for preserving crucial evidence."

--- a/apps/ffdweb-site/src/content/projects/witness.md
+++ b/apps/ffdweb-site/src/content/projects/witness.md
@@ -13,6 +13,7 @@ description:
   they live and work.
 image:
   src: /assets/images/partnerlogo_witness.png
+external-link: https://www.witness.org/
 featured-content: https://ffdweb.org/blog/ffdw-and-witness-collaborate-to-preserve-authentic-human-rights-records
 seo:
   description: "WITNESS empowers activists and civic journalists to document human rights through video technology, exploring decentralized web solutions for preserving crucial evidence."

--- a/apps/ffdweb-site/src/content/projects/world-wide-web-foundation-1.md
+++ b/apps/ffdweb-site/src/content/projects/world-wide-web-foundation-1.md
@@ -14,7 +14,7 @@ description:
   and in what areas a course correction is needed.
 image:
   src: /assets/images/web-foundation-hi-res-logo.jpeg
-external-link: https://www.webfoundation.org/
+website: https://www.webfoundation.org/
 active-partnership: true
 seo:
   description: "The Web Foundation advances Tim Berners-Lee's vision of an open web through the Web Index project, monitoring emerging issues and ensuring a safe digital future."

--- a/apps/ffdweb-site/src/content/projects/world-wide-web-foundation-1.md
+++ b/apps/ffdweb-site/src/content/projects/world-wide-web-foundation-1.md
@@ -14,6 +14,7 @@ description:
   and in what areas a course correction is needed.
 image:
   src: /assets/images/web-foundation-hi-res-logo.jpeg
+external-link: https://www.webfoundation.org/
 active-partnership: true
 seo:
   description: "The Web Foundation advances Tim Berners-Lee's vision of an open web through the Web Index project, monitoring emerging issues and ensuring a safe digital future."


### PR DESCRIPTION
## 📝 Description

This PR updates the project schema and content files to standardize the naming of the external link field from `external-link` to `website`.

Changes:

- Updated `config.yml` to reflect the field name change (`external-link` → `website`).
- Updated `ProjectFrontmatterSchema.ts` to rename `external-link` to `website`.
- Refactored `page.tsx` to use website instead of `externalLink`.
- Updated all project markdown content files to reflect the new field name.

