### PR TITLE
Refine Link Checker workflow

### DIFF
--- a/.github/workflows/apps-link-checker.yml
+++ b/.github/workflows/apps-link-checker.yml
@@ -29,6 +29,6 @@ jobs:
             --retry-wait-time 15
             --exclude https://twitter.com/*
             --exclude https://x.com/*
-            --exclude "^/.*"
+            --exclude "^\/(?:[^\/].*)?$"
             --max-retries 10
             './**/*.md'


### PR DESCRIPTION
## 📝 Description

The Link Checker workflow was already set up for both projects, it runs on a weekly schedule.

The exclusion of relative links [didn't seem to work](https://github.com/FilecoinFoundationWeb/filecoin-foundation/actions/runs/13919461529/job/38949109886), as shown in the screenshot below, so I updated it.

![CleanShot 2025-03-18 at 10 07 33@2x](https://github.com/user-attachments/assets/db88176e-8dfb-4e50-a503-a6549e0151af)

There are currently ~90 broken links on FFDW
