### PR TITLE
[FFDW][UXIT-2395] Projects · Improve look of logos

### DIFF
--- a/apps/ff-site/src/app/_styles/globals.css
+++ b/apps/ff-site/src/app/_styles/globals.css
@@ -165,6 +165,10 @@
 
   .card-image {
     @apply rounded-lg px-1 pt-1;
+
+    &.card-image-spacing {
+      @apply px-6 pt-4;
+    }
   }
 
   .card-link {

--- a/apps/ffdweb-site/src/app/_styles/globals.css
+++ b/apps/ffdweb-site/src/app/_styles/globals.css
@@ -179,7 +179,7 @@
   }
 
   .card-image {
-    @apply bg-neutral-50;
+    @apply bg-white;
 
     &.card-image-spacing {
       @apply p-4;

--- a/apps/ffdweb-site/src/app/_styles/globals.css
+++ b/apps/ffdweb-site/src/app/_styles/globals.css
@@ -180,6 +180,10 @@
 
   .card-image {
     @apply bg-neutral-50;
+
+    &.card-image-spacing {
+      @apply p-4;
+    }
   }
 
   .card-link {

--- a/apps/ffdweb-site/src/app/projects/components/ProjectsContent.tsx
+++ b/apps/ffdweb-site/src/app/projects/components/ProjectsContent.tsx
@@ -79,6 +79,7 @@ export function ProjectsContent({ projects }: ProjectsContentProps) {
                 alt: '',
                 priority: isFirstThreeImages,
                 objectFit: 'contain',
+                aspectRatio: 'square',
                 padding: true,
                 sizes: buildImageSizeProp({
                   startSize: '100vw',

--- a/packages/ui/src/Card.tsx
+++ b/packages/ui/src/Card.tsx
@@ -33,6 +33,7 @@ type CardImageProps = (StaticImageProps | ImageProps) & {
   padding?: boolean
   priority?: boolean
   sizes?: string
+  aspectRatio?: 'square' | 'video'
 }
 
 export type ExtendedCTAProps = CTAProps & {
@@ -100,6 +101,9 @@ Card.Image = function ImageComponent({
   image,
 }: Required<Pick<CardProps, 'image'>>) {
   const isStaticImage = 'data' in image
+  // const aspectRatio = image.aspectRatio || 'video'
+  const ASPECT_RATIO =
+    image.aspectRatio === 'square' ? 'aspect-square' : 'aspect-video'
 
   const commonProps = {
     alt: image.alt,
@@ -111,7 +115,7 @@ Card.Image = function ImageComponent({
       'card-image',
       image.objectFit === 'cover' && 'object-cover',
       image.objectFit === 'contain' && 'object-contain',
-      image.padding && 'px-6 pt-4',
+      image.padding && 'card-image-spacing',
     ),
   }
 
@@ -119,7 +123,7 @@ Card.Image = function ImageComponent({
     return (
       <Image
         {...commonProps}
-        className={clsx(commonProps.className, 'aspect-video')}
+        className={clsx(commonProps.className, ASPECT_RATIO)}
         src={image.data}
         alt={commonProps.alt}
       />
@@ -127,7 +131,7 @@ Card.Image = function ImageComponent({
   }
 
   return (
-    <div className="relative aspect-video">
+    <div className={clsx('relative', ASPECT_RATIO)}>
       <Image
         fill
         {...commonProps}


### PR DESCRIPTION
## 📝 Description

This PR introduces improvements to the `card-image` component styles and enhances the `Card.Image` component by adding support for an `aspectRatio` prop. Additionally, it updates styles in `globals.css` for both `ff-site` and `ffdweb-site`.

- **`apps/ff-site/src/app/_styles/globals.css`**
  - Added `.card-image-spacing` class with `px-6 pt-4` for better spacing.
  
- **`apps/ffdweb-site/src/app/_styles/globals.css`**
  - Changed `.card-image` background from `bg-neutral-50` to `bg-white`.
  - Added `.card-image-spacing` class with `p-4` for consistent styling.

- **`ProjectsContent.tsx`**
  - Added `aspectRatio: 'square'` to images in `ProjectsContent`.

- **`Card.tsx`**
  - Introduced `aspectRatio` prop (`'square' | 'video'`).
  - Implemented conditional class assignment for aspect ratio (`aspect-square` or `aspect-video`).
  - Replaced direct padding styles (`px-6 pt-4`) with the `.card-image-spacing` class.
  
## 📸 Screenshots

BEFORE
![CleanShot 2025-03-18 at 10 39 08@2x](https://github.com/user-attachments/assets/ac9fb65f-4fd6-4977-bbbb-dd2545bc573c)

AFTER
![CleanShot 2025-03-18 at 10 39 22@2x](https://github.com/user-attachments/assets/ef88352e-5f55-47e5-bd64-7f56494ea631)
