### PR TITLE
[Shared] Fix Prose Link Styles

### DIFF
--- a/apps/ff-site/src/app/_components/MarkdownContent.tsx
+++ b/apps/ff-site/src/app/_components/MarkdownContent.tsx
@@ -63,8 +63,9 @@ const MarkdownLink: Components['a'] = ({ href, children }) => {
 
     return <>{children}</>
   }
+
   return (
-    <SmartTextLink href={href} baseDomain={BASE_DOMAIN} className="not-prose">
+    <SmartTextLink href={href} baseDomain={BASE_DOMAIN}>
       {children}
     </SmartTextLink>
   )

--- a/apps/ff-site/src/app/_styles/globals.css
+++ b/apps/ff-site/src/app/_styles/globals.css
@@ -79,6 +79,7 @@
     @apply text-brand-300;
   }
 }
+
 @layer components {
   /* SHARED */
   .social-link {
@@ -299,7 +300,7 @@
 
   /* TEXT LINKS */
   .text-link {
-    @apply text-brand-300 hover:underline focus:brand-outline;
+    @apply text-brand-300! no-underline! hover:underline! focus:brand-outline!;
   }
 
   /* TOC */

--- a/apps/ff-site/src/app/_styles/globals.css
+++ b/apps/ff-site/src/app/_styles/globals.css
@@ -300,7 +300,7 @@
 
   /* TEXT LINKS */
   .text-link {
-    @apply text-brand-300! no-underline! hover:underline! focus:brand-outline!;
+    @apply font-normal! text-brand-300! no-underline! hover:underline! focus:brand-outline!;
   }
 
   /* TOC */

--- a/apps/ffdweb-site/src/app/_components/MarkdownContent.tsx
+++ b/apps/ffdweb-site/src/app/_components/MarkdownContent.tsx
@@ -55,7 +55,7 @@ const MarkdownLink: Components['a'] = ({ href, children }) => {
     return <>{children}</>
   }
   return (
-    <SmartTextLink href={href} baseDomain={BASE_DOMAIN} className="not-prose">
+    <SmartTextLink href={href} baseDomain={BASE_DOMAIN}>
       {children}
     </SmartTextLink>
   )

--- a/apps/ffdweb-site/src/app/_styles/globals.css
+++ b/apps/ffdweb-site/src/app/_styles/globals.css
@@ -298,7 +298,7 @@
 
   /* TEXT LINKS */
   .text-link {
-    @apply text-brand-primary-300 hover:text-brand-primary-500 focus:brand-outline hover:underline; /* CHECK */
+    @apply text-brand-primary-300! no-underline! hover:text-brand-primary-500! focus:brand-outline! hover:underline!; /* CHECK */
   }
 
   /* TOOLTIP */

--- a/apps/ffdweb-site/src/app/_styles/globals.css
+++ b/apps/ffdweb-site/src/app/_styles/globals.css
@@ -30,7 +30,7 @@
 
   --color-icon-primary: theme('colors.brand.primary.300');
   --color-icon-accent: theme('colors.brand.secondary.100');
-  --color-icon-subtle: theme('colors.neutral.300'); /* CHECK */
+  --color-icon-subtle: theme('colors.neutral.300');
 
   --leading-heading: 1.3;
   --spacing-readable: 60ch;
@@ -80,7 +80,7 @@
   }
 
   & pre {
-    @apply border-brand-primary-300 border border-solid; /* CHECK */
+    @apply border-brand-primary-300 border border-solid;
   }
 
   & iframe {
@@ -112,7 +112,7 @@
 
   /* AVATAR */
   .avatar-background {
-    @apply bg-brand-primary-800; /* CHECK */
+    @apply bg-brand-primary-800;
   }
 
   .avatar-full-name {
@@ -120,7 +120,7 @@
   }
 
   .avatar-initials {
-    @apply text-neutral-50; /* CHECK */
+    @apply text-neutral-50;
   }
 
   .avatar-ring {
@@ -145,15 +145,15 @@
     @apply border-2 font-bold;
 
     &.button--primary {
-      @apply border-brand-primary-300 bg-brand-primary-300 text-neutral-950 hover:border-neutral-100 hover:bg-neutral-100 focus:bg-neutral-100; /* CHECK */
+      @apply border-brand-primary-300 bg-brand-primary-300 text-neutral-950 hover:border-neutral-100 hover:bg-neutral-100 focus:bg-neutral-100;
     }
 
     &.button--ghost {
-      @apply text-brand-primary-300 border-brand-primary-300 focus:text-brand-primary-300 bg-neutral-950 hover:border-neutral-100 hover:text-neutral-100; /* CHECK */
+      @apply text-brand-primary-300 border-brand-primary-300 focus:text-brand-primary-300 bg-neutral-950 hover:border-neutral-100 hover:text-neutral-100;
     }
 
     &.button--disabled {
-      @apply bg-neutral-300; /* CHECK */
+      @apply bg-neutral-300;
     }
   }
 
@@ -298,7 +298,7 @@
 
   /* TEXT LINKS */
   .text-link {
-    @apply font-normal! text-brand-primary-300! no-underline! hover:text-brand-primary-500! hover:underline! focus:brand-outline!; /* CHECK */
+    @apply font-normal! text-brand-primary-300! no-underline! hover:text-brand-primary-500! hover:underline! focus:brand-outline!;
   }
 
   /* TOOLTIP */

--- a/apps/ffdweb-site/src/app/_styles/globals.css
+++ b/apps/ffdweb-site/src/app/_styles/globals.css
@@ -298,7 +298,7 @@
 
   /* TEXT LINKS */
   .text-link {
-    @apply text-brand-primary-300! no-underline! hover:text-brand-primary-500! focus:brand-outline! hover:underline!; /* CHECK */
+    @apply font-normal! text-brand-primary-300! no-underline! hover:text-brand-primary-500! hover:underline! focus:brand-outline!; /* CHECK */
   }
 
   /* TOOLTIP */


### PR DESCRIPTION
## 📝 Description

This PR fixes issues related to link styling in Markdown content and global styles for both ff-site and ffdweb-site. It ensures that prose links are correctly styled and do not unintentionally inherit unwanted styles from Tailwind's typography library.

## 🛠️ Key Changes
- `MarkdownContent.tsx` (both `ff-site` and `ffdweb-site`):  
  - Removed `className="not-prose"` from `<SmartTextLink>` to ensure styles are centralized under `globals.css`
- `globals.css` (ff-site & ffdweb-site):  
  - Updated `.text-link` styles:  
    - Enforced `no-underline` and `font-normal` by default to prevent unwanted underlining in prose links.  
    - Applied `hover:underline!` for consistent hover behavior.
    
## 📸 Screenshots

BEFORE

![CleanShot 2025-03-18 at 14 31 13@2x](https://github.com/user-attachments/assets/1741246d-37da-4ea5-844c-3e28c6f1e892)

AFTER

![CleanShot 2025-03-18 at 14 33 59@2x](https://github.com/user-attachments/assets/234cfc6d-e392-4be6-afc3-4667c8b12f77)
