### PR TITLE
[FFDW] Digest Page · Update kicker and headline copy [skip percy]

### DIFF
--- a/apps/ffdweb-site/src/app/digest/page.tsx
+++ b/apps/ffdweb-site/src/app/digest/page.tsx
@@ -35,8 +35,8 @@ export default async function Digest() {
         structuredData={generateStructuredData(DIGEST_SEO)}
       />
       <PageHeader
-        kicker="Digest"
-        title="The Go-to Publication for Exploring DWeb Ideas and Principles"
+        kicker="DWeb Digest"
+        title="A Publication Exploring DWeb Ideas and Principles"
         image={graphicsData.digest}
       />
 


### PR DESCRIPTION
## 📝 Description  

This PR updates the kicker and headline on the Digest Page. For more details, see the related [Slack thread](https://filecoinfoundation.slack.com/archives/C06PL3W4FPE/p1741866114902589) and the request from @dannyob.  