### PR TITLE
[UXIT-2411] Open Graph Metadata

### DIFF
--- a/apps/ffdweb-site/src/app/_utils/createMetadata.ts
+++ b/apps/ffdweb-site/src/app/_utils/createMetadata.ts
@@ -2,11 +2,7 @@ import type { AbsoluteString } from 'next/dist/lib/metadata/types/metadata-types
 
 import type { Metadata } from 'next'
 
-import {
-  BASE_URL,
-  FFDW_URLS,
-  ORGANIZATION_NAME,
-} from '@/constants/siteMetadata'
+import { FFDW_URLS, ORGANIZATION_NAME } from '@/constants/siteMetadata'
 
 import { graphicsData } from '@/data/graphicsData'
 
@@ -23,6 +19,7 @@ export type MetadataParams = {
   image?: string
   openGraph?: SharedSocialMetadata & {
     type?: 'website' | 'article'
+    locale?: string
   }
   twitter?: SharedSocialMetadata & {
     card?: 'summary' | 'summary_large_image' | 'player'
@@ -43,13 +40,14 @@ export function createMetadata({
 
   const {
     type = 'website',
+    locale = 'en_US',
     title: openGraphTitle = title,
     description: openGraphDescription = description,
     image: openGraphImage = imageArray,
   } = openGraph
 
   const {
-    card = 'summary',
+    card = 'summary_large_image',
     title: twitterTitle = title,
     description: twitterDescription = description,
     site = FFDW_URLS.social.twitter.handle,
@@ -62,11 +60,12 @@ export function createMetadata({
     description,
     openGraph: {
       type,
+      locale,
       title: openGraphTitle,
       description: openGraphDescription,
       images: openGraphImage,
       siteName: ORGANIZATION_NAME,
-      url: BASE_URL,
+      url: path,
     },
     twitter: {
       title: twitterTitle,

--- a/apps/ffdweb-site/src/app/projects/[slug]/page.tsx
+++ b/apps/ffdweb-site/src/app/projects/[slug]/page.tsx
@@ -97,7 +97,10 @@ export async function generateMetadata(props: ProjectProps) {
     title: { absolute: `${seo.title} | ${ORGANIZATION_NAME_SHORT}` },
     description: seo.description,
     image: seo.image || image?.src || graphicsData.projects.data.src,
-    openGraph: seo.openGraph,
+    openGraph: {
+      type: 'article',
+      ...seo.openGraph,
+    },
     twitter: seo.twitter,
   })
 }


### PR DESCRIPTION
## 📝 Description

This PR includes some small fixes on `createMetadata` for FFDW.

- **Type:** Bug fix

## 🛠️ Key Changes

- Changed `summary` to `summary_large_image`, since `summary` is optimised for square photos, which for us doesn't look great.
![Screenshot 2025-03-20 at 14 18 54](https://github.com/user-attachments/assets/f07be65e-e92e-4914-ac75-5ffba3a83823)

- synced `og:path` to match `canonical`
- added `locale`
- for FFDW projects, added type `article`


## 🛠️ Screenshots
![Screenshot 2025-03-20 at 14 32 35](https://github.com/user-attachments/assets/ef701b80-012a-47ab-9455-98aab384b269)
![Screenshot 2025-03-20 at 14 32 05](https://github.com/user-attachments/assets/ce748740-4780-4450-897e-2ea1198efa22)

![Screenshot 2025-03-20 at 14 34 09](https://github.com/user-attachments/assets/adda1c9a-3fd9-41c5-8ddb-229de7078e8d)

P.S. I haven't tested on FB, if anyone has an account... 🥲