### PR TITLE
[FFDW][UXIT-2490] Remove unused `description` field from CMS config

### DIFF
--- a/apps/ffdweb-site/public/admin/config.yml
+++ b/apps/ffdweb-site/public/admin/config.yml
@@ -169,9 +169,6 @@ collections:
             value: "updates"
           - label: "Use Cases"
             value: "use-cases"
-      - name: "description"
-        label: "Description"
-        widget: "text"
       - *image_config
       - *body_config
       - *meta_config_with_title_fallback


### PR DESCRIPTION
## 📝 Description

The CMS currently includes a `description` field for blog posts (`config.yml`), but the corresponding Zod schema in  
`apps/ffdweb-site/src/app/blog/schemas/BlogPostFrontmatterSchema.ts` does **not** allow a `description` field — which causes builds to fail.

This PR removes the `description` field from the CMS config to align with the schema.

- **Type:** Bug fix
