### PR TITLE
[UXIT-2571] [FF] Change “Mandarin translation” link to “Chinese translation” 

### DIFF
--- a/apps/ff-site/public/admin/config.yml
+++ b/apps/ff-site/public/admin/config.yml
@@ -410,11 +410,11 @@ collections:
       - name: "description"
         label: "Description"
         widget: "text"
-      - name: "mandarin-translation-url"
-        label: "Mandarin Translation URL"
+      - name: "chinese-translation-url"
+        label: "Chinese Translation URL"
         widget: "string"
         required: false
-        hint: "URL of the Mandarin translation of this post."
+        hint: "URL of the Chinese translation of this post."
       - *image_config
       - name: "add-table-of-contents"
         label: "Add a table of contents to this post?"

--- a/apps/ff-site/src/app/blog/[slug]/page.tsx
+++ b/apps/ff-site/src/app/blog/[slug]/page.tsx
@@ -34,7 +34,7 @@ export default async function BlogPost(props: BlogPostProps) {
     publishedOn,
     category,
     addTableOfContents,
-    mandarinTranslationUrl,
+    chineseTranslationUrl,
   } = data
 
   return (
@@ -44,7 +44,7 @@ export default async function BlogPost(props: BlogPostProps) {
         <BlogPostHeader
           title={title}
           publishedOn={publishedOn}
-          mandarinTranslationUrl={mandarinTranslationUrl}
+          chineseTranslationUrl={chineseTranslationUrl}
           category={getCategoryLabel({
             collectionName: 'blog_posts',
             category,

--- a/apps/ff-site/src/app/blog/schemas/BlogPostFrontmatterSchema.ts
+++ b/apps/ff-site/src/app/blog/schemas/BlogPostFrontmatterSchema.ts
@@ -17,5 +17,5 @@ export const BlogPostFrontmatterSchema = DynamicBaseDataSchema.extend({
   description: z.string(),
   content: z.string(),
   'add-table-of-contents': z.boolean().optional(),
-  'mandarin-translation-url': z.string().url().optional(),
+  'chinese-translation-url': z.string().url().optional(),
 }).strict()

--- a/apps/ff-site/src/content/blog/ai-agents-and-why-storage-is-the-key-to-smarter-more-reliable-agents.md
+++ b/apps/ff-site/src/content/blog/ai-agents-and-why-storage-is-the-key-to-smarter-more-reliable-agents.md
@@ -4,7 +4,7 @@ created-on: 2025-03-24T18:50:00.000Z
 updated-on: 2025-03-24T18:50:00.000Z
 published-on: 2025-03-24T18:50:00.000Z
 category: use-cases
-mandarin-translation-url: https://mp.weixin.qq.com/s/3nrl4mEZnxglJohnRJ8tsQ
+chinese-translation-url: https://mp.weixin.qq.com/s/3nrl4mEZnxglJohnRJ8tsQ
 description: "Filecoin provides the underlying storage layer to power
   verifiable, tamper-proof, and permissionless AI models, ensuring that
   AI-generated outputs can be trusted."

--- a/apps/ff-site/src/content/blog/blockfrost-and-filecoin-foundation-collaborate-to-enhance-the-decentralization-of-cardano-data.md
+++ b/apps/ff-site/src/content/blog/blockfrost-and-filecoin-foundation-collaborate-to-enhance-the-decentralization-of-cardano-data.md
@@ -5,7 +5,7 @@ created-on: 2024-12-03T09:00:00.000Z
 updated-on: 2024-12-03T09:00:00.000Z
 published-on: 2024-12-03T09:00:00.000Z
 category: news
-mandarin-translation-url: https://mp.weixin.qq.com/s/F2FyhWvQZe-hkxcc05cEUQ?token=519016850&lang=zh_CN
+chinese-translation-url: https://mp.weixin.qq.com/s/F2FyhWvQZe-hkxcc05cEUQ?token=519016850&lang=zh_CN
 description: Blockfrost and Filecoin Foundation (FF) are collaborating to
   integrate Filecoin’s decentralized storage capabilities as a robust backup
   layer for Cardano apps built with Blockfrost.

--- a/apps/ff-site/src/content/blog/building-together-the-power-of-collaboration-in-the-filecoin-ecosystem.md
+++ b/apps/ff-site/src/content/blog/building-together-the-power-of-collaboration-in-the-filecoin-ecosystem.md
@@ -4,7 +4,7 @@ created-on: 2025-02-21T14:24:00.000Z
 updated-on: 2025-02-21T14:24:00.000Z
 published-on: 2025-02-21T14:24:00.000Z
 category: news
-mandarin-translation-url: https://mp.weixin.qq.com/s/Gxk6IPuTSx-Cf_uwETTLOA?token=519016850&lang=zh_CN
+chinese-translation-url: https://mp.weixin.qq.com/s/Gxk6IPuTSx-Cf_uwETTLOA?token=519016850&lang=zh_CN
 description: Since Mainnet launch in October 2020, the Filecoin network has
   steadily evolved, with new tools and services emerging to support a growing
   range of data use cases.

--- a/apps/ff-site/src/content/blog/developer-grants-updates-august-2024.md
+++ b/apps/ff-site/src/content/blog/developer-grants-updates-august-2024.md
@@ -4,7 +4,7 @@ created-on: 2024-08-16T10:00:00.000Z
 updated-on: 2024-08-16T10:00:00.000Z
 published-on: 2024-08-16T10:00:00.000Z
 category: reports
-mandarin-translation-url: https://mp.weixin.qq.com/s/KNbnKn1AGhzRm0CFrLs_Cg?token=519016850&lang=zh_CN
+chinese-translation-url: https://mp.weixin.qq.com/s/KNbnKn1AGhzRm0CFrLs_Cg?token=519016850&lang=zh_CN
 description: The Developer Grants Updates series brings news and highlights from
   Filecoin Foundation Developer Grants team.
 image:

--- a/apps/ff-site/src/content/blog/driving-widespread-filecoin-adoption-key-initiatives-and-community-involvement-in-2024.md
+++ b/apps/ff-site/src/content/blog/driving-widespread-filecoin-adoption-key-initiatives-and-community-involvement-in-2024.md
@@ -6,7 +6,7 @@ created-on: 2024-05-17T19:51:58.627000Z
 updated-on: 2024-05-17T19:51:58.641000Z
 published-on: 2024-05-17T19:51:58.651000Z
 category: ecosystem
-mandarin-translation-url: https://mp.weixin.qq.com/s/H_rID4PQJQn_4drqvBzFFw?token=519016850&lang=zh_CN
+chinese-translation-url: https://mp.weixin.qq.com/s/H_rID4PQJQn_4drqvBzFFw?token=519016850&lang=zh_CN
 description:
   "Filecoin Foundation is one of many teams in the Filecoin network committed
   to the growth and success of the protocol. In this post, we highlight Filecoin's

--- a/apps/ff-site/src/content/blog/filecoin-as-a-depin-prototype.md
+++ b/apps/ff-site/src/content/blog/filecoin-as-a-depin-prototype.md
@@ -4,7 +4,7 @@ created-on: 2024-03-04T15:11:05.167Z
 updated-on: 2024-03-04T15:11:05.193Z
 published-on: 2024-03-04T15:11:05.224Z
 category: ecosystem
-mandarin-translation-url: https://mp.weixin.qq.com/s/INxYCAbvfzSzonCenOiiaQ?token=519016850&lang=zh_CN
+chinese-translation-url: https://mp.weixin.qq.com/s/INxYCAbvfzSzonCenOiiaQ?token=519016850&lang=zh_CN
 description: The Decentralized Physical Infrastructure Network (DePIN) movement
   is re-architecting the Internet's physical and digital backbone.
 image:

--- a/apps/ff-site/src/content/blog/filecoin-as-the-infrastructure-for-decentralized-ai.md
+++ b/apps/ff-site/src/content/blog/filecoin-as-the-infrastructure-for-decentralized-ai.md
@@ -4,7 +4,7 @@ created-on: 2024-11-18T21:22:00.000Z
 updated-on: 2024-11-19T12:37:00.000Z
 published-on: 2024-11-19T12:37:00.000Z
 category: news
-mandarin-translation-url: https://mp.weixin.qq.com/s/bphQHq7TJuZoqUan8l6zcw?token=519016850&lang=zh_CN
+chinese-translation-url: https://mp.weixin.qq.com/s/bphQHq7TJuZoqUan8l6zcw?token=519016850&lang=zh_CN
 description: Filecoin Network Named in the AI and Data category for Fast
   Company’s 2024 Next Big Things in Tech Awards.
 image:

--- a/apps/ff-site/src/content/blog/filecoin-ecosystem-teams-unveil-l2s.md
+++ b/apps/ff-site/src/content/blog/filecoin-ecosystem-teams-unveil-l2s.md
@@ -4,7 +4,7 @@ created-on: 2024-11-11T05:05:00.000Z
 updated-on: 2024-11-11T05:05:00.000Z
 published-on: 2024-11-11T05:05:00.000Z
 category: news
-mandarin-translation-url: https://mp.weixin.qq.com/s/XyVPuCNUs_4SRLuik-GCXg?token=519016850&lang=zh_CN
+chinese-translation-url: https://mp.weixin.qq.com/s/XyVPuCNUs_4SRLuik-GCXg?token=519016850&lang=zh_CN
 description: Akave and Storacha Share Announcements at FIL Bangkok Signaling New
   Era for the Filecoin Network
 image:

--- a/apps/ff-site/src/content/blog/filecoin-foundation-2024-annual-report.md
+++ b/apps/ff-site/src/content/blog/filecoin-foundation-2024-annual-report.md
@@ -4,7 +4,7 @@ created-on: 2025-01-13T19:09:00.000Z
 updated-on: 2025-01-13T19:09:00.000Z
 published-on: 2025-01-13T19:09:00.000Z
 category: reports
-mandarin-translation-url: https://mp.weixin.qq.com/s/gouaZC17NbzFvkH6lURKhQ?token=519016850&lang=zh_CN
+chinese-translation-url: https://mp.weixin.qq.com/s/gouaZC17NbzFvkH6lURKhQ?token=519016850&lang=zh_CN
 description: In this report, you’ll read about the ways that Filecoin Foundation
   supported the Filecoin community in 2024 and learn about FF’s strategic
   priorities in 2025.

--- a/apps/ff-site/src/content/blog/filecoin-foundation-s-vision-and-strategic-priorities-for-2025.md
+++ b/apps/ff-site/src/content/blog/filecoin-foundation-s-vision-and-strategic-priorities-for-2025.md
@@ -4,7 +4,7 @@ created-on: 2024-12-06T13:55:00.000Z
 updated-on: 2024-12-06T13:55:00.000Z
 published-on: 2024-12-06T13:55:00.000Z
 category: ecosystem
-mandarin-translation-url: https://mp.weixin.qq.com/s/5uukUuMldfcXWL9X2NBXhw?token=519016850&lang=zh_CN
+chinese-translation-url: https://mp.weixin.qq.com/s/5uukUuMldfcXWL9X2NBXhw?token=519016850&lang=zh_CN
 description: As Filecoin Foundation (FF) looks ahead to 2025, we want to offer a
   closer look at FF’s vision and strategic priorities. In 2025, FF’s top
   objective is to mobilize the community to make Filecoin work seamlessly and

--- a/apps/ff-site/src/content/blog/filecoin-mainnet-marks-four-years.md
+++ b/apps/ff-site/src/content/blog/filecoin-mainnet-marks-four-years.md
@@ -4,7 +4,7 @@ created-on: 2024-10-14T12:00:00.000Z
 updated-on: 2024-10-14T12:00:00.000Z
 published-on: 2024-10-14T12:00:00.000Z
 category: ecosystem
-mandarin-translation-url: https://mp.weixin.qq.com/s/Gmh43FNLYHV-jicyi-tSLA?token=519016850&lang=zh_CN
+chinese-translation-url: https://mp.weixin.qq.com/s/Gmh43FNLYHV-jicyi-tSLA?token=519016850&lang=zh_CN
 description: This month on October 15, we’re thrilled to celebrate the
   anniversary of Filecoin’s Mainnet launch! Over the past four years, the
   Filecoin network has grown tremendously, becoming the world’s largest

--- a/apps/ff-site/src/content/blog/how-f3-is-transforming-the-filecoin-network.md
+++ b/apps/ff-site/src/content/blog/how-f3-is-transforming-the-filecoin-network.md
@@ -4,7 +4,7 @@ created-on: 2024-08-29T14:00:31.895661Z
 updated-on: 2024-08-29T14:00:31.895661Z
 published-on: 2024-08-29T14:00:31.895661Z
 category: ecosystem
-mandarin-translation-url: https://mp.weixin.qq.com/s/SFsF2BKLN5kvbdjTOH7kIQ
+chinese-translation-url: https://mp.weixin.qq.com/s/SFsF2BKLN5kvbdjTOH7kIQ
 description: "Fast Finality in Filecoin (F3) is coming to the network, speeding
   up finality on the network by 450X. "
 image:

--- a/apps/ff-site/src/content/blog/how-fidl-is-enhancing-transparency-and-accountability-in-fil.md
+++ b/apps/ff-site/src/content/blog/how-fidl-is-enhancing-transparency-and-accountability-in-fil.md
@@ -4,7 +4,7 @@ created-on: 2025-03-07T18:57:00.000Z
 updated-on: 2025-03-07T18:57:00.000Z
 published-on: 2025-03-07T18:57:00.000Z
 category: ecosystem
-mandarin-translation-url: https://mp.weixin.qq.com/s/N9zGrJlCVkG42gYX8J_wpw?token=519016850&lang=zh_CN
+chinese-translation-url: https://mp.weixin.qq.com/s/N9zGrJlCVkG42gYX8J_wpw?token=519016850&lang=zh_CN
 description: In the past year, the Filecoin Plus (Fil+) program has evolved to
   help improve transparency and trust in the system by giving participants
   better tools to understand how Fil+ is working.

--- a/packages/ui/src/BlogPostHeader.tsx
+++ b/packages/ui/src/BlogPostHeader.tsx
@@ -10,7 +10,7 @@ type BlogPostHeaderProps = {
   publishedOn: Date
   image: ImageProps
   category: string
-  mandarinTranslationUrl?: string
+  chineseTranslationUrl?: string
 }
 
 export function BlogPostHeader({
@@ -18,7 +18,7 @@ export function BlogPostHeader({
   publishedOn,
   image,
   category,
-  mandarinTranslationUrl,
+  chineseTranslationUrl,
 }: BlogPostHeaderProps) {
   return (
     <ArticleHeader
@@ -31,9 +31,9 @@ export function BlogPostHeader({
       <ArticleHeader.Title>{title}</ArticleHeader.Title>
       <div className="flex flex-col gap-4 sm:flex-row sm:justify-between">
         <span className="blog-post-header-date">{formatDate(publishedOn)}</span>
-        {mandarinTranslationUrl && (
-          <ExternalTextLink href={mandarinTranslationUrl}>
-            中文版本 (Mandarin Version)
+        {chineseTranslationUrl && (
+          <ExternalTextLink href={chineseTranslationUrl}>
+            中文版本 (Chinese Version)
           </ExternalTextLink>
         )}
       </div>


### PR DESCRIPTION
## 📝 Description

[Feedback from Gary: ](https://filecoinfoundation.slack.com/archives/C06MTEQ3SP6/p1744718886579899?thread_ts=1744641502.346669&cid=C06MTEQ3SP6) "_Technically 'Mandarin' refers to the spoken form of the language so 'Chinese Version' would be more appropriate._"

![Screenshot 2025-04-15 at 15 20 37](https://github.com/user-attachments/assets/14bd0182-12d6-459f-a2a0-9a1887b73ecd)
