### PR TITLE
[UXIT-2572][FF][FFDW] Fix Husky install failure in CI by conditionally running prepare script [skip percy]

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "test": "turbo run test",
     "check:versions": "syncpack list-mismatches",
     "fix:versions": "syncpack fix-mismatches",
-    "prepare": "husky"
+    "prepare": "[ \"$CI\" != \"true\" ] && husky"
   },
   "devDependencies": {
     "husky": "^9.1.7",


### PR DESCRIPTION
## 📝 Description

This PR updates the prepare script in the root `package.json` to prevent husky from running in CI environments.

Previously, the prepare script always attempted to run husky, which caused GitHub Actions to fail during `npm install` because husky wasn’t available on the PATH yet. This is especially common in monorepos using workspaces.

The new prepare script:

`"prepare": "[ \"$CI\" != \"true\" ] && husky"`

ensures `husky` is only set up in local development, where Git hooks are needed.

Related to #1360 
