### PR TITLE
[UXIT-2572] Fix: Improve `prepare` script CI compatibility with safer shell syntax [skip percy]

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "test": "turbo run test",
     "check:versions": "syncpack list-mismatches",
     "fix:versions": "syncpack fix-mismatches",
-    "prepare": "[ \"$CI\" != \"true\" ] && husky"
+    "prepare": "test \"$CI\" = \"true\" || husky"
   },
   "devDependencies": {
     "husky": "^9.1.7",


### PR DESCRIPTION
## 📝 Description

Replaced `[ "$CI" != "true" ] && husky` with `test "$CI" = "true" || husky`
for better portability and cleaner syntax across environments. This avoids
issues with shell parsing on Windows and simplifies the logic.

Related to https://github.com/FilecoinFoundationWeb/filecoin-foundation/pull/1360