### PR TITLE
[UXIT] Add UXIT app to CI Workflow [skip percy]

### DIFF
--- a/.github/workflows/repo-ci.yml
+++ b/.github/workflows/repo-ci.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        app: [ff-site, ffdweb-site]
+        app: [ff-site, ffdweb-site, uxit]
 
     env:
       TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}


### PR DESCRIPTION
## 📝 Description

This PR adds the UXIT app to our Turborepo CI workflow, ensuring it's built and tested automatically like our other applications.

## 🛠️ Key Changes

- Added 'uxit' to the app matrix in the GitHub workflow
- Ensures consistency across all our applications in the monorepo
- Allows the UXIT app to benefit from Turborepo caching