### PR TITLE
[UXIT-2584][SHARED] Fix copyright text and extract into reusable UI component

### DIFF
--- a/apps/ff-site/src/app/_components/Footer.tsx
+++ b/apps/ff-site/src/app/_components/Footer.tsx
@@ -1,3 +1,4 @@
+import { CopyrightText } from '@filecoin-foundation/ui/CopyrightText'
 import { Social } from '@filecoin-foundation/ui/Social'
 import { ExternalTextLink } from '@filecoin-foundation/ui/TextLink/ExternalTextLink'
 import { SmartTextLink } from '@filecoin-foundation/ui/TextLink/SmartTextLink'
@@ -19,9 +20,9 @@ export function Footer() {
           <Logo />
         </div>
         <div className="sm:col-span-3">
-          <p className="mb-6 max-w-readable">
+          <p className="max-w-readable mb-6">
             For the latest big ideas and news from the Filecoin ecosystem and
-            decentralized web, subscribe to Filecoin Foundation’s newsletter,
+            decentralized web, subscribe to Filecoin Foundation's newsletter,
             The Upload.
           </p>
           <NewsletterForm />
@@ -55,13 +56,7 @@ export function Footer() {
       </nav>
 
       <hr />
-      <p className="text-center text-sm">
-        &copy; {new Date().getFullYear()} Content on this site is licensed under
-        a{' '}
-        <ExternalTextLink href="https://creativecommons.org/licenses/by/4.0/">
-          Creative Commons Attribution 4.0 International license
-        </ExternalTextLink>
-      </p>
+      <CopyrightText siteName="Filecoin Foundation" />
     </footer>
   )
 }

--- a/apps/ff-site/src/app/_components/Footer.tsx
+++ b/apps/ff-site/src/app/_components/Footer.tsx
@@ -56,7 +56,9 @@ export function Footer() {
       </nav>
 
       <hr />
-      <CopyrightText siteName="Filecoin Foundation" />
+      <div className="text-center text-sm">
+        <CopyrightText siteName="Filecoin Foundation" />
+      </div>
     </footer>
   )
 }

--- a/apps/ffdweb-site/src/app/_components/Footer.tsx
+++ b/apps/ffdweb-site/src/app/_components/Footer.tsx
@@ -1,5 +1,6 @@
 import Link from 'next/link'
 
+import { CopyrightText } from '@filecoin-foundation/ui/CopyrightText'
 import { Heading } from '@filecoin-foundation/ui/Heading'
 import { Social } from '@filecoin-foundation/ui/Social'
 import clsx from 'clsx'
@@ -84,10 +85,9 @@ export function Footer() {
             ))}
           </ul>
 
-          <p className="lg:text-end">
-            &copy; {new Date().getFullYear()} Filecoin Foundation for
-            Decentralized Web{' '}
-          </p>
+          <div className="lg:text-end">
+            <CopyrightText siteName="Filecoin Foundation for the Decentralized Web" />
+          </div>
         </div>
       </div>
     </footer>

--- a/apps/ffdweb-site/src/app/_components/Footer.tsx
+++ b/apps/ffdweb-site/src/app/_components/Footer.tsx
@@ -85,9 +85,7 @@ export function Footer() {
             ))}
           </ul>
 
-          <div className="lg:text-end">
-            <CopyrightText siteName="Filecoin Foundation for the Decentralized Web" />
-          </div>
+          <CopyrightText siteName="Filecoin Foundation for the Decentralized Web" />
         </div>
       </div>
     </footer>

--- a/apps/uxit/src/app/_components/Footer.tsx
+++ b/apps/uxit/src/app/_components/Footer.tsx
@@ -1,15 +1,9 @@
-import { ExternalTextLink } from '@filecoin-foundation/ui/TextLink/ExternalTextLink'
+import { CopyrightText } from '@filecoin-foundation/ui/CopyrightText'
 
 export function Footer() {
   return (
     <footer className="fixed right-0 bottom-0 left-0 border-t border-gray-200 bg-white py-4 text-center text-sm text-slate-500">
-      <p className="text-center text-sm">
-        &copy; {new Date().getFullYear()} Filecoin Foundation. Content on this
-        site is licensed under a{' '}
-        <ExternalTextLink href="https://creativecommons.org/licenses/by/4.0/">
-          Creative Commons Attribution 4.0 International license
-        </ExternalTextLink>
-      </p>
+      <CopyrightText siteName="UXIT · Filecoin Foundation" />
     </footer>
   )
 }

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -18,6 +18,7 @@
     "./BreakpointDebugger": "./src/BreakpointDebugger.tsx",
     "./Card/*": "./src/Card/*.tsx",
     "./CardGrid": "./src/CardGrid.tsx",
+    "./CopyrightText": "./src/CopyrightText.tsx",
     "./CopyToClipboard": "./src/CopyToClipboard.tsx",
     "./DescriptionText": "./src/DescriptionText.tsx",
     "./DigestArticleHeader": "./src/DigestArticleHeader.tsx",

--- a/packages/ui/src/CopyrightText.tsx
+++ b/packages/ui/src/CopyrightText.tsx
@@ -8,7 +8,7 @@ export function CopyrightText({ siteName }: CopyrightTextProps) {
   const currentYear = new Date().getFullYear()
 
   return (
-    <p className="text-center text-sm">
+    <p>
       &copy; {currentYear} {siteName}. Content on this site is licensed under a{' '}
       <ExternalTextLink href="https://creativecommons.org/licenses/by/4.0/">
         Creative Commons Attribution 4.0 International license

--- a/packages/ui/src/CopyrightText.tsx
+++ b/packages/ui/src/CopyrightText.tsx
@@ -1,0 +1,18 @@
+import { ExternalTextLink } from './TextLink/ExternalTextLink'
+
+type CopyrightTextProps = {
+  siteName: string
+}
+
+export function CopyrightText({ siteName }: CopyrightTextProps) {
+  const currentYear = new Date().getFullYear()
+
+  return (
+    <p className="text-center text-sm">
+      &copy; {currentYear} {siteName}. Content on this site is licensed under a{' '}
+      <ExternalTextLink href="https://creativecommons.org/licenses/by/4.0/">
+        Creative Commons Attribution 4.0 International license
+      </ExternalTextLink>
+    </p>
+  )
+}


### PR DESCRIPTION
## 📝 Description

This PR extracts the copyright text from multiple `Footer` components into a reusable `CopyrightText` component in the shared UI package. This change was requested by the legal team to ensure consistent copyright messaging across all Filecoin Foundation applications.


