### PR TITLE
[UXIT-2533] FFDW Lighthouse “Links rely on color to be distinguishable” issue

### DIFF
--- a/apps/ffdweb-site/src/app/_styles/globals.css
+++ b/apps/ffdweb-site/src/app/_styles/globals.css
@@ -338,7 +338,7 @@
 
   /* TEXT LINKS */
   .text-link {
-    @apply text-brand-primary-300! hover:text-brand-primary-500! focus:brand-outline! font-normal! no-underline! hover:underline!;
+    @apply text-brand-primary-300!  hover:text-brand-primary-500! focus:brand-outline! no-underline! hover:underline!;
   }
 
   /* TOOLTIP */


### PR DESCRIPTION
## 📝 Description

Removing `!font-normal` resolves the Lighthouse issue: _low-contrast text is difficult or impossible for many users to read. Link text that is discernible improves the experience for users with low vision._

- **Type:** Bug fix 

## 📸 Screenshots

<img width="1193" alt="Screenshot 2025-04-24 at 07 45 36" src="https://github.com/user-attachments/assets/36be02f0-db97-4908-8727-8b9eca9c1fce" />
