### PR TITLE
Make Linkedin field optional for speakers

### DIFF
--- a/apps/ff-site/public/admin/config.yml
+++ b/apps/ff-site/public/admin/config.yml
@@ -843,6 +843,7 @@ collections:
               - name: "linkedin"
                 label: "LinkedIn Profile URL"
                 widget: "string"
+                required: false
               - name: "image"
                 label: "Image"
                 widget: "object"

--- a/apps/ff-site/public/admin/config.yml
+++ b/apps/ff-site/public/admin/config.yml
@@ -844,6 +844,7 @@ collections:
                 label: "LinkedIn Profile URL"
                 widget: "string"
                 required: false
+                hint: This field is optional in case the speaker does not have a LinkedIn profile. If they do, please enter the URL.
               - name: "image"
                 label: "Image"
                 widget: "object"

--- a/apps/ff-site/src/app/_styles/globals.css
+++ b/apps/ff-site/src/app/_styles/globals.css
@@ -203,7 +203,11 @@
 
   /* KEY MEMBER CARD */
   .key-member-card {
-    @apply border-brand-500 hover:bg-brand-overlay/20 rounded-lg border p-1;
+    @apply border-brand-500 rounded-lg border p-1;
+
+    &[data-with-link='true'] {
+      @apply hover:bg-brand-overlay/20;
+    }
 
     .key-member-card-image {
       @apply rounded-sm;

--- a/apps/ff-site/src/app/events/schemas/SpeakerSchema.ts
+++ b/apps/ff-site/src/app/events/schemas/SpeakerSchema.ts
@@ -6,7 +6,7 @@ const SpeakerSchema = z.object({
   name: z.string(),
   title: z.string(),
   company: z.string(),
-  linkedin: z.string().url(),
+  linkedin: z.string().url().optional(),
   image: ImagePropsSchema,
 })
 

--- a/apps/ffdweb-site/src/app/_styles/globals.css
+++ b/apps/ffdweb-site/src/app/_styles/globals.css
@@ -224,7 +224,11 @@
 
   /* KEY MEMBER CARD */
   .key-member-card {
-    @apply border-brand-primary-700 hover:bg-brand-primary-900 border p-0.5;
+    @apply border-brand-primary-700 border p-0.5;
+
+    &[data-with-link='true'] {
+      @apply hover:bg-brand-primary-900;
+    }
 
     .key-member-card-link {
       @apply text-brand-primary-300;

--- a/apps/ffdweb-site/src/app/_styles/globals.css
+++ b/apps/ffdweb-site/src/app/_styles/globals.css
@@ -342,7 +342,7 @@
 
   /* TEXT LINKS */
   .text-link {
-    @apply text-brand-primary-300!  hover:text-brand-primary-500! focus:brand-outline! no-underline! hover:underline!;
+    @apply text-brand-primary-300! hover:text-brand-primary-500! focus:brand-outline! no-underline! hover:underline!;
   }
 
   /* TOOLTIP */

--- a/packages/ui/src/KeyMemberCard.tsx
+++ b/packages/ui/src/KeyMemberCard.tsx
@@ -13,7 +13,7 @@ type KeyMemberCardProps = {
   name: string
   title: string
   company?: string
-  linkedin: string
+  linkedin?: string
   image: StaticImageProps['data'] | ImageProps['src']
 }
 
@@ -27,7 +27,10 @@ export function KeyMemberCard({
   const fullTitle = [title, company].filter(Boolean).join(', ')
 
   return (
-    <li className="key-member-card relative flex">
+    <li
+      className="key-member-card relative flex"
+      data-with-link={Boolean(linkedin)}
+    >
       <KeyMemberImage image={image} name={name} />
 
       <div className="m-3 grow">
@@ -35,19 +38,21 @@ export function KeyMemberCard({
           {name}
         </Heading>
 
-        <p className="key-member-card-title mb-10 mt-1">{fullTitle}</p>
+        <p className="key-member-card-title mt-1 mb-10">{fullTitle}</p>
 
-        <a
-          aria-label={`Visit ${name}'s LinkedIn profile.`}
-          href={linkedin}
-          rel="noopener noreferrer"
-          className="key-member-card-link focus:brand-outline absolute inset-0"
-        >
-          <span className="absolute bottom-4 left-36 inline-flex items-center gap-2">
-            <Icon component={LinkedinLogo} />
-            LinkedIn
-          </span>
-        </a>
+        {linkedin && (
+          <a
+            aria-label={`Visit ${name}'s LinkedIn profile.`}
+            href={linkedin}
+            rel="noopener noreferrer"
+            className="key-member-card-link focus:brand-outline absolute inset-0"
+          >
+            <span className="absolute bottom-4 left-36 inline-flex items-center gap-2">
+              <Icon component={LinkedinLogo} />
+              LinkedIn
+            </span>
+          </a>
+        )}
       </div>
     </li>
   )


### PR DESCRIPTION
## 📝 Description

This PR makes the LinkedIn field optional in the CMS config, `SpeakerSchema` and `KeyMemberCard`, as some speakers don't have a LinkedIn profile.