### PR TITLE
[FF][UXIT-2450] Update Sort to use nuqs [skip percy]

### DIFF
--- a/apps/ff-site/src/app/_components/Sort.tsx
+++ b/apps/ff-site/src/app/_components/Sort.tsx
@@ -1,44 +1,35 @@
 'use client'
 
-import { useState, useEffect } from 'react'
+import { parseAsString, useQueryState } from 'nuqs'
 
-import { useUpdateSearchParams } from '@filecoin-foundation/hooks/useUpdateSearchParams'
 import type { OptionType } from '@filecoin-foundation/ui/Listbox/ListboxOption'
 import { SORT_KEY } from '@filecoin-foundation/utils/constants/urlParamsConstants'
 
 import { SortListbox } from './SortListbox'
 
 type SortProps = {
-  query: string
   options: ReadonlyArray<OptionType>
-  defaultQuery: string
+  defaultOption?: OptionType
 }
 
-export function Sort({ query, options, defaultQuery }: SortProps) {
-  const [sortId, setSortId] = useState<OptionType['id']>(query)
-  const { updateSearchParams } = useUpdateSearchParams()
+export function Sort({ options, defaultOption = options[0] }: SortProps) {
+  const [optionId, setOptionId] = useQueryState<OptionType['id']>(
+    SORT_KEY,
+    parseAsString.withDefault(defaultOption.id).withOptions({ shallow: false }),
+  )
 
   const selectedOption =
-    options.find((option) => option.id === sortId) || options[0]
-
-  useEffect(() => {
-    const sortIsReset = query === defaultQuery
-
-    if (sortIsReset) {
-      setSortId(defaultQuery)
-    }
-  }, [query, defaultQuery])
-
-  function handleSortChange(newOption: OptionType) {
-    setSortId(newOption.id)
-    updateSearchParams({ [SORT_KEY]: newOption.id })
-  }
+    options.find((option) => option.id === optionId) || defaultOption
 
   return (
     <SortListbox
       options={options}
       selected={selectedOption}
-      onChange={handleSortChange}
+      onChange={setOption}
     />
   )
+
+  function setOption(newOption: OptionType) {
+    setOptionId(newOption.id)
+  }
 }

--- a/apps/ff-site/src/app/blog/components/BlogContent.tsx
+++ b/apps/ff-site/src/app/blog/components/BlogContent.tsx
@@ -55,7 +55,7 @@ export function BlogContent({ posts }: BlogContentProps) {
     searchBy: ['title', 'description'],
   })
 
-  const { query, viewResults, defaultQuery } = useEntryView({
+  const { viewResults } = useEntryView({
     query: normalizeQueryParam(searchParams, SORT_KEY),
     entries: searchResults,
     configs: entryViewConfigs,
@@ -87,30 +87,18 @@ export function BlogContent({ posts }: BlogContentProps) {
       <FilterContainer.MainWrapper>
         <FilterContainer.DesktopFilters
           searchComponent={<Search />}
-          sortComponent={
-            <Sort
-              query={query}
-              options={sortOptions}
-              defaultQuery={defaultQuery}
-            />
-          }
+          sortComponent={<Sort options={sortOptions} />}
         />
 
         <FilterContainer.MobileFiltersAndResults
           searchComponent={<Search />}
+          sortComponent={<Sort options={sortOptions} />}
           filterComponents={[
             <CategoryFilter
               key="category"
               options={categoryOptionsWithCount}
             />,
           ]}
-          sortComponent={
-            <Sort
-              query={query}
-              options={sortOptions}
-              defaultQuery={defaultQuery}
-            />
-          }
         />
         <FilterContainer.ContentWrapper>
           {filteredEntries.length === 0 ? (

--- a/apps/ff-site/src/app/ecosystem-explorer/components/EcosystemExplorerContent.tsx
+++ b/apps/ff-site/src/app/ecosystem-explorer/components/EcosystemExplorerContent.tsx
@@ -56,7 +56,7 @@ export function EcosystemExplorerContent({
     searchBy: ['title', 'description'],
   })
 
-  const { query, viewResults, defaultQuery } = useEntryView({
+  const { viewResults } = useEntryView({
     query: normalizeQueryParam(searchParams, SORT_KEY),
     entries: searchResults,
     configs: ecosystemProjectsViewConfigs,
@@ -87,27 +87,15 @@ export function EcosystemExplorerContent({
       <FilterContainer.MainWrapper>
         <FilterContainer.DesktopFilters
           searchComponent={<Search />}
-          sortComponent={
-            <Sort
-              query={query}
-              options={sortOptions}
-              defaultQuery={defaultQuery}
-            />
-          }
+          sortComponent={<Sort options={sortOptions} />}
         />
 
         <FilterContainer.MobileFiltersAndResults
           searchComponent={<Search />}
+          sortComponent={<Sort options={sortOptions} />}
           filterComponents={[
             <CategoryFiltersSlider key="category" categories={categoryTree} />,
           ]}
-          sortComponent={
-            <Sort
-              query={query}
-              options={sortOptions}
-              defaultQuery={defaultQuery}
-            />
-          }
         />
         <FilterContainer.ContentWrapper>
           {filteredEntries.length === 0 ? (

--- a/packages/hooks/src/useEntryView/useEntryView.ts
+++ b/packages/hooks/src/useEntryView/useEntryView.ts
@@ -29,10 +29,8 @@ export function useEntryView<
   defaultConfig = configs[0],
 }: UseEntryViewProps<Entry, Configs>) {
   const viewId = useMemo(() => {
-    const viewIds = configs.map((config) => config.id)
-    const viewId = viewIds.find((id) => id === query)
-
-    return viewId || defaultConfig.id
+    const config = configs.find((config) => config.id === query)
+    return config?.id || defaultConfig.id
   }, [configs, defaultConfig.id, query])
 
   const viewResults = useMemo(() => {

--- a/packages/hooks/src/useEntryView/useEntryView.ts
+++ b/packages/hooks/src/useEntryView/useEntryView.ts
@@ -9,7 +9,7 @@ import type { normalizeQueryParam } from '@filecoin-foundation/utils/urlUtils'
 
 import type { EntryViewConfig } from './types/entryViewTypes'
 
-type UseSortProps<
+type UseEntryViewProps<
   Entry extends AnyObject,
   Configs extends NonEmptyReadonlyArray<EntryViewConfig<Entry>>,
 > = {
@@ -27,7 +27,7 @@ export function useEntryView<
   entries,
   configs,
   defaultConfig = configs[0],
-}: UseSortProps<Entry, Configs>) {
+}: UseEntryViewProps<Entry, Configs>) {
   const viewId = useMemo(() => {
     const viewIds = configs.map((config) => config.id)
     const viewId = viewIds.find((id) => id === query)
@@ -41,9 +41,5 @@ export function useEntryView<
     return viewConfig.filterOrSortFn(entries)
   }, [configs, entries, viewId])
 
-  return {
-    query: viewId,
-    viewResults,
-    defaultQuery: defaultConfig.id,
-  }
+  return { viewResults }
 }


### PR DESCRIPTION
## 📝 Description

This PR implements `nuqs` on `<Sort />` and updates `useEntryView` accordingly.

## 🧪 How to Test

[fil.org](https://fil.org/blog) | [preview](https://filecoin-foundation-site-1kas4b0k3.vercel.app/blog)

## 🔖 Resources

https://nuqs.47ng.com/docs/installation
