### PR TITLE
Refactor start-date and end-date to be string instead of Date

### DIFF
--- a/apps/ff-site/src/app/_schemas/DateTimeSchema.ts
+++ b/apps/ff-site/src/app/_schemas/DateTimeSchema.ts
@@ -1,9 +1,9 @@
 import { z } from 'zod'
 
+import { getISODateOnly } from '@filecoin-foundation/utils/dateUtils'
+
 // Date only
-export const IsoDateSchema = z.date().transform((date) => {
-  return date.toISOString().split('T')[0]
-})
+export const IsoDateSchema = z.date().transform(getISODateOnly)
 
 // Time only
 export const ISO_TIME_REGEX = /^\d{2}:\d{2}:\d{2}\.000Z$/

--- a/apps/ff-site/src/app/_schemas/DateTimeSchema.ts
+++ b/apps/ff-site/src/app/_schemas/DateTimeSchema.ts
@@ -1,16 +1,11 @@
 import { z } from 'zod'
 
-const ZERO_TIMESTAMP = '00:00:00.000Z'
-
-export const IsoDateSchema = z.date().refine(isZeroTimestamp, {
-  message:
-    'This date must not contain a time portion in the CMS, it should follow ISO 8601 format: YYYY-MM-DD',
+// Date only
+export const IsoDateSchema = z.date().transform((date) => {
+  return date.toISOString().split('T')[0]
 })
 
-function isZeroTimestamp(date: Date) {
-  return date.toISOString().endsWith(ZERO_TIMESTAMP)
-}
-
+// Time only
 export const ISO_TIME_REGEX = /^\d{2}:\d{2}:\d{2}\.000Z$/
 
 export const IsoTimeSchema = z.string().regex(ISO_TIME_REGEX)

--- a/apps/ff-site/src/app/events/[slug]/utils/dateUtils.ts
+++ b/apps/ff-site/src/app/events/[slug]/utils/dateUtils.ts
@@ -3,13 +3,12 @@ import { format } from 'date-fns'
 
 import { formatDate } from '@filecoin-foundation/utils/dateUtils'
 
-
 import { ISO_TIME_REGEX } from '@/schemas/DateTimeSchema'
 
 const PLACEHOLDER_DATE = '1970-01-01'
 
-export function formatShortDate(date: Date) {
-  return formatDate(date, 'EEE, MMM d')
+export function formatShortDate(isoDateString: string) {
+  return formatDate(new UTCDate(isoDateString), 'EEE, MMM d')
 }
 
 export function formatTime(isoTimeString: string) {

--- a/apps/ff-site/src/app/events/[slug]/utils/generateStructuredData.ts
+++ b/apps/ff-site/src/app/events/[slug]/utils/generateStructuredData.ts
@@ -24,8 +24,6 @@ type GetLocationProps = {
   slug: Event['slug']
 }
 
-const ZERO_TIMESTAMP = 'T00:00:00.000Z'
-
 export function generateStructuredData(data: Event): WithContext<EventSchema> {
   const {
     slug,
@@ -55,8 +53,8 @@ export function generateStructuredData(data: Event): WithContext<EventSchema> {
     eventAttendanceMode,
     name: seo.title,
     description: description || seo.description,
-    startDate: startDate + ZERO_TIMESTAMP,
-    endDate: (endDate || startDate) + ZERO_TIMESTAMP,
+    startDate: startDate,
+    endDate: endDate || startDate,
     location: eventLocation,
     image: image?.src,
     url: `${BASE_URL}${PATHS.EVENTS.path}/${slug}`,

--- a/apps/ff-site/src/app/events/[slug]/utils/generateStructuredData.ts
+++ b/apps/ff-site/src/app/events/[slug]/utils/generateStructuredData.ts
@@ -24,6 +24,8 @@ type GetLocationProps = {
   slug: Event['slug']
 }
 
+const ZERO_TIMESTAMP = 'T00:00:00.000Z'
+
 export function generateStructuredData(data: Event): WithContext<EventSchema> {
   const {
     slug,
@@ -53,8 +55,8 @@ export function generateStructuredData(data: Event): WithContext<EventSchema> {
     eventAttendanceMode,
     name: seo.title,
     description: description || seo.description,
-    startDate: startDate.toISOString(),
-    endDate: (endDate || startDate)?.toISOString(),
+    startDate: startDate + ZERO_TIMESTAMP,
+    endDate: (endDate || startDate) + ZERO_TIMESTAMP,
     location: eventLocation,
     image: image?.src,
     url: `${BASE_URL}${PATHS.EVENTS.path}/${slug}`,

--- a/apps/ff-site/src/app/events/utils/isEventConcluded.ts
+++ b/apps/ff-site/src/app/events/utils/isEventConcluded.ts
@@ -1,15 +1,14 @@
 import { isBefore } from 'date-fns'
 
-import { getUTCMidnightToday } from '@filecoin-foundation/utils/dateUtils'
-
+import { getTodayDateISO } from '@filecoin-foundation/utils/dateUtils'
 
 import type { Event } from '../types/eventType'
 
-type StartDate = Event['startDate']
-type EndDate = Event['endDate']
-
-export function isEventConcluded(startDate: StartDate, endDate: EndDate) {
-  const today = getUTCMidnightToday()
+export function isEventConcluded(
+  startDate: Event['startDate'],
+  endDate: Event['endDate'],
+) {
+  const today = getTodayDateISO()
   const eventDate = endDate || startDate
 
   return isBefore(eventDate, today)

--- a/apps/ff-site/src/app/events/utils/isEventConcluded.ts
+++ b/apps/ff-site/src/app/events/utils/isEventConcluded.ts
@@ -1,6 +1,6 @@
 import { isBefore } from 'date-fns'
 
-import { getTodayDateISO } from '@filecoin-foundation/utils/dateUtils'
+import { getTodayISODateOnly } from '@filecoin-foundation/utils/dateUtils'
 
 import type { Event } from '../types/eventType'
 
@@ -8,7 +8,7 @@ export function isEventConcluded(
   startDate: Event['startDate'],
   endDate: Event['endDate'],
 ) {
-  const today = getTodayDateISO()
+  const today = getTodayISODateOnly()
   const eventDate = endDate || startDate
 
   return isBefore(eventDate, today)

--- a/apps/ff-site/src/app/events/utils/sortEvents.ts
+++ b/apps/ff-site/src/app/events/utils/sortEvents.ts
@@ -1,6 +1,6 @@
 import { compareAsc, compareDesc, isAfter, isBefore } from 'date-fns'
 
-import { getTodayDateISO } from '@filecoin-foundation/utils/dateUtils'
+import { getTodayISODateOnly } from '@filecoin-foundation/utils/dateUtils'
 import type { NonEmptyMutableArray } from '@filecoin-foundation/utils/types/utilTypes'
 
 import type { Event } from '../types/eventType'
@@ -31,7 +31,7 @@ export function sortNonEmptyEventsAsc<
 }
 
 export function getUpcomingEvents<T extends DateFields>(events: Array<T>) {
-  const today = getTodayDateISO()
+  const today = getTodayISODateOnly()
 
   return sortEventsAsc(
     events.filter(({ startDate, endDate }) =>
@@ -41,7 +41,7 @@ export function getUpcomingEvents<T extends DateFields>(events: Array<T>) {
 }
 
 export function getPastEvents<T extends DateFields>(events: Array<T>) {
-  const today = getTodayDateISO()
+  const today = getTodayISODateOnly()
 
   return sortEventsDesc(
     events.filter(({ startDate, endDate }) =>

--- a/apps/ff-site/src/app/events/utils/sortEvents.ts
+++ b/apps/ff-site/src/app/events/utils/sortEvents.ts
@@ -1,11 +1,6 @@
-import {
-  compareAsc,
-  compareDesc,
-  isAfter,
-  isBefore,
-  startOfToday,
-} from 'date-fns'
+import { compareAsc, compareDesc, isAfter, isBefore } from 'date-fns'
 
+import { getTodayDateISO } from '@filecoin-foundation/utils/dateUtils'
 import type { NonEmptyMutableArray } from '@filecoin-foundation/utils/types/utilTypes'
 
 import type { Event } from '../types/eventType'
@@ -36,28 +31,21 @@ export function sortNonEmptyEventsAsc<
 }
 
 export function getUpcomingEvents<T extends DateFields>(events: Array<T>) {
-  const today = startOfToday()
+  const today = getTodayDateISO()
 
   return sortEventsAsc(
     events.filter(({ startDate, endDate }) =>
-      isAfter(getEventDate(startDate, endDate), today),
+      isAfter(endDate || startDate, today),
     ),
   )
 }
 
 export function getPastEvents<T extends DateFields>(events: Array<T>) {
-  const today = startOfToday()
+  const today = getTodayDateISO()
 
   return sortEventsDesc(
     events.filter(({ startDate, endDate }) =>
-      isBefore(getEventDate(startDate, endDate), today),
+      isBefore(endDate || startDate, today),
     ),
   )
-}
-
-function getEventDate(
-  startDate: DateFields['startDate'],
-  endDate: DateFields['endDate'],
-) {
-  return endDate || startDate
 }

--- a/packages/utils/src/dateUtils.ts
+++ b/packages/utils/src/dateUtils.ts
@@ -25,7 +25,11 @@ export function getUTCMidnightToday() {
   )
 }
 
-export function getTodayDateISO() {
+export function getTodayISODateOnly() {
   const now = new Date()
-  return now.toISOString().split('T')[0]
+  return getISODateOnly(now)
+}
+
+export function getISODateOnly(date: Date) {
+  return date.toISOString().split('T')[0]
 }

--- a/packages/utils/src/dateUtils.ts
+++ b/packages/utils/src/dateUtils.ts
@@ -1,6 +1,6 @@
 import { format } from 'date-fns'
 
-export function formatDate(date: Date, formatString = 'MMM d, yyyy') {
+export function formatDate(date: Date | string, formatString = 'MMM d, yyyy') {
   return format(date, formatString)
 }
 
@@ -23,4 +23,9 @@ export function getUTCMidnightToday() {
   return new Date(
     Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate()),
   )
+}
+
+export function getTodayDateISO() {
+  const now = new Date()
+  return now.toISOString().split('T')[0]
 }


### PR DESCRIPTION
## 📝 Description

This PR updates how we type event dates once they enter the codebase via `Zod`.

We now treat them as ISO strings `YYYY-MM-DD`, instead of `Date` objects, to avoid unintentional timezone conventions.

## 🧪 How to Test

1. Open the preview in Chrome - https://filecoin-foundation-site-hj7qyjbkc.vercel.app/events/fil-toronto-consensus-2025
2. Change timezone to San Francisco in Chrome devtools - https://www.browserstack.com/guide/change-time-zone-in-chrome-for-testing
3. Verify that the dates in `Speaking engagements` are the same as the Lisbon timezone

Slack conversation - https://filecoinfoundation.slack.com/archives/C06MTEQ3SP6/p1746639361785659

## 📸 Screenshots

![CleanShot 2025-05-08 at 14 50 20](https://github.com/user-attachments/assets/e96b1fc3-b720-4b27-8d5b-fa23da51ef32)