### PR TITLE
Fix typo in "product"

### DIFF
--- a/apps/ff-site/src/app/ecosystem-explorer/page.tsx
+++ b/apps/ff-site/src/app/ecosystem-explorer/page.tsx
@@ -57,7 +57,7 @@ export default async function EcosystemExplorer(props: Props) {
       <PageSection
         kicker="Projects"
         title="Ecosystem Projects"
-        description="Discover the diverse landscape of projects in the Filecoin ecosystem. Inclusion in the Filecoin Ecosystem Explorer is not an endorsement of any project, any company, or any company’s product or services."
+        description="Discover the diverse landscape of projects in the Filecoin ecosystem. Inclusion in the Filecoin Ecosystem Explorer is not an endorsement of any project, any company, or any company’s products or services."
       >
         <EcosystemExplorerContent
           searchParams={searchParams}


### PR DESCRIPTION
Under the Ecosystem Projects header, this sentence should say "products" (plural) not singular "product".