### PR TITLE
[FF][FFDW][UXIT-2697] Clean up Metadata schemas, config, and data [skip percy]

### DIFF
--- a/apps/ff-site/public/admin/config.yml
+++ b/apps/ff-site/public/admin/config.yml
@@ -107,38 +107,6 @@ event_sponsor_config: &event_sponsor_config
 
 seo_metadata_description_max_characters: &seo_metadata_description_max_characters 220
 
-twitter_config: &twitter_config
-  name: "twitter"
-  label: "Twitter Metadata"
-  widget: "object"
-  required: false
-  collapsed: true
-  hint: "Expand for more information on default values."
-  fields:
-    - name: "card"
-      label: "Twitter Card"
-      widget: "select"
-      options:
-        - label: "Summary Card"
-          value: "summary"
-        - label: "Summary with Large Image"
-          value: "summary_large_image"
-        - label: "Player Card"
-          value: "player"
-      required: false
-      default: "summary"
-      hint: "If left empty, the default value will be 'Summary Card.'"
-    - name: "site"
-      label: "Twitter Handle for Website"
-      widget: "string"
-      required: false
-      hint: "Enter the Twitter handle of the website or brand (e.g., @FilFoundation). Defaults to @FilFoundation."
-    - name: "creator"
-      label: "Twitter Creator"
-      widget: "string"
-      required: false
-      hint: "Enter the Twitter handle of the content creator (e.g., @juanbenet). Defaults to @FilFoundation."
-
 meta_config_with_title_fallback: &meta_config_with_title_fallback
   name: "seo"
   label: "SEO Metadata"
@@ -156,7 +124,6 @@ meta_config_with_title_fallback: &meta_config_with_title_fallback
         - "^.{0,220}$"
         - "Must have at most 220 characters."
       hint: "To generate meta title and description, copy and paste the entry content into ChatGPT 4.0, then use the prompt: 'Generate a meta title and a meta description under 220 characters for the following content: [paste your content here].'"
-    - *twitter_config
 
 meta_config: &meta_config
   name: "seo"
@@ -173,7 +140,6 @@ meta_config: &meta_config
         - "^.{0,220}$"
         - "Must have at most 220 characters."
       hint: "To generate meta title and description, copy and paste the entry content into ChatGPT 4.0, then use the prompt: 'Generate a meta title and a meta description under 220 characters for the following content: [paste your content here].'"
-    - *twitter_config
 
 collections:
   - name: "pages"

--- a/apps/ff-site/src/app/blog/[slug]/page.tsx
+++ b/apps/ff-site/src/app/blog/[slug]/page.tsx
@@ -84,5 +84,6 @@ export async function generateMetadata(props: BlogPostProps) {
     description: data.seo.description,
     image: data.image?.src || graphicsData.blog.data.src,
     path: `${PATHS.BLOG.path}/${data.slug}`,
+    openGraph: { type: 'article' },
   })
 }

--- a/apps/ff-site/src/app/digest/[slug]/page.tsx
+++ b/apps/ff-site/src/app/digest/[slug]/page.tsx
@@ -70,5 +70,6 @@ export async function generateMetadata(props: DigestArticleProps) {
     description: data.seo.description,
     image: data.image?.src || graphicsData.digest.data.src,
     path: `${PATHS.DIGEST.path}/${data.slug}`,
+    openGraph: { type: 'article' },
   })
 }

--- a/apps/ff-site/src/app/ecosystem-explorer/[slug]/page.tsx
+++ b/apps/ff-site/src/app/ecosystem-explorer/[slug]/page.tsx
@@ -110,5 +110,6 @@ export async function generateMetadata(props: EcosystemProjectProps) {
     description: data.seo.description,
     image: graphicsData.ecosystem.data.src,
     path: `${PATHS.ECOSYSTEM_EXPLORER.path}/${data.slug}`,
+    openGraph: { type: 'article' },
   })
 }

--- a/apps/ff-site/src/app/ecosystem-explorer/project-form/page.tsx
+++ b/apps/ff-site/src/app/ecosystem-explorer/project-form/page.tsx
@@ -5,9 +5,10 @@ import type { AsyncQueryParams } from '@filecoin-foundation/utils/types/urlTypes
 
 import { PATHS } from '@/constants/paths'
 
+import { attributes } from '@/content/pages/ecosystem-explorer/project-form.md'
+
 import { graphicsData } from '@/data/graphicsData'
 
-import { attributes } from '@/content/pages/ecosystem-explorer/project-form.md'
 
 import { createMetadata } from '@/utils/createMetadata'
 

--- a/apps/ff-site/src/app/ecosystem-explorer/project-form/page.tsx
+++ b/apps/ff-site/src/app/ecosystem-explorer/project-form/page.tsx
@@ -5,6 +5,8 @@ import type { AsyncQueryParams } from '@filecoin-foundation/utils/types/urlTypes
 
 import { PATHS } from '@/constants/paths'
 
+import { graphicsData } from '@/data/graphicsData'
+
 import { attributes } from '@/content/pages/ecosystem-explorer/project-form.md'
 
 import { createMetadata } from '@/utils/createMetadata'
@@ -64,6 +66,6 @@ export default async function EcosystemExplorerProjectForm(props: Props) {
 export const metadata = createMetadata({
   title: seo.title,
   description: seo.description,
-  image: seo.image,
+  image: graphicsData.ecosystem.data.src,
   path: PATHS.ECOSYSTEM_EXPLORER_PROJECT_FORM.path,
 })

--- a/apps/ff-site/src/app/employee-privacy-policy/page.tsx
+++ b/apps/ff-site/src/app/employee-privacy-policy/page.tsx
@@ -28,6 +28,5 @@ export default function EmployeePrivacyPolicy() {
 export const metadata = createMetadata({
   title: attributes.seo.title,
   description: attributes.seo.description,
-  image: attributes.seo.image,
   path: PATHS.EMPLOYEE_PRIVACY_POLICY.path,
 })

--- a/apps/ff-site/src/app/events/[slug]/page.tsx
+++ b/apps/ff-site/src/app/events/[slug]/page.tsx
@@ -149,5 +149,6 @@ export async function generateMetadata(props: EventProps) {
     description: data.seo.description,
     image: graphicsData.events1.data.src,
     path: `${PATHS.EVENTS.path}/${data.slug}`,
+    openGraph: { type: 'article' },
   })
 }

--- a/apps/ff-site/src/app/privacy-policy/page.tsx
+++ b/apps/ff-site/src/app/privacy-policy/page.tsx
@@ -26,6 +26,5 @@ export default function PrivacyPolicy() {
 export const metadata = createMetadata({
   title: attributes.seo.title,
   description: attributes.seo.description,
-  image: attributes.seo.image,
   path: PATHS.PRIVACY_POLICY.path,
 })

--- a/apps/ff-site/src/app/security/coordinated-disclosure-policy/page.tsx
+++ b/apps/ff-site/src/app/security/coordinated-disclosure-policy/page.tsx
@@ -4,6 +4,8 @@ import coordinatedDisclosurePolicyMarkdown from '@/content/pages/security/coordi
 
 import { createMetadata } from '@/utils/createMetadata'
 
+import { graphicsData } from '@/data/graphicsData'
+
 import { MarkdownPageSchema } from '@/schemas/PageFrontmatterSchema'
 
 import { MarkdownPage } from '@/components/MarkdownPage'
@@ -28,6 +30,6 @@ export default function CoordinatedDisclosurePolicy() {
 export const metadata = createMetadata({
   title: { absolute: attributes.seo.title },
   description: attributes.seo.description,
-  image: attributes.seo.image,
+  image: graphicsData.security4.data.src,
   path: PATHS.COORDINATED_DISCLOSURE_POLICY.path,
 })

--- a/apps/ff-site/src/app/security/coordinated-disclosure-policy/page.tsx
+++ b/apps/ff-site/src/app/security/coordinated-disclosure-policy/page.tsx
@@ -2,9 +2,10 @@ import { PATHS } from '@/constants/paths'
 
 import coordinatedDisclosurePolicyMarkdown from '@/content/pages/security/coordinated-disclosure-policy.md'
 
+import { graphicsData } from '@/data/graphicsData'
+
 import { createMetadata } from '@/utils/createMetadata'
 
-import { graphicsData } from '@/data/graphicsData'
 
 import { MarkdownPageSchema } from '@/schemas/PageFrontmatterSchema'
 

--- a/apps/ff-site/src/app/terms-of-use/page.tsx
+++ b/apps/ff-site/src/app/terms-of-use/page.tsx
@@ -26,6 +26,5 @@ export default function TermsOfUse() {
 export const metadata = createMetadata({
   title: attributes.seo.title,
   description: attributes.seo.description,
-  image: attributes.seo.image,
   path: PATHS.TERMS_OF_USE.path,
 })

--- a/apps/ff-site/src/content/blog/ai-agents-and-why-storage-is-the-key-to-smarter-more-reliable-agents.md
+++ b/apps/ff-site/src/content/blog/ai-agents-and-why-storage-is-the-key-to-smarter-more-reliable-agents.md
@@ -11,8 +11,6 @@ description: "Filecoin provides the underlying storage layer to power
 image:
   src: /assets/images/filecoinai.webp
 seo:
-  twitter:
-    card: summary
   description: "Filecoin provides the underlying storage layer to power
     verifiable, tamper-proof, and permissionless AI models, ensuring that
     AI-generated outputs can be trusted."

--- a/apps/ff-site/src/content/blog/an-inside-look-at-a-filecoin-data-center.md
+++ b/apps/ff-site/src/content/blog/an-inside-look-at-a-filecoin-data-center.md
@@ -10,8 +10,6 @@ description: >
 image:
   src: /assets/images/102224-dcent-documentary.webp
 seo:
-  twitter:
-    card: summary
   description: Take a tour of DCENT, Europe’s largest Filecoin storage provider,
     in the first-ever DWeb Decoded Special Report.
 ---

--- a/apps/ff-site/src/content/blog/announcing-the-filecoin-nv24-tuk-tuk-upgrade-enhancing-filecoin-s-efficiency.md
+++ b/apps/ff-site/src/content/blog/announcing-the-filecoin-nv24-tuk-tuk-upgrade-enhancing-filecoin-s-efficiency.md
@@ -8,8 +8,6 @@ description: The Filecoin network has completed its NV24 upgrade, marking anothe
 image:
   src: /assets/images/blog-post-header-nv24-upgrade.webp
 seo:
-  twitter:
-    card: summary
   description: The Filecoin network has completed its NV24 upgrade, marking another significant step in enhancing the network's security, efficiency, and developer capabilities.
 ---
 

--- a/apps/ff-site/src/content/blog/announcing-the-filecoin-orbit-university-challenge.md
+++ b/apps/ff-site/src/content/blog/announcing-the-filecoin-orbit-university-challenge.md
@@ -9,8 +9,6 @@ description: University blockchain organizations are invited to design and
 image:
   src: /assets/images/orbit-university-challenge.webp
 seo:
-  twitter:
-    card: summary
   description: University blockchain organizations are invited to design and
     propose decentralized AI applications leveraging the Filecoin network.
 ---

--- a/apps/ff-site/src/content/blog/apac-ama-recap-november-2024.md
+++ b/apps/ff-site/src/content/blog/apac-ama-recap-november-2024.md
@@ -10,8 +10,6 @@ description: The latest APAC Ask Me Anything (AMA), held on November 21, brought
 image:
   src: /assets/images/apac-ama-header.webp
 seo:
-  twitter:
-    card: summary
   description:
     The latest APAC Ask Me Anything (AMA), held on November 21, brought
     together more than 70 participants, including many Storage Providers (SPs),

--- a/apps/ff-site/src/content/blog/blockfrost-and-filecoin-foundation-collaborate-to-enhance-the-decentralization-of-cardano-data.md
+++ b/apps/ff-site/src/content/blog/blockfrost-and-filecoin-foundation-collaborate-to-enhance-the-decentralization-of-cardano-data.md
@@ -12,8 +12,6 @@ description: Blockfrost and Filecoin Foundation (FF) are collaborating to
 image:
   src: /assets/images/112524-cardanoblockfrost.webp
 seo:
-  twitter:
-    card: summary
   description: Blockfrost and Filecoin Foundation (FF) are collaborating to
     integrate Filecoin’s decentralized storage capabilities as a robust backup
     layer for Cardano apps built with Blockfrost.

--- a/apps/ff-site/src/content/blog/building-together-the-power-of-collaboration-in-the-filecoin-ecosystem.md
+++ b/apps/ff-site/src/content/blog/building-together-the-power-of-collaboration-in-the-filecoin-ecosystem.md
@@ -11,8 +11,6 @@ description: Since Mainnet launch in October 2020, the Filecoin network has
 image:
   src: /assets/images/022025-cid-lighthouse.webp
 seo:
-  twitter:
-    card: summary
   description: "Since Mainnet launch in October 2020, the Filecoin network has
     steadily evolved, with new tools and services emerging to support a growing
     range of data use cases."

--- a/apps/ff-site/src/content/blog/decentralize-your-data-store-it-with-filecoin.md
+++ b/apps/ff-site/src/content/blog/decentralize-your-data-store-it-with-filecoin.md
@@ -11,8 +11,6 @@ description: >
 image:
   src: /assets/images/032625-defiant-header.webp
 seo:
-  twitter:
-    card: summary
   description: The future of storage isn’t just about where data lives –– it’s
     also about who controls it. Filecoin puts that power back in your hands ––
     redefining data ownership in the digital age.

--- a/apps/ff-site/src/content/blog/developer-grants-updates-february-2025.md
+++ b/apps/ff-site/src/content/blog/developer-grants-updates-february-2025.md
@@ -9,8 +9,6 @@ description: The Developer Grants Updates series brings news and highlights from
 image:
   src: /assets/images/feb25-dg-updates.webp
 seo:
-  twitter:
-    card: summary
   description: "Explore Filecoin Foundation's latest Developer Grants Updates,
     featuring new highlights and builder opportunities."
 ---

--- a/apps/ff-site/src/content/blog/fast-secure-and-scalable-how-f3-is-reshaping-the-future-of-onchain-storage.md
+++ b/apps/ff-site/src/content/blog/fast-secure-and-scalable-how-f3-is-reshaping-the-future-of-onchain-storage.md
@@ -10,8 +10,6 @@ description: The upcoming Fast Finality in Filecoin (F3) represents one of the
 image:
   src: /assets/images/030625-f3.webp
 seo:
-  twitter:
-    card: summary
   description: The upcoming Fast Finality in Filecoin (F3) represents one of the
     biggest storage-retrieval lifecycle improvements in the network’s history,
     making the future of Filecoin fast, secure, and accessible.

--- a/apps/ff-site/src/content/blog/filecoin-as-the-infrastructure-for-decentralized-ai.md
+++ b/apps/ff-site/src/content/blog/filecoin-as-the-infrastructure-for-decentralized-ai.md
@@ -10,8 +10,6 @@ description: Filecoin Network Named in the AI and Data category for Fast
 image:
   src: /assets/images/blog-post-header-fast-company-we-made-the-list.webp
 seo:
-  twitter:
-    card: summary
   title: Filecoin as the Infrastructure for Decentralized AI
   description: Filecoin Network Named in the AI and Data category for Fast
     Company’s 2024 Next Big Things in Tech Awards.

--- a/apps/ff-site/src/content/blog/filecoin-ecosystem-teams-unveil-l2s.md
+++ b/apps/ff-site/src/content/blog/filecoin-ecosystem-teams-unveil-l2s.md
@@ -10,8 +10,6 @@ description: Akave and Storacha Share Announcements at FIL Bangkok Signaling New
 image:
   src: /assets/images/blog-post-header-filecoin-ecosystem-teams-unveil-l2s.webp
 seo:
-  twitter:
-    card: summary
   description: "Teams across the Filecoin ecosystem announced new L2s, extending
     the capabilities of the network."
 ---

--- a/apps/ff-site/src/content/blog/filecoin-foundation-2024-annual-report.md
+++ b/apps/ff-site/src/content/blog/filecoin-foundation-2024-annual-report.md
@@ -12,8 +12,6 @@ add-table-of-contents: true
 image:
   src: /assets/images/2024-annual-report-hero.webp
 seo:
-  twitter:
-    card: summary
   description:
     In this report, you’ll read about the ways that Filecoin Foundation
     supported the Filecoin community in 2024 and learn about FF’s strategic

--- a/apps/ff-site/src/content/blog/filecoin-foundation-quarterly-update-april-2025.md
+++ b/apps/ff-site/src/content/blog/filecoin-foundation-quarterly-update-april-2025.md
@@ -6,12 +6,10 @@ published-on: 2025-04-17T20:27:00.000Z
 category: reports
 description: In this quarterly update, we will spotlight how the Filecoin
   network is forming the backbone for not only a better version of the web, but
-  a better foundation for emerging technologies like AI. 
+  a better foundation for emerging technologies like AI.
 image:
   src: /assets/images/quarterlyupdate_q22025_header.webp
 seo:
-  twitter:
-    card: summary
   description: In this quarterly update, we will spotlight how the Filecoin
     network is forming the backbone for not only a better version of the web,
     but a better foundation for emerging technologies like AI.
@@ -25,9 +23,9 @@ The challenges of centralization extend to AI agents –– autonomous systems r
 
 The Filecoin network is uniquely positioned to address these challenges by enabling decentralization and transparency. Key advantages include: 
 
-* Creating an auditable and tamper-proof way for AI projects to verify their models, datasets, and computations;
-* Offering a compelling alternative to these centralized models through decentralized, transparent data storage; and
-* Fostering trust while reinforcing the resilience of our digital infrastructure. 
+- Creating an auditable and tamper-proof way for AI projects to verify their models, datasets, and computations;
+- Offering a compelling alternative to these centralized models through decentralized, transparent data storage; and
+- Fostering trust while reinforcing the resilience of our digital infrastructure. 
 
 In this quarterly update, we will spotlight how the Filecoin network is forming the backbone for not only a better version of the web, but a better foundation for emerging technologies like AI. 
 
@@ -71,9 +69,9 @@ Filecoin builders are shaping the future of AI and other emerging technologies a
 
 FF’s Developer Grants Updates bring news and highlights from the FF Developer Grants team. [The second issue](/blog/developer-grants-updates-february-2025), published in February, explores how FF continues to support new, impactful projects and introduce program updates to empower more developers in the Filecoin ecosystem. A few proposals that we recently funded include:
 
-* [Eastore](https://github.com/filecoin-project/devgrants/issues/1770): An onchain way of storing small files on Filecoin, as an alternative to traditional centralized file storage protocols. 
-* [UCAN development support](https://github.com/filecoin-project/devgrants/issues/1776): A project supporting the development of multiple User Controlled Authorization Network (UCAN) functionalities, including v1 JS UCAN implementation, debugger, and other developer tooling and resources for ecosystem projects using UCANs. 
-* [IPNI Reverse Index](https://github.com/filecoin-project/devgrants/issues/1781): This project will help assess the quality of Filecoin retrieval services and drive improvements. 
+- [Eastore](https://github.com/filecoin-project/devgrants/issues/1770): An onchain way of storing small files on Filecoin, as an alternative to traditional centralized file storage protocols. 
+- [UCAN development support](https://github.com/filecoin-project/devgrants/issues/1776): A project supporting the development of multiple User Controlled Authorization Network (UCAN) functionalities, including v1 JS UCAN implementation, debugger, and other developer tooling and resources for ecosystem projects using UCANs. 
+- [IPNI Reverse Index](https://github.com/filecoin-project/devgrants/issues/1781): This project will help assess the quality of Filecoin retrieval services and drive improvements. 
 
 For a more comprehensive look at developer projects we have funded in the past, check out Filecoin Foundation’s [2024 Annual Report](/blog/filecoin-foundation-2024-annual-report). 
 
@@ -91,7 +89,7 @@ FF continues to award grants valued at up to $50,000 for projects that align wit
 
 FF's Storage and Community team continues to help share business strategies on how to drive demand, create additional revenue streams for storage providers (SP), and solidify Filecoin's market positioning as part of its ongoing mission to help the network achieve product-market fit (PMF). Alongside [FilOz](https://www.filoz.org/) and other key ecosystem builders, founders, and business development leaders, FF is supporting discussions outlining Filecoin’s value proposition and how it can align with market needs. 
 
-#### Activating the Global Storage Community 
+#### Activating the Global Storage Community
 
 On January 27, 2025, Filecoin Foundation and MetaEra hosted FF’s second AMA, focusing on “APAC Builder Opportunities” and drawing over 24,000 listeners on X Spaces. During the session, FF shared important updates on gas changes, providing valuable context for ongoing network developments. Representatives from Secured Finance, FIL-B, Titan Network, Zetablock, and Storswift joined the call to offer insightful perspectives on key opportunities in the data marketplace, AI agents, stablecoins, and cross-chain collaboration. This AMA reinforced FF’s commitment to empowering APAC builders and fostering innovation across the ecosystem.
 

--- a/apps/ff-site/src/content/blog/filecoin-foundation-quarterly-update-october-2024.md
+++ b/apps/ff-site/src/content/blog/filecoin-foundation-quarterly-update-october-2024.md
@@ -9,8 +9,6 @@ description: "This month, Filecoin Foundation (FF) is launching quarterly
 image:
   src: /assets/images/ff_q4report_hero-1-.webp
 seo:
-  twitter:
-    card: summary
   description: "This month, Filecoin Foundation (FF) is launching quarterly
     updates designed to hone in on different trends across our ecosystem. "
 ---

--- a/apps/ff-site/src/content/blog/filecoin-foundation-s-vision-and-strategic-priorities-for-2025.md
+++ b/apps/ff-site/src/content/blog/filecoin-foundation-s-vision-and-strategic-priorities-for-2025.md
@@ -12,8 +12,6 @@ description: As Filecoin Foundation (FF) looks ahead to 2025, we want to offer a
 image:
   src: /assets/images/102924-2025vision.webp
 seo:
-  twitter:
-    card: summary
   description:
     As Filecoin Foundation (FF looks ahead to 2025, we want to offer a
     closer look at FF’s vision and strategic priorities.

--- a/apps/ff-site/src/content/blog/filecoin-mainnet-marks-four-years.md
+++ b/apps/ff-site/src/content/blog/filecoin-mainnet-marks-four-years.md
@@ -12,8 +12,6 @@ description: This month on October 15, we’re thrilled to celebrate the
 image:
   src: /assets/images/ma-blogheader-fixed.webp
 seo:
-  twitter:
-    card: summary
   description:
     Today, we say a huge thank you to the incredible Filecoin community
     of builders, storage providers, data clients, and all those who are helping

--- a/apps/ff-site/src/content/blog/filecoin-plus-fds-recap-and-2025-priorities.md
+++ b/apps/ff-site/src/content/blog/filecoin-plus-fds-recap-and-2025-priorities.md
@@ -9,8 +9,6 @@ description: Dive deeper into the discussions around Fil+ at FIL Dev Summit and
 image:
   src: /assets/images/02122025-fil-plus-blog-1-.webp
 seo:
-  twitter:
-    card: summary
   description:
     Dive deeper into the discussions around Fil+ at FIL Dev Summit and
     get an overview and 2025 roadmap for the program.

--- a/apps/ff-site/src/content/blog/flickr-foundation-internet-archive-and-other-leading-organizations-leverage-filecoin-to-safeguard-cultural-heritage.md
+++ b/apps/ff-site/src/content/blog/flickr-foundation-internet-archive-and-other-leading-organizations-leverage-filecoin-to-safeguard-cultural-heritage.md
@@ -10,8 +10,6 @@ description: Over 500,000 Culturally Significant Digital Artifacts Now Stored on
 image:
   src: /assets/images/012125-culturalheritage.webp
 seo:
-  twitter:
-    card: summary
   description: Filecoin Foundation announced the addition of over 500,000
     culturally significant digital artifacts now stored on the Filecoin Network.
 ---

--- a/apps/ff-site/src/content/blog/fresh-from-ff-april-2025.md
+++ b/apps/ff-site/src/content/blog/fresh-from-ff-april-2025.md
@@ -8,8 +8,6 @@ description: Check out the latest updates about what Filecoin Foundation has bee
 image:
   src: /assets/images/freshfromffapril2025.webp
 seo:
-  twitter:
-    card: summary
   description: Check out the latest updates about what Filecoin Foundation has been up to in April, 2025.
 ---
 

--- a/apps/ff-site/src/content/blog/fresh-from-ff-december-2024.md
+++ b/apps/ff-site/src/content/blog/fresh-from-ff-december-2024.md
@@ -8,8 +8,6 @@ description: "Check out the latest updates about what Filecoin Foundation has be
 image:
   src: /assets/images/fresh-from-ff-december-2024.webp
 seo:
-  twitter:
-    card: summary
   description: "Check out the latest updates about what Filecoin Foundation has
     been up to."
 ---

--- a/apps/ff-site/src/content/blog/fresh-from-ff-february-2025.md
+++ b/apps/ff-site/src/content/blog/fresh-from-ff-february-2025.md
@@ -8,8 +8,6 @@ description: Check out the latest updates about what Filecoin Foundation has bee
 image:
   src: /assets/images/0215-ff-22-.webp
 seo:
-  twitter:
-    card: summary
   description: Check out the latest updates about what Filecoin Foundation has
     been up to in February, 2025.
 ---

--- a/apps/ff-site/src/content/blog/fresh-from-ff-march-2025.md
+++ b/apps/ff-site/src/content/blog/fresh-from-ff-march-2025.md
@@ -8,8 +8,6 @@ description: Check out the latest updates about what Filecoin Foundation has bee
 image:
   src: /assets/images/0215-ff-23-.webp
 seo:
-  twitter:
-    card: summary
   description: Check out the latest updates about what Filecoin Foundation has been up to.
 ---
 

--- a/apps/ff-site/src/content/blog/fresh-from-ff-may-2025.md
+++ b/apps/ff-site/src/content/blog/fresh-from-ff-may-2025.md
@@ -8,8 +8,6 @@ description: "Check out the latest updates about what Filecoin Foundation has be
 image:
   src: /assets/images/0215-ff-24-.webp
 seo:
-  twitter:
-    card: summary
   title: "Fresh From FF: May, 2025"
   description: "Check out the latest updates about what Filecoin Foundation has
     been up to. "

--- a/apps/ff-site/src/content/blog/fresh-from-ff-november-2024.md
+++ b/apps/ff-site/src/content/blog/fresh-from-ff-november-2024.md
@@ -8,8 +8,6 @@ description: "Check out the latest updates about what Filecoin Foundation has be
 image:
   src: /assets/images/0215-ff-20-.webp
 seo:
-  twitter:
-    card: summary
   title: "Fresh From FF: November, 2024"
   description: "Check out the latest updates about what Filecoin Foundation has been up to."
 ---

--- a/apps/ff-site/src/content/blog/how-fidl-is-enhancing-transparency-and-accountability-in-fil.md
+++ b/apps/ff-site/src/content/blog/how-fidl-is-enhancing-transparency-and-accountability-in-fil.md
@@ -11,8 +11,6 @@ description: In the past year, the Filecoin Plus (Fil+) program has evolved to
 image:
   src: /assets/images/030425-fidl.webp
 seo:
-  twitter:
-    card: summary
   description: In the past year, the Filecoin Plus (Fil+) program has evolved to
     help improve transparency and trust in the system by giving participants
     better tools to understand how Fil+ is working.

--- a/apps/ff-site/src/content/blog/making-space-for-experimentation-the-experimental-pathway-metaallocator.md
+++ b/apps/ff-site/src/content/blog/making-space-for-experimentation-the-experimental-pathway-metaallocator.md
@@ -12,8 +12,6 @@ description: Over the past year, the Fil+ governance team, in close
 image:
   src: /assets/images/fil-header-1-.webp
 seo:
-  twitter:
-    card: summary
   description: "The Filecoin Plus (Fil+) program is adding a long-awaited
     Experimental Pathway Metaallocator."
 ---
@@ -34,11 +32,11 @@ From the governance perspective, the value of this pathway is twofold: it opens 
 
 Key parameters include:
 
-* Lower Datacap ceilings: Allocators in this pathway receive up to 1 PiB, minimizing risk while allowing space for real experimentation.
+- Lower Datacap ceilings: Allocators in this pathway receive up to 1 PiB, minimizing risk while allowing space for real experimentation.
 
-* Faster review cycles: Tighter feedback loops support active iteration and learning.
+- Faster review cycles: Tighter feedback loops support active iteration and learning.
 
-* Transparency through reporting: Participants are expected to publish metrics and insights throughout their process.
+- Transparency through reporting: Participants are expected to publish metrics and insights throughout their process.
 
 ## The Role of FIDL in the Experimental Pathway Metaallocator
 
@@ -46,11 +44,11 @@ Filecoin Incentive Design Labs (FIDL) is supporting this pathway by stewarding i
 
 Specifically, FIDL is:
 
-* Supporting prospective allocators through the application and onboarding process.
+- Supporting prospective allocators through the application and onboarding process.
 
-* Providing dashboards and metrics to track outcomes.
+- Providing dashboards and metrics to track outcomes.
 
-* Sharing learnings with the Fil+ governance community to support evidence-based decisions.
+- Sharing learnings with the Fil+ governance community to support evidence-based decisions.
 
 The Experimental Pathway offers a lightweight mechanism to validate ideas before they graduate into one of the main Fil+ allocation routes—Manual, Market-based, or Automated.
 
@@ -64,5 +62,5 @@ If you’re building new allocation logic, testing novel incentives, or prototyp
 
 To apply, use the form on [FIDL’s website](https://www.fidl.tech/apply-for-datacap_1). You can also follow the development and governance discussions here:
 
-* [Experimental Pathway Metaallocator proposal](https://github.com/filecoin-project/Allocator-Governance/issues/313)
-* [Manual Pathway Metaallocator](https://github.com/filecoin-project/Allocator-Governance/issues/282)
+- [Experimental Pathway Metaallocator proposal](https://github.com/filecoin-project/Allocator-Governance/issues/313)
+- [Manual Pathway Metaallocator](https://github.com/filecoin-project/Allocator-Governance/issues/282)

--- a/apps/ff-site/src/content/blog/security-team-update-march-2025.md
+++ b/apps/ff-site/src/content/blog/security-team-update-march-2025.md
@@ -11,8 +11,6 @@ description: "Security is the backbone of any successful technology ecosystem â€
 image:
   src: /assets/images/security.webp
 seo:
-  twitter:
-    card: summary
   description: "The Filecoin Foundation Security Team is dedicated to protecting
     the Filecoin network and its community of developers, storage providers, and
     users."

--- a/apps/ff-site/src/content/blog/spotlight-seal-storage.md
+++ b/apps/ff-site/src/content/blog/spotlight-seal-storage.md
@@ -10,8 +10,6 @@ description: Discover how Seal Storage, a Filecoin ecosystem pioneer, partners
 image:
   src: /assets/images/102224-seal.webp
 seo:
-  twitter:
-    card: summary
   description: Discover how Seal Storage, a Filecoin ecosystem pioneer, partners
     with CERN, IEEE, and others to provide scalable, decentralized cloud storage
     for research institutions worldwide.

--- a/apps/ff-site/src/content/blog/the-2024-filecoin-ecosystem-rewind.md
+++ b/apps/ff-site/src/content/blog/the-2024-filecoin-ecosystem-rewind.md
@@ -9,8 +9,6 @@ description: As 2024 comes to a close, it's time to look back and celebrate a
 image:
   src: /assets/images/2024rewind.webp
 seo:
-  twitter:
-    card: summary
   description: As 2024 comes to a close, it's time to look back and celebrate a
     year of progress, milestones, and innovation across the Filecoin ecosystem.
 ---

--- a/apps/ff-site/src/content/blog/the-web-isn-t-forever-new-research-findings-from-not-your-parents-web-project.md
+++ b/apps/ff-site/src/content/blog/the-web-isn-t-forever-new-research-findings-from-not-your-parents-web-project.md
@@ -11,8 +11,6 @@ description: Findings from the "Not Your Parents Web" project –– an extensiv
 image:
   src: /assets/images/101024-nypw-1-.webp
 seo:
-  twitter:
-    card: summary
   description: The "Not Your Parents' Web" project reveals the fragile lifespan
     of online content.
 ---

--- a/apps/ff-site/src/content/events/consensus-toronto.md
+++ b/apps/ff-site/src/content/events/consensus-toronto.md
@@ -22,8 +22,6 @@ start-date: 2025-05-14
 end-date: 2025-05-16
 external-link: https://consensus2025.coindesk.com/
 seo:
-  twitter:
-    card: summary
   description: Discover Consensus 2025 in Toronto – the premier gathering for
     blockchain, Web3, and AI leaders. Join industry pioneers shaping the future
     of digital assets and innovation. Don’t miss out!

--- a/apps/ff-site/src/content/events/davos.md
+++ b/apps/ff-site/src/content/events/davos.md
@@ -308,8 +308,6 @@ sponsors:
 recap:
   youtube-playlist-url: https://www.youtube.com/playlist?list=PLp3zrT1ewY0mjCUeq_pEFH_H4J-376pRr
 seo:
-  twitter:
-    card: summary
   description: Join the Filecoin community in Davos during the World Economic
     Forum (Jan 20-23, 2025). Explore speaking engagements and events shaping the
     future of the decentralized web.

--- a/apps/ff-site/src/content/events/digital-real-estate-summit.md
+++ b/apps/ff-site/src/content/events/digital-real-estate-summit.md
@@ -10,8 +10,6 @@ location:
 start-date: 2025-02-11
 external-link: https://lu.ma/n4c8aotx?tk=GRGiWo
 seo:
-  twitter:
-    card: summary
   description: The Frost Museum summit, hosted by Magma, Propy, Akila, Filecoin, and SustainaCities, explores how digital assets drive sustainable urban futures, from design to operations.
   title: "Digital Real Estate Summit - Filecoin Foundation Sponsorship"
 ---

--- a/apps/ff-site/src/content/events/fds-6-virtual-kickoff-sessions.md
+++ b/apps/ff-site/src/content/events/fds-6-virtual-kickoff-sessions.md
@@ -86,8 +86,6 @@ program:
         structure.
       location: Virtual
 seo:
-  twitter:
-    card: summary
   description:
     Kick off FDS-6 with our engaging virtual sessions! Connect, learn,
     and get ready for an exciting journey ahead. Don't miss out on the action!

--- a/apps/ff-site/src/content/events/fil-dev-summit.md
+++ b/apps/ff-site/src/content/events/fil-dev-summit.md
@@ -22,8 +22,6 @@ external-link: https://www.fildev.io/FDS-6
 image:
   src: /assets/images/fil-dev-summit.png
 seo:
-  twitter:
-    card: summary
   title: FIL Dev Summit 6 - Toronto, Canada | May 12-13, 2025
   description:
     Join us for FIL Dev Summit 6 in Toronto, Canada, on May 12-13! This

--- a/apps/ff-site/src/content/events/fil-toronto-consensus-2025.md
+++ b/apps/ff-site/src/content/events/fil-toronto-consensus-2025.md
@@ -305,8 +305,6 @@ sponsors:
       name: Impossible Cloud Network
       website: https://www.icn.global/
 seo:
-  twitter:
-    card: summary
   title: FIL Toronto @ Consensus 2025
   description:
     The Filecoin community is heading to Consensus in Toronto! Connect

--- a/apps/ff-site/src/content/events/filecoin-consensus-hong-kong.md
+++ b/apps/ff-site/src/content/events/filecoin-consensus-hong-kong.md
@@ -87,8 +87,6 @@ speakers:
       image:
         src: /assets/images/qing-warthen.jpg
 seo:
-  twitter:
-    card: summary
   description: Explore Filecoin's impactful presence at Consensus Hong Kong,
     featuring key announcements, innovations, and industry collaborations
     shaping the future of decentralized storage.

--- a/apps/ff-site/src/content/events/filecoin-ethdenver-2025.md
+++ b/apps/ff-site/src/content/events/filecoin-ethdenver-2025.md
@@ -212,8 +212,6 @@ speakers:
       image:
         src: /assets/images/robert-dowling.webp
 seo:
-  twitter:
-    card: summary
   description:
     Join Filecoin at ETHDenver 2025 to explore cutting-edge blockchain
     technology, network with industry leaders, and discover new opportunities in

--- a/apps/ff-site/src/content/events/filecoin-orbit-kampala-fvm-hack-day.md
+++ b/apps/ff-site/src/content/events/filecoin-orbit-kampala-fvm-hack-day.md
@@ -15,8 +15,6 @@ external-link: https://lu.ma/zc25ir6p
 image:
   src: /assets/images/orbit-placeholder.webp
 seo:
-  twitter:
-    card: summary
   description: "Join Filecoin Orbit Kampala: FVM Hack Day at The Innovation
     Village! Collaborate with developers, explore Filecoin's FVM, and build
     impactful blockchain projects. Don't miss this chance to innovate and

--- a/apps/ff-site/src/content/events/filecoin-orbit-playground-16-ai-and-data-storage-for-workforce.md
+++ b/apps/ff-site/src/content/events/filecoin-orbit-playground-16-ai-and-data-storage-for-workforce.md
@@ -18,8 +18,6 @@ external-link: https://www.eventpop.me/e/63652/filecoinplayground16
 image:
   src: /assets/images/orbit-placeholder.webp
 seo:
-  twitter:
-    card: summary
   description: "Join Filecoin Playground #16 at SCBX Next Tech, Siam Paragon,
     Bangkok, on Dec 23! Explore AI, decentralized storage, and workforce
     innovation. Limited seats—register now to network and learn!"

--- a/apps/ff-site/src/content/events/filecoin-token2049-dubai.md
+++ b/apps/ff-site/src/content/events/filecoin-token2049-dubai.md
@@ -67,8 +67,6 @@ speakers:
       image:
         src: /assets/images/paul-wagner.webp
 seo:
-  twitter:
-    card: summary
   description: Join our team in Dubai during Token2049 for expert insights,
     networking opportunities, and exclusive speaking engagements. Connect with
     industry leaders and stay ahead in the world of crypto and blockchain!

--- a/apps/ff-site/src/content/events/vision-weekend.md
+++ b/apps/ff-site/src/content/events/vision-weekend.md
@@ -13,8 +13,6 @@ external-link: https://foresight.org/vw2024us/
 image:
   src: /assets/images/vision-sf-2022.png
 seo:
-  twitter:
-    card: summary
   description:
     Join Foresight Institute’s Vision Weekends—two immersive festivals
     focused on long-term futures. Explore tech breakthroughs, mentorship, demos,

--- a/apps/ffdweb-site/public/admin/config.yml
+++ b/apps/ffdweb-site/public/admin/config.yml
@@ -88,38 +88,6 @@ image_config: &image_config
 
 seo_metadata_description_max_characters: &seo_metadata_description_max_characters 220
 
-twitter_config: &twitter_config
-  name: "twitter"
-  label: "Twitter Metadata"
-  widget: "object"
-  required: false
-  collapsed: true
-  hint: "Expand for more information on default values."
-  fields:
-    - name: "card"
-      label: "Twitter Card"
-      widget: "select"
-      options:
-        - label: "Summary Card"
-          value: "summary"
-        - label: "Summary with Large Image"
-          value: "summary_large_image"
-        - label: "Player Card"
-          value: "player"
-      required: false
-      default: "summary"
-      hint: "If left empty, the default value will be 'Summary Card.'"
-    - name: "site"
-      label: "Twitter Handle for Website"
-      widget: "string"
-      required: false
-      hint: "Enter the Twitter handle of the website or brand (e.g., @FilFoundation). Defaults to @FilFoundation."
-    - name: "creator"
-      label: "Twitter Creator"
-      widget: "string"
-      required: false
-      hint: "Enter the Twitter handle of the content creator (e.g., @juanbenet). Defaults to @FilFoundation."
-
 meta_config_with_title_fallback: &meta_config_with_title_fallback
   name: "seo"
   label: "SEO Metadata"
@@ -137,7 +105,6 @@ meta_config_with_title_fallback: &meta_config_with_title_fallback
         - "^.{0,220}$"
         - "Must have at most 220 characters."
       hint: "To generate meta title and description, copy and paste the entry content into ChatGPT 4.0, then use the prompt: 'Generate a meta title and a meta description under 220 characters for the following content: [paste your content here].'"
-    - *twitter_config
 
 collections:
   - name: "blog_posts"

--- a/apps/ffdweb-site/src/app/blog/[slug]/page.tsx
+++ b/apps/ffdweb-site/src/app/blog/[slug]/page.tsx
@@ -70,7 +70,7 @@ export async function generateMetadata(props: BlogPostProps) {
     path: `${PATHS.BLOG.path}/${slug}`,
     title: { absolute: `${seo.title} | ${ORGANIZATION_NAME_SHORT}` },
     description: seo.description,
-    image: seo.image || image?.src || graphicsData.blog.data.src,
+    image: image?.src || graphicsData.blog.data.src,
     openGraph: { type: 'article' },
     twitter: seo.twitter,
   })

--- a/apps/ffdweb-site/src/app/blog/[slug]/page.tsx
+++ b/apps/ffdweb-site/src/app/blog/[slug]/page.tsx
@@ -72,6 +72,5 @@ export async function generateMetadata(props: BlogPostProps) {
     description: seo.description,
     image: image?.src || graphicsData.blog.data.src,
     openGraph: { type: 'article' },
-    twitter: seo.twitter,
   })
 }

--- a/apps/ffdweb-site/src/app/digest/[slug]/page.tsx
+++ b/apps/ffdweb-site/src/app/digest/[slug]/page.tsx
@@ -84,6 +84,5 @@ export async function generateMetadata(props: DigestArticleProps) {
     description: seo.description,
     image: image?.src || graphicsData.digest.data.src,
     openGraph: { type: 'article' },
-    twitter: seo.twitter,
   })
 }

--- a/apps/ffdweb-site/src/app/digest/[slug]/page.tsx
+++ b/apps/ffdweb-site/src/app/digest/[slug]/page.tsx
@@ -82,7 +82,7 @@ export async function generateMetadata(props: DigestArticleProps) {
     path: `${PATHS.DIGEST.path}/${slug}`,
     title: { absolute: `${seo.title} | ${ORGANIZATION_NAME_SHORT}` },
     description: seo.description,
-    image: seo.image || image?.src || graphicsData.digest.data.src,
+    image: image?.src || graphicsData.digest.data.src,
     openGraph: { type: 'article' },
     twitter: seo.twitter,
   })

--- a/apps/ffdweb-site/src/app/projects/[slug]/page.tsx
+++ b/apps/ffdweb-site/src/app/projects/[slug]/page.tsx
@@ -108,7 +108,7 @@ export async function generateMetadata(props: ProjectProps) {
     path: `${PATHS.PROJECTS.path}/${slug}`,
     title: { absolute: `${seo.title} | ${ORGANIZATION_NAME_SHORT}` },
     description: seo.description,
-    image: seo.image || image?.src || graphicsData.projects.data.src,
+    image: image?.src || graphicsData.projects.data.src,
     openGraph: { type: 'article' },
     twitter: seo.twitter,
   })

--- a/apps/ffdweb-site/src/app/projects/[slug]/page.tsx
+++ b/apps/ffdweb-site/src/app/projects/[slug]/page.tsx
@@ -110,6 +110,5 @@ export async function generateMetadata(props: ProjectProps) {
     description: seo.description,
     image: image?.src || graphicsData.projects.data.src,
     openGraph: { type: 'article' },
-    twitter: seo.twitter,
   })
 }

--- a/packages/utils/src/schemas/SeoMetadataSchema.ts
+++ b/packages/utils/src/schemas/SeoMetadataSchema.ts
@@ -13,7 +13,6 @@ const TwitterMetadataSchema = z
 const BaseSeoMetadataSchema = z
   .object({
     description: z.string().max(220),
-    image: z.string().optional(),
     twitter: TwitterMetadataSchema.optional(),
   })
   .strict()

--- a/packages/utils/src/schemas/SeoMetadataSchema.ts
+++ b/packages/utils/src/schemas/SeoMetadataSchema.ts
@@ -1,19 +1,8 @@
 import { z } from 'zod'
 
-const TwitterCardType = z.enum(['summary', 'summary_large_image', 'player'])
-
-const TwitterMetadataSchema = z
-  .object({
-    card: TwitterCardType.optional(),
-    site: z.string().optional(),
-    creator: z.string().optional(),
-  })
-  .strict()
-
 const BaseSeoMetadataSchema = z
   .object({
     description: z.string().max(220),
-    twitter: TwitterMetadataSchema.optional(),
   })
   .strict()
 


### PR DESCRIPTION
## 📝 Description

This PR removes metadata configuration fields that are no longer used by the content team, simplifying the SEO configuration across the codebase.

## 🛠️ Key Changes

- Removed optional image field from SEO metadata
- Updated handling of SEO meta images to match current usage
- Removed `TwitterMetadataSchema` and related schema configuration
- Removed unused Twitter-specific metadata from the codebase
