### PR TITLE
[FFDW][UXIT-2723] Projects · Make website field optional

### DIFF
--- a/apps/ffdweb-site/src/app/projects/[slug]/page.tsx
+++ b/apps/ffdweb-site/src/app/projects/[slug]/page.tsx
@@ -65,6 +65,7 @@ export default async function Project(props: ProjectProps) {
               {title}
             </Heading>
           </div>
+
           <div className="relative mb-6 aspect-video bg-neutral-50">
             <Image
               fill
@@ -75,15 +76,20 @@ export default async function Project(props: ProjectProps) {
               sizes={buildImageSizeProp({ startSize: '100vw', md: '640px' })}
             />
           </div>
-          <div className="inline-flex flex-col gap-8 sm:flex-row sm:gap-12">
-            <CTALink href={website}>Visit Project Website</CTALink>
 
-            {featuredContent && (
-              <CTALink href={featuredContent} icon={Newspaper}>
-                Read Blog Post
-              </CTALink>
-            )}
-          </div>
+          {(website || featuredContent) && (
+            <div className="inline-flex flex-col gap-8 sm:flex-row sm:gap-12">
+              {website && (
+                <CTALink href={website}>Visit Project Website</CTALink>
+              )}
+
+              {featuredContent && (
+                <CTALink href={featuredContent} icon={Newspaper}>
+                  Read Blog Post
+                </CTALink>
+              )}
+            </div>
+          )}
         </div>
 
         <div className="prose">

--- a/apps/ffdweb-site/src/app/projects/schemas/ProjectFrontmatterSchema.ts
+++ b/apps/ffdweb-site/src/app/projects/schemas/ProjectFrontmatterSchema.ts
@@ -16,7 +16,7 @@ export const ProjectFrontmatterSchema = DynamicBaseDataSchema.extend({
   title: z.string(),
   category: CategorySchema,
   description: z.string(),
-  website: z.string(),
+  website: z.string().optional(),
   'featured-content': z.string().optional(),
   'active-partnership': z.boolean().optional().default(false),
 }).strict()


### PR DESCRIPTION
## 📝 Description

This PR updates the ProjectFrontmatterSchema to make the website field optional. This allows projects without a dedicated external site to be properly handled and displayed.

## 🔑 Key Changes

- Changed website from a required `z.string()` to `z.string().optional()` in the schema.
- Updated the component rendering logic to conditionally display the CTA section only if either website or featuredContent is provided. This prevents rendering an empty block when neither is available.