### PR TITLE
Upgrade Decap to 3.6.3 [skip percy]

### DIFF
--- a/apps/ff-site/public/admin/index.html
+++ b/apps/ff-site/public/admin/index.html
@@ -6,7 +6,7 @@
     <title>FF-Site Content Manager</title>
   </head>
   <body>
-    <script src="https://unpkg.com/decap-cms@3.5.0/dist/decap-cms.js"></script>
+    <script src="https://unpkg.com/decap-cms@3.6.3/dist/decap-cms.js"></script>
     <script src="./cmsComponents.js"></script>
     <script src="./cmsEncryptionWidget.js"></script>
   </body>

--- a/apps/ffdweb-site/public/admin/index.html
+++ b/apps/ffdweb-site/public/admin/index.html
@@ -6,7 +6,7 @@
     <title>FFDW Content Manager</title>
   </head>
   <body>
-    <script src="https://unpkg.com/decap-cms@3.5.0/dist/decap-cms.js"></script>
+    <script src="https://unpkg.com/decap-cms@3.6.3/dist/decap-cms.js"></script>
     <script src="./cmsComponents.js"></script>
   </body>
 </html>


### PR DESCRIPTION
## 📝 Description

This PR upgrade Decap to the latest version - [3.6.3](https://github.com/decaporg/decap-cms/releases/tag/decap-cms%403.6.3)

It looks like the nested validation issue is fixed, but It does NOT fix the leading/trailing space issue...

