### PR TITLE
[SHARED] Add pre-push hook for version consistency checks [skip percy]

### DIFF
--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -1,0 +1,1 @@
+npm run check:versions


### PR DESCRIPTION
## 📝 Description

We’ve added a new Git pre-push hook that runs `npm run check:versions` before any code is pushed to the remote repository. This hook helps catch package version mismatches early in the development workflow, ensuring they’re addressed before code reaches the remote.

The main goal is to maintain version consistency across the monorepo. By surfacing mismatches during PR creation or updates, we reduce the likelihood of version-related issues slipping into production. This improves overall stability and saves time debugging preventable problems.
