### PR TITLE
Add solid frame around mobile table of contents button

### DIFF
--- a/apps/ff-site/src/app/security/maturity-model/components/DesktopTableOfContentsWrapper.tsx
+++ b/apps/ff-site/src/app/security/maturity-model/components/DesktopTableOfContentsWrapper.tsx
@@ -1,0 +1,13 @@
+type DesktopTableOfContentsWrapperProps = {
+  children: React.ReactNode
+}
+
+export function DesktopTableOfContentsWrapper({
+  children,
+}: DesktopTableOfContentsWrapperProps) {
+  return (
+    <div className="hidden lg:sticky lg:top-12 lg:order-last lg:block lg:w-72">
+      {children}
+    </div>
+  )
+}

--- a/apps/ff-site/src/app/security/maturity-model/components/MobileTableOfContentsWrapper.tsx
+++ b/apps/ff-site/src/app/security/maturity-model/components/MobileTableOfContentsWrapper.tsx
@@ -1,0 +1,26 @@
+import clsx from 'clsx'
+
+type MobileTableOfContentsWrapperProps = {
+  children: React.ReactNode
+}
+
+const topPadding = {
+  value: 'pt-6',
+  offset: '-mt-6',
+}
+
+export function MobileTableOfContentsWrapper({
+  children,
+}: MobileTableOfContentsWrapperProps) {
+  return (
+    <div
+      className={clsx(
+        'bg-brand-800 sticky top-0 z-10 order-first block pb-1 lg:hidden',
+        topPadding.value,
+        topPadding.offset,
+      )}
+    >
+      {children}
+    </div>
+  )
+}

--- a/apps/ff-site/src/app/security/maturity-model/page.tsx
+++ b/apps/ff-site/src/app/security/maturity-model/page.tsx
@@ -19,7 +19,9 @@ import { PageSection } from '@/components/PageSection'
 
 import { CoreFunctions } from './components/CoreFunctions'
 import { DesktopTableOfContents } from './components/DesktopTableOfContents'
+import { DesktopTableOfContentsWrapper } from './components/DesktopTableOfContentsWrapper'
 import { MobileTableOfContents } from './components/MobileTableOfContents'
+import { MobileTableOfContentsWrapper } from './components/MobileTableOfContentsWrapper'
 import { applicationAndUseData } from './data/applicationAndUseData'
 import { generateStructuredData } from './utils/generateStructuredData'
 
@@ -64,12 +66,12 @@ export default function MaturityModel() {
           <div className="grow">
             <CoreFunctions />
           </div>
-          <div className="hidden lg:sticky lg:top-12 lg:order-last lg:block lg:w-72">
+          <DesktopTableOfContentsWrapper>
             <DesktopTableOfContents />
-          </div>
-          <div className="bg-brand-800 sticky top-0 z-10 order-first -mt-6 block pt-6 pb-1 lg:hidden">
+          </DesktopTableOfContentsWrapper>
+          <MobileTableOfContentsWrapper>
             <MobileTableOfContents />
-          </div>
+          </MobileTableOfContentsWrapper>
         </div>
       </PageSection>
     </PageLayout>


### PR DESCRIPTION
## 📝 Description

This PR adds a solid frame around the mobile table of contents button on the security/maturity model page. 

Before/After video: https://share.cleanshot.com/3JYWrzKX