### PR TITLE
Update Airtable config with new FIL-B Orbit database IDs

### DIFF
--- a/apps/ff-site/src/app/orbit/constants/airtableOrbitEventsConfig.ts
+++ b/apps/ff-site/src/app/orbit/constants/airtableOrbitEventsConfig.ts
@@ -1,12 +1,16 @@
+// Link to table IDs
+// https://airtable.com/apprCQqrHfze7O5S7/api/docs#javascript/table:event%20request
+
 export const AIRTABLE_ORBIT_EVENTS_CONFIG = {
-  BASE_ID: 'appAGdqyYrqoFNuPI',
+  BASE_ID: 'apprCQqrHfze7O5S7',
   EVENTS_TABLE_ID: 'tblnrsxREgBikWu9A',
   FIELDS: {
+    TITLE: 'fldhD7ClKauhqeD79',
     CITY: 'fldQJZQAS4Jm0eiiL',
     START_DATE: 'flddTSgPuKgL6h1JG',
     STATUS: 'fldnRqMzqmu7VLUlD',
-    TITLE: 'fldhD7ClKauhqeD79',
     REGISTRATION_LINK: 'fldlcV4631rFgbdd6',
   },
-  APPROVED_STATUS_VALUE: 'Approved',
 } as const
+
+export const APPROVED_STATUS_VALUE = 'Approved'

--- a/apps/ff-site/src/app/orbit/services/airtable.ts
+++ b/apps/ff-site/src/app/orbit/services/airtable.ts
@@ -3,12 +3,14 @@ import { z } from 'zod'
 
 import { getUTCMidnightToday } from '@filecoin-foundation/utils/dateUtils'
 
-import { AIRTABLE_ORBIT_EVENTS_CONFIG } from '../constants/airtableOrbitEventsConfig'
+import {
+  AIRTABLE_ORBIT_EVENTS_CONFIG,
+  APPROVED_STATUS_VALUE,
+} from '../constants/airtableOrbitEventsConfig'
 
 const airtable = new Airtable({ apiKey: process.env.AIRTABLE_READ_ONLY_TOKEN })
 
-const { BASE_ID, EVENTS_TABLE_ID, FIELDS, APPROVED_STATUS_VALUE } =
-  AIRTABLE_ORBIT_EVENTS_CONFIG
+const { BASE_ID, EVENTS_TABLE_ID, FIELDS } = AIRTABLE_ORBIT_EVENTS_CONFIG
 const { TITLE, CITY, START_DATE, REGISTRATION_LINK } = FIELDS
 
 const airtableRecordSchema = z.object({


### PR DESCRIPTION
## 📝 Description

This PR updates our Airtable configuration for the Orbit page with the new [FIL-B database](https://airtable.com/apprCQqrHfze7O5S7/tblnrsxREgBikWu9A/viwCXMcuCkLrEtzNy?blocks=hide) IDs.

There are currently no events to display; the last one was in May.

> [!IMPORTANT]
> I created a new API token and updated the value of `AIRTABLE_READ_ONLY_TOKEN` on Vercel. You can grab the new value from the [dashboard](https://vercel.com/filecoin-foundations-projects/filecoin-foundation-site/settings/environment-variables) or run `vercel env pull` if you use the CLI.

## 🔖 Resources

Link to the Table IDs: https://airtable.com/apprCQqrHfze7O5S7/api/docs#javascript/table:event%20request
