### PR TITLE
[UXIT-2917] Make Event Sponsor Website Optional

### DIFF
--- a/apps/ff-site/public/admin/config.yml
+++ b/apps/ff-site/public/admin/config.yml
@@ -93,6 +93,7 @@ event_sponsor_config: &event_sponsor_config
   - name: "website"
     label: "Website"
     widget: "string"
+    required: false
   - name: "image"
     label: "Image"
     widget: "object"

--- a/apps/ff-site/src/app/events/schemas/SponsorSchema.ts
+++ b/apps/ff-site/src/app/events/schemas/SponsorSchema.ts
@@ -4,7 +4,7 @@ import { ImagePropsSchema } from '@filecoin-foundation/utils/schemas/ImagePropsS
 
 const sponsorSchema = z.object({
   name: z.string(),
-  website: z.string().url(),
+  website: z.string().url().optional(),
   image: ImagePropsSchema,
 })
 


### PR DESCRIPTION
## 📝 Description

This PR makes the `website` property in the `sponsorSchema` optional, allowing sponsors without a website to be included.