### PR TITLE
[FILECOIN][UXIT-2923] Add site layout and font

### DIFF
--- a/apps/filecoin-site/package.json
+++ b/apps/filecoin-site/package.json
@@ -18,6 +18,7 @@
     "@filecoin-foundation/eslint-config": "0.0.0",
     "@filecoin-foundation/typescript-config": "0.0.0",
     "@filecoin-foundation/utils": "0.0.0",
+    "@filecoin-foundation/ui": "0.0.0",
     "@tailwindcss/postcss": "^4.1.11",
     "@types/node": "^24.0.3",
     "@types/react": "19.1.8",

--- a/apps/filecoin-site/src/app/(homepage)/page.tsx
+++ b/apps/filecoin-site/src/app/(homepage)/page.tsx
@@ -1,10 +1,14 @@
+import { PageLayout } from '@filecoin-foundation/ui/PageLayout'
+
 export default function Home() {
   return (
-    <main className="p-24">
-      <h1 className="text-brand-500 text-4xl font-bold">Filecoin.io V3</h1>
-      <p className="mt-4 text-lg text-zinc-600">
-        This is the new Filecoin.io website, built with Next.js and Tailwind.
-      </p>
-    </main>
+    <PageLayout>
+      <section>
+        <h1 className="text-brand-500 text-4xl font-bold">Filecoin.io V3</h1>
+        <p className="mt-4 text-lg text-zinc-600">
+          This is the new Filecoin.io website, built with Next.js and Tailwind.
+        </p>
+      </section>
+    </PageLayout>
   )
 }

--- a/apps/filecoin-site/src/app/_components/SiteLayout.tsx
+++ b/apps/filecoin-site/src/app/_components/SiteLayout.tsx
@@ -1,0 +1,24 @@
+import { Inter } from 'next/font/google'
+
+import { SiteLayout as SharedSiteLayout } from '@filecoin-foundation/ui/SiteLayout'
+
+const inter = Inter({
+  subsets: ['latin'],
+  display: 'swap',
+})
+
+type SiteLayoutProps = {
+  children: React.ReactNode
+}
+
+export function SiteLayout({ children }: SiteLayoutProps) {
+  return (
+    <SharedSiteLayout
+      font={inter}
+      Navigation={() => <header className="bg-zinc-50 p-8">Header</header>}
+      Footer={() => <footer className="bg-zinc-50 p-8">Footer</footer>}
+    >
+      {children}
+    </SharedSiteLayout>
+  )
+}

--- a/apps/filecoin-site/src/app/_styles/globals.css
+++ b/apps/filecoin-site/src/app/_styles/globals.css
@@ -1,4 +1,5 @@
 @import 'tailwindcss';
+@source "../../../../../node_modules/@filecoin-foundation/ui";
 
 @theme {
   --color-brand-50: oklch(0.98 0.0157 216.67);

--- a/apps/filecoin-site/src/app/layout.tsx
+++ b/apps/filecoin-site/src/app/layout.tsx
@@ -1,3 +1,5 @@
+import { SiteLayout } from '@/components/SiteLayout'
+
 import '@/styles/globals.css'
 
 export const metadata = {
@@ -10,9 +12,5 @@ type RootLayoutProps = {
 }
 
 export default function RootLayout({ children }: RootLayoutProps) {
-  return (
-    <html lang="en">
-      <body>{children}</body>
-    </html>
-  )
+  return <SiteLayout>{children}</SiteLayout>
 }

--- a/apps/filecoin-site/tsconfig.json
+++ b/apps/filecoin-site/tsconfig.json
@@ -8,7 +8,8 @@
       "@/*": ["./src/app/*"],
       "@/styles/*": ["./src/app/_styles/*"],
       "@/constants/*": ["./src/app/_constants/*"],
-      "@/utils/*": ["./src/app/_utils/*"]
+      "@/utils/*": ["./src/app/_utils/*"],
+      "@/components/*": ["./src/app/_components/*"]
     },
     "plugins": [{ "name": "next" }]
   },

--- a/package-lock.json
+++ b/package-lock.json
@@ -148,6 +148,7 @@
       "devDependencies": {
         "@filecoin-foundation/eslint-config": "0.0.0",
         "@filecoin-foundation/typescript-config": "0.0.0",
+        "@filecoin-foundation/ui": "0.0.0",
         "@filecoin-foundation/utils": "0.0.0",
         "@tailwindcss/postcss": "^4.1.11",
         "@types/node": "^24.0.3",


### PR DESCRIPTION
## 📝 Description

This PR implements the `SiteLayout` component and imports the [custom fonts](https://github.com/filecoin-project/filecoin.io/blob/tina/staging/src/sass/globals/fonts.scss) from the existing filecoin.io project: `suisse_intl` and `suisse_mono`