### PR TITLE
[SHARED][UXIT-2751] Update Phosphor Icons to use new Icon suffix [skip percy]

### DIFF
--- a/apps/ff-site/src/app/(homepage)/components/FeaturedEcosystemProjects.tsx
+++ b/apps/ff-site/src/app/(homepage)/components/FeaturedEcosystemProjects.tsx
@@ -1,4 +1,4 @@
-import { MagnifyingGlass } from '@phosphor-icons/react/dist/ssr'
+import { MagnifyingGlassIcon } from '@phosphor-icons/react/dist/ssr'
 
 import { CardGrid } from '@filecoin-foundation/ui/CardGrid'
 import { buildImageSizeProp } from '@filecoin-foundation/utils/buildImageSizeProp'
@@ -30,7 +30,7 @@ export function FeaturedEcosystemProjects({
             href: `${PATHS.ECOSYSTEM_EXPLORER.path}/${slug}`,
             text: 'Learn More',
             icon: {
-              component: MagnifyingGlass,
+              component: MagnifyingGlassIcon,
             },
           }}
           image={{

--- a/apps/ff-site/src/app/_components/Form/FormCheckbox.tsx
+++ b/apps/ff-site/src/app/_components/Form/FormCheckbox.tsx
@@ -1,5 +1,5 @@
 import { Checkbox, type CheckboxProps, Field, Label } from '@headlessui/react'
-import { Check } from '@phosphor-icons/react/dist/ssr'
+import { CheckIcon } from '@phosphor-icons/react/dist/ssr'
 import { clsx } from 'clsx'
 
 import { Icon } from '@filecoin-foundation/ui/Icon'
@@ -40,7 +40,7 @@ export function FormCheckbox({
           )}
         >
           <span className="hidden group-data-checked:block">
-            <Icon component={Check} size={16} weight="bold" />
+            <Icon component={CheckIcon} size={16} weight="bold" />
           </span>
         </div>
       </Checkbox>

--- a/apps/ff-site/src/app/_components/Form/FormFileInput/SelectedFile.tsx
+++ b/apps/ff-site/src/app/_components/Form/FormFileInput/SelectedFile.tsx
@@ -1,6 +1,6 @@
 import Image from 'next/image'
 
-import { X } from '@phosphor-icons/react/dist/ssr'
+import { XIcon } from '@phosphor-icons/react/dist/ssr'
 
 import { Icon } from '@filecoin-foundation/ui/Icon'
 
@@ -26,7 +26,7 @@ export function SelectedFile({ file, onReset }: SelectedFileProps) {
         onClick={onReset}
       >
         <div className="z-10 flex size-8 items-center justify-center rounded-full bg-brand-100 p-3 text-brand-700 shadow-brand-800/20 drop-shadow-md group-hover:bg-brand-200">
-          <Icon component={X} size={20} />
+          <Icon component={XIcon} size={20} />
         </div>
       </button>
     </div>

--- a/apps/ff-site/src/app/_components/Form/FormFileInput/UploadInstructions.tsx
+++ b/apps/ff-site/src/app/_components/Form/FormFileInput/UploadInstructions.tsx
@@ -1,4 +1,4 @@
-import { Image } from '@phosphor-icons/react/dist/ssr'
+import { ImageIcon } from '@phosphor-icons/react/dist/ssr'
 import { clsx } from 'clsx'
 import prettyBytes from 'pretty-bytes'
 
@@ -25,7 +25,7 @@ export function UploadInstructions({
       )}
     >
       <div className="flex flex-col items-center justify-center gap-2 p-4">
-        <Icon component={Image} size={80} weight="fill" />
+        <Icon component={ImageIcon} size={80} weight="fill" />
         <p className="max-w-xs text-center text-brand-100">
           <span className="font-bold text-brand-300 group-hover:text-brand-400">
             Upload a file

--- a/apps/ff-site/src/app/_components/LocationFilter.tsx
+++ b/apps/ff-site/src/app/_components/LocationFilter.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { GlobeSimple } from '@phosphor-icons/react'
+import { GlobeSimpleIcon } from '@phosphor-icons/react'
 
 import { DEFAULT_LOCATION_FILTER_OPTION } from '@filecoin-foundation/hooks/useFilter/constants'
 import { useListboxQueryState } from '@filecoin-foundation/hooks/useListboxQueryState'
@@ -23,7 +23,7 @@ export function LocationFilter({ options }: LocationFilterProps) {
     <FilterListbox
       selected={locationOption}
       options={options}
-      buttonIcon={GlobeSimple}
+      buttonIcon={GlobeSimpleIcon}
       onChange={setLocationOption}
     />
   )

--- a/apps/ff-site/src/app/_components/Navigation/DesktopNavigation/ExternalLink.tsx
+++ b/apps/ff-site/src/app/_components/Navigation/DesktopNavigation/ExternalLink.tsx
@@ -1,6 +1,6 @@
 import type { AnchorHTMLAttributes } from 'react'
 
-import { ArrowUpRight } from '@phosphor-icons/react'
+import { ArrowUpRightIcon } from '@phosphor-icons/react'
 
 import { Icon } from '@filecoin-foundation/ui/Icon'
 
@@ -29,13 +29,13 @@ export function ExternalLink({
       target="_blank"
       {...rest}
     >
-      <div className="inline-flex items-center gap-1">
+      <div className="group inline-flex items-center gap-1">
         <p className="font-bold">{label}</p>
         <span className="text-brand-400 group-hover:text-brand-100">
-          <Icon component={ArrowUpRight} size={20} />
+          <Icon component={ArrowUpRightIcon} size={20} />
         </span>
       </div>
-      {description && <p className="mt-1 text-brand-300">{description}</p>}
+      {description && <p className="text-brand-300 mt-1">{description}</p>}
     </a>
   )
 }

--- a/apps/ff-site/src/app/_components/Navigation/MobileNavigation/LinkItem.tsx
+++ b/apps/ff-site/src/app/_components/Navigation/MobileNavigation/LinkItem.tsx
@@ -2,7 +2,7 @@
 
 import type { Dispatch, SetStateAction } from 'react'
 
-import { ArrowUpRight } from '@phosphor-icons/react'
+import { ArrowUpRightIcon } from '@phosphor-icons/react'
 import { clsx } from 'clsx'
 
 import { type BaseLinkProps, BaseLink } from '@filecoin-foundation/ui/BaseLink'
@@ -35,7 +35,9 @@ export function LinkItem({ label, href, nested, setOpen }: LinkItemProps) {
       >
         {label}
       </BaseLink>
-      {isExternal && <Icon size={16} component={ArrowUpRight} color="subtle" />}
+      {isExternal && (
+        <Icon size={16} component={ArrowUpRightIcon} color="subtle" />
+      )}
     </li>
   )
 }

--- a/apps/ff-site/src/app/_components/Navigation/MobileNavigation/MobileNavigation.tsx
+++ b/apps/ff-site/src/app/_components/Navigation/MobileNavigation/MobileNavigation.tsx
@@ -2,7 +2,7 @@
 
 import { useState } from 'react'
 
-import { List, X } from '@phosphor-icons/react'
+import { ListIcon, XIcon } from '@phosphor-icons/react'
 
 import { IconButton } from '@filecoin-foundation/ui/IconButton'
 import { LogoLink } from '@filecoin-foundation/ui/LogoLink'
@@ -25,7 +25,7 @@ export function MobileNavigation() {
   return (
     <div className="lg:hidden">
       <IconButton
-        icon={List}
+        icon={ListIcon}
         label="Open mobile navigation"
         onClick={() => setOpen(true)}
       />
@@ -37,7 +37,7 @@ export function MobileNavigation() {
               <LogoLink logo={Logo} onClick={() => setOpen(false)} />
             </div>
             <IconButton
-              icon={X}
+              icon={XIcon}
               label="Close mobile navigation"
               onClick={() => setOpen(false)}
             />

--- a/apps/ff-site/src/app/_components/NavigationPopover.tsx
+++ b/apps/ff-site/src/app/_components/NavigationPopover.tsx
@@ -1,10 +1,9 @@
 'use client'
 
 import { Popover, PopoverButton, PopoverPanel } from '@headlessui/react'
-import { CaretDown } from '@phosphor-icons/react'
+import { CaretDownIcon } from '@phosphor-icons/react'
 
 import { Icon } from '@filecoin-foundation/ui/Icon'
-
 
 type PopOverProps = {
   label: string
@@ -29,8 +28,8 @@ export function NavigationPopover({
         className={mainNavItemStyles}
       >
         <span>{label}</span>
-        <span className="transition-transform ui-open:rotate-180">
-          <Icon component={CaretDown} size={20} color="subtle" />
+        <span className="ui-open:rotate-180 transition-transform">
+          <Icon component={CaretDownIcon} size={20} color="subtle" />
         </span>
       </PopoverButton>
       <PopoverPanel
@@ -44,7 +43,7 @@ export function NavigationPopover({
       >
         {(props) => (
           <div
-            className="overflow-hidden rounded-2xl border border-brand-500 bg-brand-800 p-4"
+            className="border-brand-500 bg-brand-800 overflow-hidden rounded-2xl border p-4"
             onClick={(e) => {
               e.stopPropagation()
               props.close()

--- a/apps/ff-site/src/app/_components/NewsletterForm.tsx
+++ b/apps/ff-site/src/app/_components/NewsletterForm.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import { zodResolver } from '@hookform/resolvers/zod'
-import { CheckCircle, XCircle } from '@phosphor-icons/react'
+import { CheckCircleIcon, XCircleIcon } from '@phosphor-icons/react'
 import * as Sentry from '@sentry/nextjs'
 import { useForm } from 'react-hook-form'
 import { z } from 'zod'
@@ -86,13 +86,13 @@ function useNewsletterForm() {
 
       dialog.open({
         message: 'Successfully subscribed!',
-        icon: { component: CheckCircle, color: 'success' },
+        icon: { component: CheckCircleIcon, color: 'success' },
       })
     } catch (error) {
       dialog.open({
         message: 'An error has occurred. Please try again.',
         duration: NOTIFICATION_DIALOG_ERROR_DURATION_MS,
-        icon: { component: XCircle, color: 'error' },
+        icon: { component: XCircleIcon, color: 'error' },
       })
 
       Sentry.captureException(error)

--- a/apps/ff-site/src/app/_components/SortListbox.tsx
+++ b/apps/ff-site/src/app/_components/SortListbox.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { ArrowsDownUp } from '@phosphor-icons/react'
+import { ArrowsDownUpIcon } from '@phosphor-icons/react'
 
 import { Listbox } from '@filecoin-foundation/ui/Listbox'
 import {
@@ -22,7 +22,7 @@ export function SortListbox({
   selected,
   onChange,
   options,
-  buttonIcon = ArrowsDownUp,
+  buttonIcon = ArrowsDownUpIcon,
 }: SortListboxProps) {
   return (
     <Listbox value={selected} onChange={onChange}>

--- a/apps/ff-site/src/app/_components/Table/PopoverHeader.tsx
+++ b/apps/ff-site/src/app/_components/Table/PopoverHeader.tsx
@@ -1,5 +1,5 @@
 import { Button } from '@headlessui/react'
-import { Question } from '@phosphor-icons/react/dist/ssr'
+import { QuestionIcon } from '@phosphor-icons/react/dist/ssr'
 import { clsx } from 'clsx'
 
 import { Icon } from '@filecoin-foundation/ui/Icon'
@@ -52,7 +52,7 @@ export function PopoverHeader({
               )}
             >
               <Icon
-                component={Question}
+                component={QuestionIcon}
                 size={TOUCH_TARGET_ICON.visibleElementSize}
               />
             </span>

--- a/apps/ff-site/src/app/_data/filecoinEcosystemData.ts
+++ b/apps/ff-site/src/app/_data/filecoinEcosystemData.ts
@@ -1,4 +1,4 @@
-import { Code, HardDrives, Money, Person } from '@phosphor-icons/react/dist/ssr'
+import { CodeIcon, HardDrivesIcon, MoneyIcon, PersonIcon } from '@phosphor-icons/react/dist/ssr'
 
 import type { IconProps } from '@filecoin-foundation/ui/Icon'
 
@@ -26,7 +26,7 @@ export const filecoinEcosystemData: Array<FilecoinEcosystemData> = [
   {
     heading: {
       title: 'Grants Program',
-      icon: Money,
+      icon: MoneyIcon,
     },
     description:
       'Learn more about support for teams building on the Filecoin network.',
@@ -38,7 +38,7 @@ export const filecoinEcosystemData: Array<FilecoinEcosystemData> = [
   {
     heading: {
       title: 'Filecoin Events',
-      icon: Person,
+      icon: PersonIcon,
     },
     description:
       'Connect and collaborate with the Filecoin community around the globe! Get details on the latest Filecoin Foundation, Web3, and community events.',
@@ -50,7 +50,7 @@ export const filecoinEcosystemData: Array<FilecoinEcosystemData> = [
   {
     heading: {
       title: 'Builder Resources',
-      icon: Code,
+      icon: CodeIcon,
     },
     description:
       'Join thousands of developers and teams building on the Filecoin network.',
@@ -62,7 +62,7 @@ export const filecoinEcosystemData: Array<FilecoinEcosystemData> = [
   {
     heading: {
       title: 'Storage Resources',
-      icon: HardDrives,
+      icon: HardDrivesIcon,
     },
     description:
       'Join the Filecoin community as a Storage Provider or leverage the network to store your data with robust and secure storage.',

--- a/apps/ff-site/src/app/_utils/generateShareArticleLinks.ts
+++ b/apps/ff-site/src/app/_utils/generateShareArticleLinks.ts
@@ -1,8 +1,8 @@
 import {
-  FacebookLogo,
-  LinkedinLogo,
-  RedditLogo,
-  XLogo,
+  FacebookLogoIcon,
+  LinkedinLogoIcon,
+  RedditLogoIcon,
+  XLogoIcon,
 } from '@phosphor-icons/react/dist/ssr'
 
 import { BASE_URL } from '@/constants/siteMetadata'
@@ -12,22 +12,22 @@ const PLACEHOLDER_TITLE = 'Explore more on our website!'
 
 export const SHARE_SOCIAL_LINKS_CONFIG = [
   {
-    icon: FacebookLogo,
+    icon: FacebookLogoIcon,
     label: 'Facebook',
     href: `https://www.facebook.com/sharer/sharer.php?u=${PLACEHOLDER_URL}&quote=${PLACEHOLDER_TITLE}`,
   },
   {
-    icon: LinkedinLogo,
+    icon: LinkedinLogoIcon,
     label: 'LinkedIn',
     href: `https://www.linkedin.com/shareArticle?mini=true&url=${PLACEHOLDER_URL}&title=${PLACEHOLDER_TITLE}`,
   },
   {
-    icon: RedditLogo,
+    icon: RedditLogoIcon,
     label: 'Reddit',
     href: `https://old.reddit.com/submit?url=${PLACEHOLDER_URL}&title=${PLACEHOLDER_TITLE}`,
   },
   {
-    icon: XLogo,
+    icon: XLogoIcon,
     label: 'X',
     href: `https://twitter.com/share?url=${PLACEHOLDER_URL}&text=${PLACEHOLDER_TITLE}`,
   },

--- a/apps/ff-site/src/app/_utils/socialConfig.ts
+++ b/apps/ff-site/src/app/_utils/socialConfig.ts
@@ -1,8 +1,8 @@
 import {
-  GithubLogo,
-  LinkedinLogo,
-  XLogo,
-  YoutubeLogo,
+  GithubLogoIcon,
+  LinkedinLogoIcon,
+  XLogoIcon,
+  YoutubeLogoIcon,
 } from '@phosphor-icons/react/dist/ssr'
 
 import { FILECOIN_FOUNDATION_URLS } from '@/constants/siteMetadata'
@@ -11,10 +11,10 @@ import BlueskyLogo from '@/assets/logos/bluesky-logo.svg'
 
 const socialIcons = {
   bluesky: BlueskyLogo,
-  github: GithubLogo,
-  linkedin: LinkedinLogo,
-  twitter: XLogo,
-  youtube: YoutubeLogo,
+  github: GithubLogoIcon,
+  linkedin: LinkedinLogoIcon,
+  twitter: XLogoIcon,
+  youtube: YoutubeLogoIcon,
 }
 
 type SocialIconKey = keyof typeof socialIcons

--- a/apps/ff-site/src/app/about/page.tsx
+++ b/apps/ff-site/src/app/about/page.tsx
@@ -1,4 +1,4 @@
-import { Files } from '@phosphor-icons/react/dist/ssr'
+import { FilesIcon } from '@phosphor-icons/react/dist/ssr'
 import { clsx } from 'clsx'
 
 import { CardGrid } from '@filecoin-foundation/ui/CardGrid'
@@ -125,7 +125,7 @@ export default function About() {
                     href: link,
                     text: 'View Report',
                     icon: {
-                      component: Files,
+                      component: FilesIcon,
                     },
                   }}
                   title={{

--- a/apps/ff-site/src/app/blog/components/BlogContent.tsx
+++ b/apps/ff-site/src/app/blog/components/BlogContent.tsx
@@ -2,7 +2,7 @@
 
 import { useSearchParams } from 'next/navigation'
 
-import { BookOpen } from '@phosphor-icons/react'
+import { BookOpenIcon } from '@phosphor-icons/react'
 
 import { useEntryView } from '@filecoin-foundation/hooks/useEntryView'
 import { useFilter } from '@filecoin-foundation/hooks/useFilter'
@@ -132,7 +132,7 @@ export function BlogContent({ posts }: BlogContentProps) {
                         href: `${PATHS.BLOG.path}/${slug}`,
                         text: 'Read Post',
                         icon: {
-                          component: BookOpen,
+                          component: BookOpenIcon,
                         },
                       }}
                       image={{

--- a/apps/ff-site/src/app/digest/page.tsx
+++ b/apps/ff-site/src/app/digest/page.tsx
@@ -1,4 +1,4 @@
-import { BookOpen } from '@phosphor-icons/react/dist/ssr'
+import { BookOpenIcon } from '@phosphor-icons/react/dist/ssr'
 
 import { CardGrid } from '@filecoin-foundation/ui/CardGrid'
 import { PageLayout } from '@filecoin-foundation/ui/PageLayout'
@@ -72,7 +72,7 @@ export default async function Digest() {
                   href: `${PATHS.DIGEST.path}/${slug}`,
                   text: 'Read Article',
                   icon: {
-                    component: BookOpen,
+                    component: BookOpenIcon,
                   },
                 }}
                 image={{

--- a/apps/ff-site/src/app/ecosystem-explorer/[slug]/components/Article.tsx
+++ b/apps/ff-site/src/app/ecosystem-explorer/[slug]/components/Article.tsx
@@ -1,4 +1,4 @@
-import { BookOpen, GitFork, Globe, XLogo } from '@phosphor-icons/react/dist/ssr'
+import { BookOpenIcon, GitForkIcon, GlobeIcon, XLogoIcon } from '@phosphor-icons/react/dist/ssr'
 
 import { Heading } from '@filecoin-foundation/ui/Heading'
 import { Icon } from '@filecoin-foundation/ui/Icon'
@@ -52,7 +52,7 @@ export function Article({
         <ul className="flex flex-col gap-5">
           {website && (
             <li className="inline-flex gap-2 whitespace-nowrap text-brand-300">
-              <Icon component={Globe} />
+              <Icon component={GlobeIcon} />
               <SmartTextLink href={website} baseDomain={BASE_DOMAIN}>
                 Website
               </SmartTextLink>
@@ -60,19 +60,19 @@ export function Article({
           )}
           {repo && (
             <li className="inline-flex gap-2 whitespace-nowrap text-brand-300">
-              <Icon component={GitFork} />
+              <Icon component={GitForkIcon} />
               <ExternalTextLink href={repo}>GitHub</ExternalTextLink>
             </li>
           )}
           {twitter && (
             <li className="inline-flex gap-2 whitespace-nowrap text-brand-300">
-              <Icon component={XLogo} />
+              <Icon component={XLogoIcon} />
               <ExternalTextLink href={twitter}>X.com</ExternalTextLink>
             </li>
           )}
           {featuredContent && (
             <li className="inline-flex gap-2 whitespace-nowrap text-brand-300">
-              <Icon component={BookOpen} />
+              <Icon component={BookOpenIcon} />
               <SmartTextLink href={featuredContent} baseDomain={BASE_DOMAIN}>
                 Featured Content
               </SmartTextLink>

--- a/apps/ff-site/src/app/ecosystem-explorer/components/CategoryFiltersSlider.tsx
+++ b/apps/ff-site/src/app/ecosystem-explorer/components/CategoryFiltersSlider.tsx
@@ -3,7 +3,7 @@
 import { useState } from 'react'
 
 import { Button as HeadlessUIButton } from '@headlessui/react'
-import { FunnelSimple, X } from '@phosphor-icons/react'
+import { FunnelSimpleIcon, XIcon } from '@phosphor-icons/react'
 
 import { useUpdateSearchParams } from '@filecoin-foundation/hooks/useUpdateSearchParams'
 import { Icon } from '@filecoin-foundation/ui/Icon'
@@ -28,19 +28,19 @@ export function CategoryFiltersSlider({
         className="border-brand-300 bg-brand-800 text-brand-300 hover:text-brand-400 focus:brand-outline flex h-full w-full items-center gap-2 rounded-lg border p-3 font-bold hover:border-current"
         onClick={openSlider}
       >
-        <Icon component={FunnelSimple} />
+        <Icon component={FunnelSimpleIcon} />
         Filters
       </HeadlessUIButton>
 
       <SlideOver open={open} setOpen={setOpen} slideFrom="left">
         <div className="flex items-center justify-between px-6 pt-6">
           <div className="flex items-center gap-2">
-            <Icon component={FunnelSimple} size={24} />
+            <Icon component={FunnelSimpleIcon} size={24} />
             <h2 className="text-xl font-bold">Filters</h2>
           </div>
 
           <IconButton
-            icon={X}
+            icon={XIcon}
             label="Close category filters"
             onClick={closeSlider}
           />

--- a/apps/ff-site/src/app/ecosystem-explorer/components/EcosystemExplorerContent.tsx
+++ b/apps/ff-site/src/app/ecosystem-explorer/components/EcosystemExplorerContent.tsx
@@ -1,4 +1,4 @@
-import { BookOpen } from '@phosphor-icons/react/dist/ssr'
+import { BookOpenIcon } from '@phosphor-icons/react/dist/ssr'
 
 import { useEntryView } from '@filecoin-foundation/hooks/useEntryView'
 import { useFilter } from '@filecoin-foundation/hooks/useFilter'
@@ -127,7 +127,7 @@ export function EcosystemExplorerContent({
                         href: `${PATHS.ECOSYSTEM_EXPLORER.path}/${slug}`,
                         text: 'Learn More',
                         icon: {
-                          component: BookOpen,
+                          component: BookOpenIcon,
                         },
                       }}
                       image={{

--- a/apps/ff-site/src/app/ecosystem-explorer/project-form/components/ErrorNotification.tsx
+++ b/apps/ff-site/src/app/ecosystem-explorer/project-form/components/ErrorNotification.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { XCircle } from '@phosphor-icons/react'
+import { XCircleIcon } from '@phosphor-icons/react'
 
 import { useUpdateSearchParams } from '@filecoin-foundation/hooks/useUpdateSearchParams'
 import {
@@ -19,7 +19,7 @@ export function ErrorNotification(props: ErrorMessageProps) {
   const dialog = useNotificationDialog({
     init: 'open',
     message: props.message,
-    icon: { component: XCircle, color: 'error' },
+    icon: { component: XCircleIcon, color: 'error' },
     duration: NOTIFICATION_DIALOG_ERROR_DURATION_MS,
     onClose: resetSearchParams,
   })

--- a/apps/ff-site/src/app/ecosystem-explorer/project-form/components/SuccessMessage.tsx
+++ b/apps/ff-site/src/app/ecosystem-explorer/project-form/components/SuccessMessage.tsx
@@ -1,6 +1,6 @@
 import Link from 'next/link'
 
-import { CheckCircle } from '@phosphor-icons/react/dist/ssr'
+import { CheckCircleIcon } from '@phosphor-icons/react/dist/ssr'
 
 import { Heading } from '@filecoin-foundation/ui/Heading'
 import { Icon } from '@filecoin-foundation/ui/Icon'
@@ -23,7 +23,7 @@ export function SuccessMessage({ prNumber }: SuccessMessageProps) {
       <div className="max-w-[420px] space-y-6 sm:text-center">
         <div className="sm:flex sm:justify-center">
           <Icon
-            component={CheckCircle}
+            component={CheckCircleIcon}
             size={96}
             weight="fill"
             color="primary"

--- a/apps/ff-site/src/app/events/[slug]/components/ProgramSection.tsx
+++ b/apps/ff-site/src/app/events/[slug]/components/ProgramSection.tsx
@@ -1,4 +1,4 @@
-import { MagnifyingGlass } from '@phosphor-icons/react/dist/ssr'
+import { MagnifyingGlassIcon } from '@phosphor-icons/react/dist/ssr'
 
 import { CardGrid } from '@filecoin-foundation/ui/CardGrid'
 
@@ -30,7 +30,7 @@ export function ProgramSection({ title, kicker, events }: ProgramSectionProps) {
               href: externalLink,
               text: DEFAULT_CTA_TEXT,
               icon: {
-                component: MagnifyingGlass,
+                component: MagnifyingGlassIcon,
               },
             },
           }

--- a/apps/ff-site/src/app/events/components/EventSort.tsx
+++ b/apps/ff-site/src/app/events/components/EventSort.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { CalendarBlank } from '@phosphor-icons/react'
+import { CalendarBlankIcon } from '@phosphor-icons/react'
 
 import { useListboxQueryState } from '@filecoin-foundation/hooks/useListboxQueryState'
 import { SORT_KEY } from '@filecoin-foundation/utils/constants/urlParamsConstants'
@@ -23,7 +23,7 @@ export function EventSort() {
     <SortListbox
       options={options}
       selected={selectedSort}
-      buttonIcon={CalendarBlank}
+      buttonIcon={CalendarBlankIcon}
       onChange={setSelectedSort}
     />
   )

--- a/apps/ff-site/src/app/events/components/EventsContent.tsx
+++ b/apps/ff-site/src/app/events/components/EventsContent.tsx
@@ -1,4 +1,4 @@
-import { MagnifyingGlass } from '@phosphor-icons/react/dist/ssr'
+import { MagnifyingGlassIcon } from '@phosphor-icons/react/dist/ssr'
 
 import { useEntryView } from '@filecoin-foundation/hooks/useEntryView'
 import { useFilter } from '@filecoin-foundation/hooks/useFilter'
@@ -175,7 +175,7 @@ export default function EventsContent({
                           `${PATHS.EVENTS.path}/${slug}`,
                         text: DEFAULT_CTA_TEXT,
                         icon: {
-                          component: MagnifyingGlass,
+                          component: MagnifyingGlassIcon,
                         },
                       }}
                       title={{

--- a/apps/ff-site/src/app/events/data/getInvolvedData.ts
+++ b/apps/ff-site/src/app/events/data/getInvolvedData.ts
@@ -1,4 +1,4 @@
-import { Clipboard, Envelope, HandWaving } from '@phosphor-icons/react/dist/ssr'
+import { ClipboardIcon, EnvelopeIcon, HandWavingIcon } from '@phosphor-icons/react/dist/ssr'
 
 import type { CTAProps } from '@filecoin-foundation/utils/types/ctaType'
 
@@ -20,7 +20,7 @@ export const getInvolvedData: Array<GetInvolvedData> = [
       href: FILECOIN_FOUNDATION_URLS.events.sponsorshipsEmail,
       text: 'Email Us',
       icon: {
-        component: Envelope,
+        component: EnvelopeIcon,
       },
     },
   },
@@ -32,7 +32,7 @@ export const getInvolvedData: Array<GetInvolvedData> = [
       href: FILECOIN_FOUNDATION_URLS.events.speakerEngagementForm,
       text: 'Submit Form',
       icon: {
-        component: Clipboard,
+        component: ClipboardIcon,
       },
     },
   },
@@ -44,7 +44,7 @@ export const getInvolvedData: Array<GetInvolvedData> = [
       href: FILECOIN_FOUNDATION_URLS.events.orbitAmbassadorForm,
       text: 'Apply to Filecoin Orbit',
       icon: {
-        component: HandWaving,
+        component: HandWavingIcon,
       },
     },
   },

--- a/apps/ff-site/src/app/filecoin-plus/allocators/components/NoDataAvailableMessage.tsx
+++ b/apps/ff-site/src/app/filecoin-plus/allocators/components/NoDataAvailableMessage.tsx
@@ -1,4 +1,4 @@
-import { CloudSlash } from '@phosphor-icons/react/dist/ssr'
+import { CloudSlashIcon } from '@phosphor-icons/react/dist/ssr'
 
 import { NoResultsMessage } from '@filecoin-foundation/ui/NoResultsMessage'
 
@@ -9,7 +9,7 @@ import { Button } from '@/components/Button'
 export function NoDataAvailableMessage() {
   return (
     <NoResultsMessage
-      icon={CloudSlash}
+      icon={CloudSlashIcon}
       title="Allocator Data Unavailable"
       message="We're having trouble fetching the allocator data. For the latest
         information, please check the Allocators list on the Filecoin Plus

--- a/apps/ff-site/src/app/filecoin-plus/allocators/components/SelectSort.tsx
+++ b/apps/ff-site/src/app/filecoin-plus/allocators/components/SelectSort.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { ArrowsDownUp } from '@phosphor-icons/react/dist/ssr'
+import { ArrowsDownUpIcon } from '@phosphor-icons/react/dist/ssr'
 import type { Column, SortDirection } from '@tanstack/react-table'
 
 import { Listbox } from '@filecoin-foundation/ui/Listbox'
@@ -34,7 +34,7 @@ export function SelectSort({
   return (
     <Listbox value={selectedOption} onChange={setColumnSort}>
       <ListboxButton
-        leadingIcon={ArrowsDownUp}
+        leadingIcon={ArrowsDownUpIcon}
         text={selectedOption.name}
         compactBelow="md"
       />

--- a/apps/ff-site/src/app/filecoin-plus/allocators/data/allocatorsTableColumnsData.tsx
+++ b/apps/ff-site/src/app/filecoin-plus/allocators/data/allocatorsTableColumnsData.tsx
@@ -1,4 +1,4 @@
-import { ArrowUpRight } from '@phosphor-icons/react'
+import { ArrowUpRightIcon } from '@phosphor-icons/react'
 import { createColumnHelper } from '@tanstack/react-table'
 
 import { Icon } from '@filecoin-foundation/ui/Icon'
@@ -24,18 +24,18 @@ export const allocatorsTableColumnsData = [
               aria-label={`See more information about ${name} allocator`}
               href={link}
               title={name}
-              className="group flex items-center hover:text-brand-300 hover:underline focus:brand-outline focus:text-brand-300"
+              className="group hover:text-brand-300 focus:brand-outline focus:text-brand-300 flex items-center hover:underline"
               rel="noopener noreferrer"
             >
-              <span className="block truncate text-brand-100 group-hover:text-inherit group-focus:text-inherit">
+              <span className="text-brand-100 block truncate group-hover:text-inherit group-focus:text-inherit">
                 {name}
               </span>
-              <span className="ml-2 inline-flex self-center text-brand-300">
-                <Icon component={ArrowUpRight} size={18} />
+              <span className="text-brand-300 ml-2 inline-flex self-center">
+                <Icon component={ArrowUpRightIcon} size={18} />
               </span>
             </a>
           ) : (
-            <p title={name} className="truncate text-brand-100">
+            <p title={name} className="text-brand-100 truncate">
               {name}
             </p>
           )}

--- a/apps/ff-site/src/app/governance/data/governanceDocsData.tsx
+++ b/apps/ff-site/src/app/governance/data/governanceDocsData.tsx
@@ -1,4 +1,4 @@
-import { GithubLogo } from '@phosphor-icons/react/dist/ssr'
+import { GithubLogoIcon } from '@phosphor-icons/react/dist/ssr'
 
 import type { IconProps } from '@filecoin-foundation/ui/Icon'
 import type { CTAProps } from '@filecoin-foundation/utils/types/ctaType'
@@ -18,7 +18,7 @@ export const governanceDocsData: Array<GovernanceDocsData> = [
   {
     heading: {
       title: 'Governance GitHub',
-      icon: GithubLogo,
+      icon: GithubLogoIcon,
     },
     description:
       'Deep dive into the Filecoin Improvement Proposal (FIP) process, including proposals, discussions, and technical documentation.',

--- a/apps/ff-site/src/app/grants/components/FeaturedGrantGraduates.tsx
+++ b/apps/ff-site/src/app/grants/components/FeaturedGrantGraduates.tsx
@@ -1,4 +1,4 @@
-import { BookOpen } from '@phosphor-icons/react/dist/ssr'
+import { BookOpenIcon } from '@phosphor-icons/react/dist/ssr'
 
 import { CardGrid } from '@filecoin-foundation/ui/CardGrid'
 import { buildImageSizeProp } from '@filecoin-foundation/utils/buildImageSizeProp'
@@ -29,7 +29,7 @@ export function FeaturedGrantGraduates({
             href: `${PATHS.ECOSYSTEM_EXPLORER.path}/${slug}`,
             text: 'Read More',
             icon: {
-              component: BookOpen,
+              component: BookOpenIcon,
             },
           }}
           image={{

--- a/apps/ff-site/src/app/grants/data/opportunitiesData.tsx
+++ b/apps/ff-site/src/app/grants/data/opportunitiesData.tsx
@@ -1,4 +1,8 @@
-import { Megaphone, Coins, Coin } from '@phosphor-icons/react/dist/ssr'
+import {
+  MegaphoneIcon,
+  CoinsIcon,
+  CoinIcon,
+} from '@phosphor-icons/react/dist/ssr'
 
 import { FILECOIN_FOUNDATION_URLS } from '@/constants/siteMetadata'
 
@@ -7,7 +11,7 @@ export const opportunitiesData = [
     title: 'Open Grants',
     description:
       "Open Grants support projects that drive the Filecoin ecosystem forward, including projects that enhance the network's utility or improve Filecoin functionality. Refer to GitHub for more details.",
-    icon: Coins,
+    icon: CoinsIcon,
     cta: {
       href: FILECOIN_FOUNDATION_URLS.grants.documents.openGrants,
       text: 'Learn More',
@@ -17,7 +21,7 @@ export const opportunitiesData = [
     title: 'FIL Builder Next Step Grants',
     description:
       'Grants between $5k and $10k are available to support builders taking their Filecoin projects to the next level! Refer to Github for more details.',
-    icon: Coin,
+    icon: CoinIcon,
     cta: {
       href: FILECOIN_FOUNDATION_URLS.grants.documents.builderNextStepGrants,
       text: 'Learn More',
@@ -27,7 +31,7 @@ export const opportunitiesData = [
     title: 'Requests for Proposals',
     description:
       'Request for Proposals (RFP) grants have clearly scoped deliverables, milestones, and funding limits. Refer to GitHub for any ongoing RFPs.',
-    icon: Megaphone,
+    icon: MegaphoneIcon,
     cta: {
       href: FILECOIN_FOUNDATION_URLS.grants.documents.requestsForProposals,
       text: 'Learn More',

--- a/apps/ff-site/src/app/grants/data/submissionCriteriaData.tsx
+++ b/apps/ff-site/src/app/grants/data/submissionCriteriaData.tsx
@@ -1,4 +1,4 @@
-import { Code, BracketsAngle, Users } from '@phosphor-icons/react/dist/ssr'
+import { CodeIcon, BracketsAngleIcon, UsersIcon } from '@phosphor-icons/react/dist/ssr'
 
 import { ExternalTextLink } from '@filecoin-foundation/ui/TextLink/ExternalTextLink'
 
@@ -7,7 +7,7 @@ export const submissionCriteriaData = [
   {
     title: 'Open-source',
     description: 'All projects must be open-sourced.',
-    icon: Code,
+    icon: CodeIcon,
   },
   {
     title: 'MIT and APACHE2',
@@ -24,11 +24,11 @@ export const submissionCriteriaData = [
         licenses.
       </>
     ),
-    icon: BracketsAngle,
+    icon: BracketsAngleIcon,
   },
   {
     title: 'Self-Management',
     description: 'All teams must be self-managed.',
-    icon: Users,
+    icon: UsersIcon,
   },
 ]

--- a/apps/ff-site/src/app/orbit/data/exploreOrbitData.ts
+++ b/apps/ff-site/src/app/orbit/data/exploreOrbitData.ts
@@ -1,13 +1,12 @@
 import {
-  BookOpen,
-  ClipboardText,
-  Envelope,
+  BookOpenIcon,
+  ClipboardTextIcon,
+  EnvelopeIcon,
 } from '@phosphor-icons/react/dist/ssr'
 
 import type { IconProps } from '@filecoin-foundation/ui/Icon'
 
 import { FILECOIN_FOUNDATION_URLS } from '@/constants/siteMetadata'
-
 
 type ExploreOrbitData = {
   heading: {
@@ -25,7 +24,7 @@ export const exploreOrbitData: Array<ExploreOrbitData> = [
   {
     heading: {
       title: '2023 Orbit Recap',
-      icon: BookOpen,
+      icon: BookOpenIcon,
     },
     description: 'Discover the highlights and milestones from our past year.',
     cta: {
@@ -36,7 +35,7 @@ export const exploreOrbitData: Array<ExploreOrbitData> = [
   {
     heading: {
       title: 'Get in Touch',
-      icon: Envelope,
+      icon: EnvelopeIcon,
     },
     description:
       'Connect with the Orbit Team for more information and support.',
@@ -48,7 +47,7 @@ export const exploreOrbitData: Array<ExploreOrbitData> = [
   {
     heading: {
       title: "Ambassador's Portal",
-      icon: ClipboardText,
+      icon: ClipboardTextIcon,
     },
     description: 'Access the private portal with tools and resources.',
     cta: {

--- a/apps/ff-site/src/app/orbit/data/programFeaturesAndPerksData.tsx
+++ b/apps/ff-site/src/app/orbit/data/programFeaturesAndPerksData.tsx
@@ -1,12 +1,11 @@
 import {
-  CurrencyCircleDollar,
-  Gift,
-  MegaphoneSimple,
-  PenNib,
+  CurrencyCircleDollarIcon,
+  GiftIcon,
+  MegaphoneSimpleIcon,
+  PenNibIcon,
 } from '@phosphor-icons/react/dist/ssr'
 
 import type { IconProps } from '@filecoin-foundation/ui/Icon'
-
 
 type ProgramFeaturesAndPerksDataProps = {
   icon: IconProps['component']
@@ -17,25 +16,25 @@ type ProgramFeaturesAndPerksDataProps = {
 export const programFeaturesAndPerksData: Array<ProgramFeaturesAndPerksDataProps> =
   [
     {
-      icon: CurrencyCircleDollar,
+      icon: CurrencyCircleDollarIcon,
       title: 'Funding and Promotion',
       description:
         'Host events in your community with funding and promotion from Filecoin Foundation.',
     },
     {
-      icon: PenNib,
+      icon: PenNibIcon,
       title: 'Content Creation',
       description:
         'Create tutorials, translate technical documentation and serve as administrators for community communication channels.',
     },
     {
-      icon: Gift,
+      icon: GiftIcon,
       title: 'Exclusive Rewards',
       description:
         'Earn points through Orbit activities to unlock limited edition swag, travel reimbursements to network events, speaking slots at FIL-city events, spot at invite-only workshops and Hacker Bases.',
     },
     {
-      icon: MegaphoneSimple,
+      icon: MegaphoneSimpleIcon,
       title: 'Ecosystem Recognition',
       description:
         'Cement yourself and your organization as key contributors to the Filecoin Ecosystem!',

--- a/apps/ff-site/src/app/orbit/data/statisticsData.tsx
+++ b/apps/ff-site/src/app/orbit/data/statisticsData.tsx
@@ -1,31 +1,31 @@
 import {
-  GlobeHemisphereWest,
-  GraduationCap,
-  Trophy,
-  UsersThree,
+  GlobeHemisphereWestIcon,
+  GraduationCapIcon,
+  TrophyIcon,
+  UsersThreeIcon,
 } from '@phosphor-icons/react/dist/ssr'
 
 import type { BasicStatisticCardProps } from '@/components/StatisticCard/BasicStatisticCard'
 
 export const statisticsData: Array<BasicStatisticCardProps> = [
   {
-    icon: UsersThree,
+    icon: UsersThreeIcon,
     value: 145,
     description: 'Orbit Ambassadors active worldwide',
   },
   {
-    icon: GraduationCap,
+    icon: GraduationCapIcon,
     value: 10_000,
     description:
       'Early-career developers, students, and enthusiasts introduced to the Filecoin ecosystem',
   },
   {
-    icon: Trophy,
+    icon: TrophyIcon,
     value: 190,
     description: 'Workshops and community hackathons hosted',
   },
   {
-    icon: GlobeHemisphereWest,
+    icon: GlobeHemisphereWestIcon,
     value: 40,
     description: 'Countries that have hosted Orbit events',
   },

--- a/apps/ff-site/src/app/security/bug-bounty/utils/getLogoFromLink.ts
+++ b/apps/ff-site/src/app/security/bug-bounty/utils/getLogoFromLink.ts
@@ -1,24 +1,24 @@
 import {
-  GithubLogo,
-  Globe,
-  LinkedinLogo,
-  XLogo,
+  GithubLogoIcon,
+  GlobeIcon,
+  LinkedinLogoIcon,
+  XLogoIcon,
 } from '@phosphor-icons/react/dist/ssr'
 
 export function getLogoFromLink(url: string) {
   const { hostname } = new URL(url)
 
   if (hostname.includes('linkedin.com')) {
-    return LinkedinLogo
+    return LinkedinLogoIcon
   }
 
   if (hostname.includes('x.com') || hostname.includes('twitter.com')) {
-    return XLogo
+    return XLogoIcon
   }
 
   if (hostname.includes('github.com')) {
-    return GithubLogo
+    return GithubLogoIcon
   }
 
-  return Globe
+  return GlobeIcon
 }

--- a/apps/ff-site/src/app/security/data/developerSupportData.tsx
+++ b/apps/ff-site/src/app/security/data/developerSupportData.tsx
@@ -1,4 +1,4 @@
-import { FileText, UserCircle } from '@phosphor-icons/react/dist/ssr'
+import { FileTextIcon, UserCircleIcon } from '@phosphor-icons/react/dist/ssr'
 
 import type { IconProps } from '@filecoin-foundation/ui/Icon'
 import { ExternalTextLink } from '@filecoin-foundation/ui/TextLink/ExternalTextLink'
@@ -6,7 +6,6 @@ import { ExternalTextLink } from '@filecoin-foundation/ui/TextLink/ExternalTextL
 import { FILECOIN_FOUNDATION_URLS } from '@/constants/siteMetadata'
 
 import { extractEmailAddress } from '@/utils/extractEmailAddress'
-
 
 type DeveloperSupportData = {
   heading: {
@@ -20,7 +19,7 @@ export const developerSupportData: Array<DeveloperSupportData> = [
   {
     heading: {
       title: 'Auditor Network',
-      icon: UserCircle,
+      icon: UserCircleIcon,
     },
     description: (
       <>
@@ -41,7 +40,7 @@ export const developerSupportData: Array<DeveloperSupportData> = [
   {
     heading: {
       title: 'Security Resources',
-      icon: FileText,
+      icon: FileTextIcon,
     },
     description: (
       <>

--- a/apps/ff-site/src/app/security/maturity-model/components/Article.tsx
+++ b/apps/ff-site/src/app/security/maturity-model/components/Article.tsx
@@ -2,7 +2,7 @@
 
 import Link from 'next/link'
 
-import { LinkSimple } from '@phosphor-icons/react/dist/ssr'
+import { LinkSimpleIcon } from '@phosphor-icons/react/dist/ssr'
 import type { Route } from 'next'
 import { useIntersectionObserver } from 'usehooks-ts'
 
@@ -45,7 +45,7 @@ export function Article({ title, slug, children }: ArticleProps) {
         >
           {title}
           <span className="invisible group-hover:visible">
-            <Icon component={LinkSimple} size={18} />
+            <Icon component={LinkSimpleIcon} size={18} />
           </span>
         </Link>
       </h3>

--- a/apps/ffdweb-site/src/app/_components/CTALink.tsx
+++ b/apps/ffdweb-site/src/app/_components/CTALink.tsx
@@ -1,5 +1,8 @@
 import type { Icon as IconType } from '@phosphor-icons/react'
-import { CaretRight, ArrowUpRight } from '@phosphor-icons/react/dist/ssr'
+import {
+  CaretRightIcon,
+  ArrowUpRightIcon,
+} from '@phosphor-icons/react/dist/ssr'
 import clsx from 'clsx'
 
 import { type BaseLinkProps, BaseLink } from '@filecoin-foundation/ui/BaseLink'
@@ -52,8 +55,8 @@ function getIconComponent(isExternal: boolean, icon?: IconType) {
   }
 
   if (isExternal) {
-    return ArrowUpRight
+    return ArrowUpRightIcon
   }
 
-  return CaretRight
+  return CaretRightIcon
 }

--- a/apps/ffdweb-site/src/app/_components/Navigation/MobileNavigation.tsx
+++ b/apps/ffdweb-site/src/app/_components/Navigation/MobileNavigation.tsx
@@ -2,7 +2,7 @@
 
 import { useState } from 'react'
 
-import { List, X } from '@phosphor-icons/react'
+import { ListIcon, XIcon } from '@phosphor-icons/react'
 import { clsx } from 'clsx'
 
 import { IconButton } from '@filecoin-foundation/ui/IconButton'
@@ -22,7 +22,7 @@ export function MobileNavigation() {
   return (
     <div className="lg:hidden">
       <IconButton
-        icon={List}
+        icon={ListIcon}
         label="Open mobile navigation"
         onClick={openPanel}
       />
@@ -32,7 +32,7 @@ export function MobileNavigation() {
           <div className="flex items-center justify-between">
             <LogoLink height={50} />
             <IconButton
-              icon={X}
+              icon={XIcon}
               label="Close mobile navigation"
               onClick={closePanel}
             />

--- a/apps/ffdweb-site/src/app/_constants/cardCTAIcons.ts
+++ b/apps/ffdweb-site/src/app/_constants/cardCTAIcons.ts
@@ -1,8 +1,8 @@
-import { CaretRight } from '@phosphor-icons/react/dist/ssr'
+import { CaretRightIcon } from '@phosphor-icons/react/dist/ssr'
 
 const CARD_CTA_ICON_CONFIG = {
   CARET_RIGHT: {
-    component: CaretRight,
+    component: CaretRightIcon,
     size: 16,
     position: 'trailing',
     weight: 'bold',

--- a/apps/ffdweb-site/src/app/_utils/socialConfig.ts
+++ b/apps/ffdweb-site/src/app/_utils/socialConfig.ts
@@ -1,15 +1,15 @@
 import {
-  LinkedinLogo,
-  XLogo,
-  YoutubeLogo,
+  LinkedinLogoIcon,
+  XLogoIcon,
+  YoutubeLogoIcon,
 } from '@phosphor-icons/react/dist/ssr'
 
 import { FFDW_URLS } from '@/constants/siteMetadata'
 
 const socialIcons = {
-  linkedin: LinkedinLogo,
-  twitter: XLogo,
-  youtube: YoutubeLogo,
+  linkedin: LinkedinLogoIcon,
+  twitter: XLogoIcon,
+  youtube: YoutubeLogoIcon,
 }
 
 type SocialIconKey = keyof typeof socialIcons

--- a/apps/ffdweb-site/src/app/learning-resources/components/LearningResourcesContent.tsx
+++ b/apps/ffdweb-site/src/app/learning-resources/components/LearningResourcesContent.tsx
@@ -2,7 +2,7 @@
 
 import { useSearchParams } from 'next/navigation'
 
-import { ArrowUpRight } from '@phosphor-icons/react'
+import { ArrowUpRightIcon } from '@phosphor-icons/react'
 
 import { useFilter } from '@filecoin-foundation/hooks/useFilter'
 import {
@@ -155,7 +155,7 @@ export function LearningResourcesContent({
                 href: link,
                 text: 'View Resource',
                 icon: {
-                  component: ArrowUpRight,
+                  component: ArrowUpRightIcon,
                   size: 16,
                   position: 'trailing',
                   weight: 'bold',

--- a/apps/ffdweb-site/src/app/projects/[slug]/page.tsx
+++ b/apps/ffdweb-site/src/app/projects/[slug]/page.tsx
@@ -1,6 +1,6 @@
 import Image from 'next/image'
 
-import { Newspaper } from '@phosphor-icons/react/dist/ssr'
+import { NewspaperIcon } from '@phosphor-icons/react/dist/ssr'
 
 import { ArticleLayout } from '@filecoin-foundation/ui/Article/ArticleLayout'
 import { Heading } from '@filecoin-foundation/ui/Heading'
@@ -84,7 +84,7 @@ export default async function Project(props: ProjectProps) {
               )}
 
               {featuredContent && (
-                <CTALink href={featuredContent} icon={Newspaper}>
+                <CTALink href={featuredContent} icon={NewspaperIcon}>
                   Read Blog Post
                 </CTALink>
               )}

--- a/apps/uxit/src/app/(homepage)/data/homepage.ts
+++ b/apps/uxit/src/app/(homepage)/data/homepage.ts
@@ -1,4 +1,4 @@
-import { ArrowRight } from '@phosphor-icons/react/dist/ssr'
+import { ArrowRightIcon } from '@phosphor-icons/react/dist/ssr'
 
 import { type CardProps } from '@filecoin-foundation/ui/Card/Card'
 import { type ExternalTextLinkProps } from '@filecoin-foundation/ui/TextLink/ExternalTextLink'
@@ -50,7 +50,7 @@ export const homepageCards: HomepageCard[] = [
       text: 'View Reports',
       baseDomain: 'filecoin.org',
       icon: {
-        component: ArrowRight,
+        component: ArrowRightIcon,
         position: 'trailing',
       },
     },

--- a/apps/uxit/src/app/_components/Navigation.tsx
+++ b/apps/uxit/src/app/_components/Navigation.tsx
@@ -1,4 +1,4 @@
-import { GithubLogo } from '@phosphor-icons/react/dist/ssr'
+import { GithubLogoIcon } from '@phosphor-icons/react/dist/ssr'
 
 import { LogoLink } from '@filecoin-foundation/ui/LogoLink'
 
@@ -13,7 +13,7 @@ export function Navigation() {
         aria-label="View project on GitHub"
         className="focus:brand-outline inline-flex items-center gap-2 hover:opacity-80"
       >
-        <GithubLogo size={24} aria-hidden="true" />
+        <GithubLogoIcon size={24} aria-hidden="true" />
         <span className="sr-only">GitHub Repository</span>
       </a>
     </nav>

--- a/apps/uxit/src/app/site-audit-reports/page.tsx
+++ b/apps/uxit/src/app/site-audit-reports/page.tsx
@@ -1,4 +1,4 @@
-import { ArrowRight } from '@phosphor-icons/react/dist/ssr'
+import { ArrowRightIcon } from '@phosphor-icons/react/dist/ssr'
 
 import { CardGrid } from '@filecoin-foundation/ui/CardGrid'
 import { Heading } from '@filecoin-foundation/ui/Heading'
@@ -44,7 +44,7 @@ export default function SiteAuditPage() {
               href: `${PATHS.SITE_AUDIT_REPORTS.path}/${id}/`,
               text: 'View Report',
               icon: {
-                component: ArrowRight,
+                component: ArrowRightIcon,
                 position: 'trailing',
               },
             }}

--- a/packages/ui/src/BreadCrumbs.tsx
+++ b/packages/ui/src/BreadCrumbs.tsx
@@ -2,7 +2,7 @@
 
 import type { Route } from 'next'
 
-import { CaretRight } from '@phosphor-icons/react/dist/ssr'
+import { CaretRightIcon } from '@phosphor-icons/react/dist/ssr'
 import { clsx } from 'clsx'
 import Link from 'next/link'
 import { usePathname } from 'next/navigation'
@@ -40,7 +40,7 @@ export function BreadCrumbs() {
             >
               {!isRoot && (
                 <Icon
-                  component={CaretRight}
+                  component={CaretRightIcon}
                   size={20}
                   color="subtle"
                   weight="bold"

--- a/packages/ui/src/Button.tsx
+++ b/packages/ui/src/Button.tsx
@@ -1,4 +1,4 @@
-import { ArrowUpRight } from '@phosphor-icons/react/dist/ssr'
+import { ArrowUpRightIcon } from '@phosphor-icons/react/dist/ssr'
 import { clsx } from 'clsx'
 
 import { BaseLink, type BaseLinkProps } from '@filecoin-foundation/ui/BaseLink'
@@ -73,7 +73,7 @@ function ButtonInner({
     <>
       {!isExternalLink && Icon && <IconComponent component={Icon} />}
       {children}
-      {isExternalLink && <IconComponent component={ArrowUpRight} size={20} />}
+      {isExternalLink && <IconComponent component={ArrowUpRightIcon} size={20} />}
     </>
   )
 }

--- a/packages/ui/src/Card/CardLink.tsx
+++ b/packages/ui/src/Card/CardLink.tsx
@@ -1,4 +1,4 @@
-import { ArrowUpRight } from '@phosphor-icons/react/dist/ssr'
+import { ArrowUpRightIcon } from '@phosphor-icons/react/dist/ssr'
 
 import { BaseLink } from '@filecoin-foundation/ui/BaseLink'
 import { Icon } from '@filecoin-foundation/ui/Icon'
@@ -37,7 +37,7 @@ function renderCardLinkContent({
 
   if (!icon) {
     return isExternal
-      ? [textElement, <Icon key="arrow" component={ArrowUpRight} />]
+      ? [textElement, <Icon key="arrow" component={ArrowUpRightIcon} />]
       : textElement
   }
 

--- a/packages/ui/src/CopyToClipboard.tsx
+++ b/packages/ui/src/CopyToClipboard.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import { Button } from '@headlessui/react'
-import { Link } from '@phosphor-icons/react/dist/ssr'
+import { LinkIcon } from '@phosphor-icons/react/dist/ssr'
 import * as Sentry from '@sentry/nextjs'
 import { clsx } from 'clsx'
 import { useCopyToClipboard } from 'usehooks-ts'
@@ -70,7 +70,7 @@ export function CopyToClipboard({
           onClick={() => handleCopy(text)}
           aria-label={ariaLabel}
         >
-          <Icon component={Link} size={32} weight="light" />
+          <Icon component={LinkIcon} size={32} weight="light" />
         </Button>
       </Tooltip>
     </>

--- a/packages/ui/src/FilterListbox.tsx
+++ b/packages/ui/src/FilterListbox.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { FunnelSimple } from '@phosphor-icons/react'
+import { FunnelSimpleIcon } from '@phosphor-icons/react'
 
 import { Listbox } from '@filecoin-foundation/ui/Listbox'
 import {
@@ -28,7 +28,7 @@ export function FilterListbox({
   selected,
   options,
   onChange,
-  buttonIcon = FunnelSimple,
+  buttonIcon = FunnelSimpleIcon,
   optionsPosition,
 }: FilterListboxProps) {
   return (

--- a/packages/ui/src/KeyMemberCard.tsx
+++ b/packages/ui/src/KeyMemberCard.tsx
@@ -1,4 +1,4 @@
-import { LinkedinLogo } from '@phosphor-icons/react/dist/ssr'
+import { LinkedinLogoIcon } from '@phosphor-icons/react/dist/ssr'
 import { clsx } from 'clsx'
 import Image from 'next/image'
 
@@ -48,7 +48,7 @@ export function KeyMemberCard({
             className="key-member-card-link focus:brand-outline absolute inset-0"
           >
             <span className="absolute bottom-4 left-36 inline-flex items-center gap-2">
-              <Icon component={LinkedinLogo} />
+              <Icon component={LinkedinLogoIcon} />
               LinkedIn
             </span>
           </a>

--- a/packages/ui/src/Listbox/ListboxButton.tsx
+++ b/packages/ui/src/Listbox/ListboxButton.tsx
@@ -1,5 +1,5 @@
 import { ListboxButton as HeadlessUIListboxButton } from '@headlessui/react'
-import { CaretDown } from '@phosphor-icons/react/dist/ssr'
+import { CaretDownIcon } from '@phosphor-icons/react/dist/ssr'
 import { clsx } from 'clsx'
 
 import { Icon, type IconProps } from '@filecoin-foundation/ui/Icon'
@@ -50,7 +50,7 @@ export function ListboxButton({
         <span className="block truncate pr-6">{text}</span>
 
         <div className="pointer-events-none absolute inset-y-0 right-4 flex items-center">
-          <Icon component={CaretDown} size={16} weight="bold" />
+          <Icon component={CaretDownIcon} size={16} weight="bold" />
         </div>
       </div>
 
@@ -60,7 +60,7 @@ export function ListboxButton({
           compactBelow ? breakpointStyles[compactBelow].compact : 'hidden',
         )}
       >
-        <Icon component={leadingIcon ?? CaretDown} />
+        <Icon component={leadingIcon ?? CaretDownIcon} />
       </div>
     </HeadlessUIListboxButton>
   )

--- a/packages/ui/src/Listbox/ListboxOption.tsx
+++ b/packages/ui/src/Listbox/ListboxOption.tsx
@@ -1,7 +1,7 @@
 import { type ElementType } from 'react'
 
 import { ListboxOption as HeadlessUIListboxOption } from '@headlessui/react'
-import { Check } from '@phosphor-icons/react'
+import { CheckIcon } from '@phosphor-icons/react'
 
 import { Icon } from '@filecoin-foundation/ui/Icon'
 
@@ -35,8 +35,8 @@ export function ListboxOption<Value extends OptionType>({
         )}
       </span>
 
-      <span className="group-data-selected:visible invisible mb-px">
-        <Icon component={Check} size={20} />
+      <span className="invisible mb-px group-data-selected:visible">
+        <Icon component={CheckIcon} size={20} />
       </span>
     </HeadlessUIListboxOption>
   )

--- a/packages/ui/src/NoSearchResultsMessage.tsx
+++ b/packages/ui/src/NoSearchResultsMessage.tsx
@@ -1,4 +1,4 @@
-import { MagnifyingGlass } from '@phosphor-icons/react/dist/ssr'
+import { MagnifyingGlassIcon } from '@phosphor-icons/react/dist/ssr'
 
 import { Button } from '@filecoin-foundation/ui/Button'
 import { NoResultsMessage } from '@filecoin-foundation/ui/NoResultsMessage'
@@ -10,7 +10,7 @@ type NoSearchResultsMessageProps = {
 export function NoSearchResultsMessage({ cta }: NoSearchResultsMessageProps) {
   return (
     <NoResultsMessage
-      icon={MagnifyingGlass}
+      icon={MagnifyingGlassIcon}
       title="No Results Found"
       message="Try changing your search query."
       cta={cta}

--- a/packages/ui/src/NotificationDialog/NotificationDialog.tsx
+++ b/packages/ui/src/NotificationDialog/NotificationDialog.tsx
@@ -5,7 +5,7 @@ import {
   DialogTitle,
   type DialogProps,
 } from '@headlessui/react'
-import { X } from '@phosphor-icons/react/dist/ssr'
+import { XIcon } from '@phosphor-icons/react/dist/ssr'
 import { clsx } from 'clsx'
 
 import { Icon, type IconProps } from '@filecoin-foundation/ui/Icon'
@@ -56,7 +56,7 @@ export function NotificationDialog({
             )}
             aria-label="Close notification"
           >
-            <Icon component={X} size={16} aria-hidden="true" />
+            <Icon component={XIcon} size={16} aria-hidden="true" />
           </CloseButton>
         </DialogPanel>
       </div>

--- a/packages/ui/src/Pagination/Pagination.tsx
+++ b/packages/ui/src/Pagination/Pagination.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { CaretLeft, CaretRight, LineVertical } from '@phosphor-icons/react'
+import { CaretLeftIcon, CaretRightIcon, LineVerticalIcon } from '@phosphor-icons/react'
 import { useQueryState, parseAsInteger } from 'nuqs'
 
 import { Icon } from '@filecoin-foundation/ui/Icon'
@@ -44,12 +44,12 @@ export function Pagination({ pageCount }: PaginationProps) {
           }
           onClick={() => setPage(page - 1)}
         >
-          <Icon component={CaretLeft} size={20} weight="bold" />
+          <Icon component={CaretLeftIcon} size={20} weight="bold" />
           <span className="hidden sm:mx-1.5 sm:inline">Prev</span>
         </button>
 
         <div className="pagination-delimiter flex items-center">
-          <Icon component={LineVertical} weight="light" />
+          <Icon component={LineVerticalIcon} weight="light" />
         </div>
       </div>
 
@@ -80,7 +80,7 @@ export function Pagination({ pageCount }: PaginationProps) {
 
       <div className="flex">
         <div className="pagination-delimiter flex items-center">
-          <Icon component={LineVertical} weight="light" />
+          <Icon component={LineVerticalIcon} weight="light" />
         </div>
 
         <button
@@ -91,7 +91,7 @@ export function Pagination({ pageCount }: PaginationProps) {
           onClick={() => setPage(page + 1)}
         >
           <span className="hidden sm:mx-1.5 sm:inline">Next</span>
-          <Icon component={CaretRight} size={20} weight="bold" />
+          <Icon component={CaretRightIcon} size={20} weight="bold" />
         </button>
       </div>
     </nav>

--- a/packages/ui/src/SearchInput.tsx
+++ b/packages/ui/src/SearchInput.tsx
@@ -1,5 +1,5 @@
 import { Input, Label, Field, Button } from '@headlessui/react'
-import { MagnifyingGlass, X } from '@phosphor-icons/react/dist/ssr'
+import { MagnifyingGlassIcon, XIcon } from '@phosphor-icons/react/dist/ssr'
 
 import { Icon } from '@filecoin-foundation/ui/Icon'
 
@@ -21,7 +21,7 @@ export function SearchInput({ query, onChange }: SearchInputProps) {
           onChange={(event) => onChange(event.target.value)}
         />
         <div className="search-icon peer pointer-events-none absolute inset-y-0 left-0 flex items-center pl-3">
-          <Icon component={MagnifyingGlass} />
+          <Icon component={MagnifyingGlassIcon} />
         </div>
         {query && (
           <Button
@@ -29,7 +29,7 @@ export function SearchInput({ query, onChange }: SearchInputProps) {
             aria-label="Clear search input"
             onClick={() => onChange('')}
           >
-            <Icon component={X} size={16} weight="bold" />
+            <Icon component={XIcon} size={16} weight="bold" />
           </Button>
         )}
       </div>

--- a/packages/ui/src/TextLink/ExternalTextLink.tsx
+++ b/packages/ui/src/TextLink/ExternalTextLink.tsx
@@ -1,4 +1,4 @@
-import { ArrowUpRight } from '@phosphor-icons/react/dist/ssr'
+import { ArrowUpRightIcon } from '@phosphor-icons/react/dist/ssr'
 import { clsx } from 'clsx'
 
 import { Icon } from '@filecoin-foundation/ui/Icon'
@@ -20,7 +20,7 @@ export function ExternalTextLink({
     >
       {children}
       <span className="ml-1 inline-flex self-center">
-        <Icon component={ArrowUpRight} size={16} color="subtle" />
+        <Icon component={ArrowUpRightIcon} size={16} color="subtle" />
       </span>
     </a>
   )

--- a/packages/utils/src/generateShareArticleLinks.ts
+++ b/packages/utils/src/generateShareArticleLinks.ts
@@ -1,8 +1,8 @@
 import {
-  FacebookLogo,
-  LinkedinLogo,
-  RedditLogo,
-  XLogo,
+  FacebookLogoIcon,
+  LinkedinLogoIcon,
+  RedditLogoIcon,
+  XLogoIcon,
 } from '@phosphor-icons/react/dist/ssr'
 
 const PLACEHOLDER_TITLE = 'Explore more on our website!'
@@ -23,22 +23,22 @@ export function generateShareArticleLinks({
 
   const SHARE_SOCIAL_LINKS_CONFIG = [
     {
-      icon: FacebookLogo,
+      icon: FacebookLogoIcon,
       label: 'Facebook',
       href: `https://www.facebook.com/sharer/sharer.php?u=${PLACEHOLDER_URL}&quote=${PLACEHOLDER_TITLE}`,
     },
     {
-      icon: LinkedinLogo,
+      icon: LinkedinLogoIcon,
       label: 'LinkedIn',
       href: `https://www.linkedin.com/shareArticle?mini=true&url=${PLACEHOLDER_URL}&title=${PLACEHOLDER_TITLE}`,
     },
     {
-      icon: RedditLogo,
+      icon: RedditLogoIcon,
       label: 'Reddit',
       href: `https://old.reddit.com/submit?url=${PLACEHOLDER_URL}&title=${PLACEHOLDER_TITLE}`,
     },
     {
-      icon: XLogo,
+      icon: XLogoIcon,
       label: 'X',
       href: `https://twitter.com/share?url=${PLACEHOLDER_URL}&text=${PLACEHOLDER_TITLE}`,
     },


### PR DESCRIPTION
## 📝 Description

Phosphor Icons recently deprecated the old import style. This PR updates all icon imports from  `@phosphor-icons/react` and `@phosphor-icons/react/dist/ssr` to use the new Icon suffix (e.g., `Check` → `CheckIcon`) as required by the latest version.
