### PR TITLE
Make receivedDatacapChange nullable in APIDatacapSchema

### DIFF
--- a/apps/ff-site/src/app/filecoin-plus/allocators/schemas/DatacapSchema.ts
+++ b/apps/ff-site/src/app/filecoin-plus/allocators/schemas/DatacapSchema.ts
@@ -32,7 +32,7 @@ const APIDatacapSchema = z.object({
   issueCreateTimestamp: z.number().nullable(),
   createMessageTimestamp: z.number(),
   verifiedClientsCount: z.number(),
-  receivedDatacapChange: z.string(),
+  receivedDatacapChange: z.string().nullable(),
   allowanceArray: z.array(APIDatacapAllowanceHistorySchema),
   auditStatus: z.string().nullable(),
   remainingDatacap: z.string(),


### PR DESCRIPTION
## 📝 Description

This PR fixes the allocators table by making `receivedDatacapChange` nullable in APIDatacapSchema. This field now appears as nullable in the response from `https://api.datacapstats.io/api/getVerifiers`.