### PR TITLE
[FILECOIN][UXIT-2972] Create Heading Component (skip percy)

### DIFF
--- a/apps/filecoin-site/src/app/(homepage)/page.tsx
+++ b/apps/filecoin-site/src/app/(homepage)/page.tsx
@@ -1,12 +1,17 @@
 import { PageLayout } from '@filecoin-foundation/ui/PageLayout'
 
+import { Title } from '@/components/PageHeader/Title'
+
 export default function Home() {
   return (
     <PageLayout>
       <section>
-        <h1 className="text-brand-500 text-4xl font-bold">Filecoin.io V3</h1>
-        <p className="mt-4 text-lg text-zinc-600">
-          This is the new Filecoin.io website, built with Next.js and Tailwind.
+        <Title backgroundVariant="light">
+          Preserving humanity’s most important information
+        </Title>
+        <p>
+          Keep your data accessible, verifiable, and free from centralized
+          control with the world’s largest decentralized storage network.
         </p>
       </section>
     </PageLayout>

--- a/apps/filecoin-site/src/app/_components/Card.tsx
+++ b/apps/filecoin-site/src/app/_components/Card.tsx
@@ -7,6 +7,7 @@ import type { CTAProps } from '@filecoin-foundation/utils/types/ctaType'
 
 import { BASE_DOMAIN } from '@/constants/siteMetadata'
 
+import { Heading } from './Heading'
 import { IconBadge } from './IconBadge'
 
 type IconPosition = 'top' | 'side'
@@ -15,7 +16,7 @@ type CardProps = {
   as: 'li' | 'article' | 'div'
   title: string
   description: string
-  variant: 'dark' | 'light'
+  backgroundVariant: 'dark' | 'light'
   cta?: CTAProps
   icon?: {
     component: IconProps['component']
@@ -27,11 +28,11 @@ export function Card({
   as: Tag,
   title,
   description,
-  variant,
+  backgroundVariant,
   cta,
   icon,
 }: CardProps) {
-  const styles = getVariantClasses(variant === 'dark')
+  const styles = getVariantClasses(backgroundVariant === 'dark')
 
   return (
     <Tag className={getLayoutClasses(icon)}>
@@ -39,7 +40,13 @@ export function Card({
 
       <div className="space-y-10">
         <div className="space-y-3">
-          <h3 className={clsx('text-xl font-medium', styles.title)}>{title}</h3>
+          <Heading
+            tag="h3"
+            variant="xl-medium"
+            backgroundVariant={backgroundVariant}
+          >
+            {title}
+          </Heading>
           <p className={clsx('text-xl', styles.description)}>{description}</p>
         </div>
 
@@ -66,7 +73,6 @@ export function Card({
 
 function getVariantClasses(isDark: boolean) {
   return {
-    title: isDark ? 'text-white' : 'text-zinc-950',
     description: isDark ? 'text-zinc-400' : 'text-zinc-600',
     ctaText: isDark ? 'text-white' : 'text-zinc-600',
   }

--- a/apps/filecoin-site/src/app/_components/Heading.tsx
+++ b/apps/filecoin-site/src/app/_components/Heading.tsx
@@ -1,17 +1,21 @@
+import { type ComponentPropsWithoutRef } from 'react'
+
 import { clsx } from 'clsx'
 
-export type HeadingProps = {
-  tag: 'h1' | 'h2' | 'h3' | 'h4' | 'h5' | 'h6'
-  variant: '6xl-medium' | '5xl-medium' | 'xl-medium'
+type HeadingTag = 'h1' | 'h2' | 'h3' | 'h4' | 'h5' | 'h6'
+
+export type HeadingProps<T extends HeadingTag = HeadingTag> = {
+  tag: T
+  variant: '6xl-medium' | '5xl-medium' | 'xl-medium' | 'xl-regular'
   backgroundVariant: 'light' | 'dark'
-  className?: string
   children: string
-}
+} & Omit<ComponentPropsWithoutRef<T>, 'children'>
 
 const variantStyles = {
   '6xl-medium': 'text-6xl font-medium',
   '5xl-medium': 'text-5xl font-medium',
   'xl-medium': 'text-xl font-medium',
+  'xl-regular': 'text-xl font-normal',
 }
 
 const colorStyles = {

--- a/apps/filecoin-site/src/app/_components/Heading.tsx
+++ b/apps/filecoin-site/src/app/_components/Heading.tsx
@@ -1,0 +1,38 @@
+import { clsx } from 'clsx'
+
+export type HeadingProps = {
+  tag: 'h1' | 'h2' | 'h3' | 'h4' | 'h5' | 'h6'
+  variant: '6xl-medium' | '5xl-medium' | 'xl-medium'
+  backgroundVariant: 'light' | 'dark'
+  className?: string
+  children: string
+}
+
+const variantStyles = {
+  '6xl-medium': 'text-6xl font-medium',
+  '5xl-medium': 'text-5xl font-medium',
+  'xl-medium': 'text-xl font-medium',
+}
+
+const colorStyles = {
+  light: 'text-zinc-950',
+  dark: 'text-white',
+}
+
+export function Heading({
+  tag,
+  variant,
+  backgroundVariant,
+  className,
+  children,
+}: HeadingProps) {
+  const Tag = tag
+
+  const combinedClassName = clsx(
+    variantStyles[variant],
+    colorStyles[backgroundVariant],
+    className,
+  )
+
+  return <Tag className={combinedClassName}>{children}</Tag>
+}

--- a/apps/filecoin-site/src/app/_components/LogoSection/LogoSection.tsx
+++ b/apps/filecoin-site/src/app/_components/LogoSection/LogoSection.tsx
@@ -1,3 +1,5 @@
+import { Heading } from '@/components/Heading'
+
 import { type LogoItemProps, LogoItem } from './LogoItem'
 
 type LogoSectionProps = {
@@ -9,9 +11,15 @@ export function LogoSection({ logos, title }: LogoSectionProps) {
   return (
     <section aria-labelledby={title ? 'logo-section-title' : undefined}>
       {title && (
-        <h2 id="logo-section-title" className="sr-only">
+        <Heading
+          id="logo-section-title"
+          className="sr-only"
+          tag="h2"
+          variant="xl-regular"
+          backgroundVariant="light"
+        >
           {title}
-        </h2>
+        </Heading>
       )}
       <ul className="flex flex-wrap justify-start gap-x-16 gap-y-10">
         {logos.map((logoItem, index) => (

--- a/apps/filecoin-site/src/app/_components/PageHeader/Title.tsx
+++ b/apps/filecoin-site/src/app/_components/PageHeader/Title.tsx
@@ -1,0 +1,18 @@
+import { Heading } from '@/components/Heading'
+
+type TitleProps = {
+  backgroundVariant: 'light' | 'dark'
+  children: string
+}
+
+export function Title({ backgroundVariant, children }: TitleProps) {
+  return (
+    <Heading
+      tag="h1"
+      variant="5xl-medium"
+      backgroundVariant={backgroundVariant}
+    >
+      {children}
+    </Heading>
+  )
+}

--- a/apps/filecoin-site/src/app/blog/[slug]/page.tsx
+++ b/apps/filecoin-site/src/app/blog/[slug]/page.tsx
@@ -1,5 +1,7 @@
 import { type SlugParams } from '@filecoin-foundation/utils/types/paramsTypes'
 
+import { Title } from '@/components/PageHeader/Title'
+
 type BlogPostProps = {
   params: Promise<SlugParams>
 }
@@ -7,5 +9,5 @@ type BlogPostProps = {
 export default async function BlogPost({ params }: BlogPostProps) {
   const { slug } = await params
 
-  return <h1>Blog Post: {slug}</h1>
+  return <Title backgroundVariant="light">{slug}</Title>
 }

--- a/apps/filecoin-site/src/app/blog/page.tsx
+++ b/apps/filecoin-site/src/app/blog/page.tsx
@@ -1,3 +1,5 @@
+import { Title } from '@/components/PageHeader/Title'
+
 export default function Blog() {
-  return <h1>Blog</h1>
+  return <Title backgroundVariant="light">Blog</Title>
 }

--- a/apps/filecoin-site/src/app/build-on-filecoin/page.tsx
+++ b/apps/filecoin-site/src/app/build-on-filecoin/page.tsx
@@ -1,3 +1,16 @@
+import { Title } from '@/components/PageHeader/Title'
+
 export default function BuildOnFilecoin() {
-  return <h1>Build on Filecoin</h1>
+  return (
+    <section>
+      <Title backgroundVariant="light">
+        Build on Filecoin with programmable storage
+      </Title>
+      <p>
+        Deploy Ethereum-compatible smart contracts on the Filecoin Virtual
+        Machine (FVM) and power dApps with verifiable, persistent data—perfect
+        for AI, cross-chain storage, and storage-native apps.
+      </p>
+    </section>
+  )
 }

--- a/apps/filecoin-site/src/app/learn/page.tsx
+++ b/apps/filecoin-site/src/app/learn/page.tsx
@@ -1,3 +1,5 @@
+import { Title } from '@/components/PageHeader/Title'
+
 export default function Learn() {
-  return <h1>Learn</h1>
+  return <Title backgroundVariant="light">Learn</Title>
 }

--- a/apps/filecoin-site/src/app/offer-storage/page.tsx
+++ b/apps/filecoin-site/src/app/offer-storage/page.tsx
@@ -1,3 +1,9 @@
+import { Title } from '@/components/PageHeader/Title'
+
 export default function OfferStorage() {
-  return <h1>Offer Storage</h1>
+  return (
+    <section className="bg-zinc-950">
+      <Title backgroundVariant="dark">Offer storage</Title>
+    </section>
+  )
 }

--- a/apps/filecoin-site/src/app/privacy-policy/page.tsx
+++ b/apps/filecoin-site/src/app/privacy-policy/page.tsx
@@ -1,3 +1,5 @@
+import { Title } from '@/components/PageHeader/Title'
+
 export default function PrivacyPolicy() {
-  return <h1>Privacy Policy</h1>
+  return <Title backgroundVariant="light">Privacy Policy</Title>
 }

--- a/apps/filecoin-site/src/app/store-data/page.tsx
+++ b/apps/filecoin-site/src/app/store-data/page.tsx
@@ -1,3 +1,14 @@
+import { Title } from '@/components/PageHeader/Title'
+
 export default function StoreData() {
-  return <h1>Store Data</h1>
+  return (
+    <section className="bg-zinc-950">
+      <Title backgroundVariant="dark">
+        Secure, decentralized storage for data that matters
+      </Title>
+      <p>
+        A powerful and dynamic distributed cloud storage network for your data.
+      </p>
+    </section>
+  )
 }

--- a/apps/filecoin-site/src/app/terms-of-use/page.tsx
+++ b/apps/filecoin-site/src/app/terms-of-use/page.tsx
@@ -1,3 +1,5 @@
+import { Title } from '@/components/PageHeader/Title'
+
 export default function TermsOfUse() {
-  return <h1>Terms of Use</h1>
+  return <Title backgroundVariant="light">Terms of Use</Title>
 }


### PR DESCRIPTION
## 📝 Description

Create a `Heading` component for the app with background variant support and clean typography options.

- **Type:** New feature 

## 🛠️ Key Changes

- Create new `Heading` component with `6xl-medium`, `5xl-medium`, and `xl-medium` variants
- Add background variants (`light`/`dark`) with automatic text color adjustment (`zinc-950`/`white`)
- Create page header `Title` component using new `Heading`
- Implement `Title` and `Heading` components across relevant pages
