### PR TITLE
[FILECOIN][UXIT-2942] Use PageHeader Component (skip percy)

### DIFF
--- a/apps/filecoin-site/src/app/(homepage)/page.tsx
+++ b/apps/filecoin-site/src/app/(homepage)/page.tsx
@@ -20,18 +20,17 @@ import { PATHS } from '@/constants/paths'
 import { Button } from '@/components/Button'
 import { Card } from '@/components/Card'
 import { Heading } from '@/components/Heading'
-import { Title } from '@/components/PageHeader/Title'
+import { PageHeader } from '@/components/PageHeader/PageHeader'
 import { PageSection } from '@/components/PageSection'
 
 export default function Home() {
   return (
     <>
       <PageSection backgroundVariant="transparent">
-        <Title>Preserving humanity's most important information</Title>
-        <DescriptionText>
-          Keep your data accessible, verifiable, and free from centralized
-          control with the world's largest decentralized storage network.
-        </DescriptionText>
+        <PageHeader
+          description="Keep your data accessible, verifiable, and free from centralized control with the world's largest decentralized storage network."
+          title="Preserving humanity's most important information"
+        />
         <CardGrid as="ul" cols="lgThree">
           <Card
             as="li"

--- a/apps/filecoin-site/src/app/build-on-filecoin/page.tsx
+++ b/apps/filecoin-site/src/app/build-on-filecoin/page.tsx
@@ -4,7 +4,7 @@ import { DescriptionText } from '@filecoin-foundation/ui/DescriptionText'
 import { Button } from '@/components/Button'
 import { Card } from '@/components/Card'
 import { Heading } from '@/components/Heading'
-import { Title } from '@/components/PageHeader/Title'
+import { PageHeader } from '@/components/PageHeader/PageHeader'
 import { PageSection } from '@/components/PageSection'
 
 import { blockExplorers } from './data/blockExplorers'
@@ -18,21 +18,21 @@ import { getInvolvedOptions } from './data/getInvolvedOptions'
 export default function BuildOnFilecoin() {
   return (
     <>
-      {' '}
       <PageSection backgroundVariant="dark">
-        <Title>Build on Filecoin with programmable storage</Title>
-
-        <DescriptionText>
-          Build on Filecoin — the programmable, permissionless storage network
+        <PageHeader
+          title="Build on Filecoin with programmable storage"
+          description="Build on Filecoin — the programmable, permissionless storage network
           with cryptographic verification and global redundancy by design.
           Integrate storage that safeguards data integrity at every layer and
-          scales with your application's needs.
-        </DescriptionText>
-
-        <Button href="" variant="primaryDark">
-          Explore documentation
-        </Button>
+          scales with your application's needs."
+          cta={
+            <Button href="" variant="primaryDark">
+              Explore documentation
+            </Button>
+          }
+        />
       </PageSection>
+
       <PageSection backgroundVariant="dark">
         <Heading tag="h2" variant="6xl-medium">
           Beyond storage, a foundation for next-gen applications

--- a/apps/filecoin-site/src/app/learn/page.tsx
+++ b/apps/filecoin-site/src/app/learn/page.tsx
@@ -6,7 +6,7 @@ import { PATHS } from '@/constants/paths'
 import { Button } from '@/components/Button'
 import { Card } from '@/components/Card'
 import { Heading } from '@/components/Heading'
-import { Title } from '@/components/PageHeader/Title'
+import { PageHeader } from '@/components/PageHeader/PageHeader'
 import { PageSection } from '@/components/PageSection'
 
 import { ComparisonTable } from './components/ComparisonTable'
@@ -15,23 +15,22 @@ import { filecoinParticipants } from './data/filecoinParticipants'
 import { filecoinStackFeatures } from './data/filecoinStackFeatures'
 import { filecoinStorageFlow } from './data/filecoinStorageFlow'
 import { filecoinValues } from './data/filecoinValues'
-// import { filecoinVsCloudComparison } from './data/filecoinVsCloudComparison'
 
 export default function Learn() {
   return (
     <>
       <PageSection backgroundVariant="dark">
-        <Title>A decentralized storage network for humanity's data</Title>
-
-        <DescriptionText>
-          Filecoin is a protocol, economy, and community powering the world's
+        <PageHeader
+          title="A decentralized storage network for humanity's data"
+          description="Filecoin is a protocol, economy, and community powering the world's
           largest open storage network. It enables anyone to store, retrieve,
-          and build on verifiable data — securely and at scale.
-        </DescriptionText>
-
-        <Button href="" variant="primaryDark">
-          Explore documentation
-        </Button>
+          and build on verifiable data — securely and at scale."
+          cta={
+            <Button href="" variant="primaryDark">
+              Explore documentation
+            </Button>
+          }
+        />
       </PageSection>
 
       <PageSection backgroundVariant="dark">

--- a/apps/filecoin-site/src/app/offer-storage/page.tsx
+++ b/apps/filecoin-site/src/app/offer-storage/page.tsx
@@ -1,10 +1,19 @@
-import { Title } from '@/components/PageHeader/Title'
+import { Button } from '@/components/Button'
+import { PageHeader } from '@/components/PageHeader/PageHeader'
 import { PageSection } from '@/components/PageSection'
 
 export default function OfferStorage() {
   return (
     <PageSection backgroundVariant="dark">
-      <Title>Offer storage</Title>
+      <PageHeader
+        title="Join the world's largest decentralized storage network"
+        description="Become a Filecoin storage provider and contribute capacity to a global system preserving humanity's most important data. If you've got the infrastructure, you can become a core part of it."
+        cta={
+          <Button href="" variant="primaryDark">
+            Check requirements
+          </Button>
+        }
+      />
     </PageSection>
   )
 }

--- a/apps/filecoin-site/src/app/privacy-policy/page.tsx
+++ b/apps/filecoin-site/src/app/privacy-policy/page.tsx
@@ -1,10 +1,10 @@
-import { Title } from '@/components/PageHeader/Title'
+import { PageHeader } from '@/components/PageHeader/PageHeader'
 import { PageSection } from '@/components/PageSection'
 
 export default function PrivacyPolicy() {
   return (
     <PageSection backgroundVariant="light">
-      <Title>Privacy Policy</Title>
+      <PageHeader title="Privacy Policy" />
     </PageSection>
   )
 }

--- a/apps/filecoin-site/src/app/store-data/page.tsx
+++ b/apps/filecoin-site/src/app/store-data/page.tsx
@@ -5,7 +5,7 @@ import { Button } from '@/components/Button'
 import { Card } from '@/components/Card'
 import { Heading } from '@/components/Heading'
 import { LogoSection } from '@/components/LogoSection/LogoSection'
-import { Title } from '@/components/PageHeader/Title'
+import { PageHeader } from '@/components/PageHeader/PageHeader'
 import { PageSection } from '@/components/PageSection'
 
 import { filecoinFeatures } from './data/filecoinFeatures'
@@ -16,16 +16,15 @@ export default function StoreData() {
   return (
     <>
       <PageSection backgroundVariant="dark">
-        <Title>Secure, decentralized storage for data that matters</Title>
-
-        <DescriptionText>
-          A powerful and dynamic distributed cloud storage network for your
-          data.
-        </DescriptionText>
-
-        <Button href="" variant="primaryDark">
-          Explore storage solutions
-        </Button>
+        <PageHeader
+          title="Secure, decentralized storage for data that matters"
+          description="A powerful and dynamic distributed cloud storage network for your data."
+          cta={
+            <Button href="" variant="primaryDark">
+              Explore storage solutions
+            </Button>
+          }
+        />
       </PageSection>
 
       <PageSection backgroundVariant="dark">

--- a/apps/filecoin-site/src/app/terms-of-use/page.tsx
+++ b/apps/filecoin-site/src/app/terms-of-use/page.tsx
@@ -1,10 +1,10 @@
-import { Title } from '@/components/PageHeader/Title'
+import { PageHeader } from '@/components/PageHeader/PageHeader'
 import { PageSection } from '@/components/PageSection'
 
 export default function TermsOfUse() {
   return (
     <PageSection backgroundVariant="light">
-      <Title>Terms of Use</Title>
+      <PageHeader title="Terms of Use" />
     </PageSection>
   )
 }


### PR DESCRIPTION
## 📝 Description
This pull request refactors multiple pages across the Filecoin site to replace the `Title` and `DescriptionText` components with our `PageHeader` component. The changes streamline the codebase by consolidating page header functionality into a single component, enhancing consistency and maintainability.
