### PR TITLE
[FILECOIN][UXIT-2997] Create SectionDivider Component [skip percy]

### DIFF
--- a/apps/filecoin-site/src/app/_components/Footer/Footer.tsx
+++ b/apps/filecoin-site/src/app/_components/Footer/Footer.tsx
@@ -1,5 +1,6 @@
 import { Container } from '@/components/Container'
 import { Section } from '@/components/Section'
+import { SectionDivider } from '@/components/SectionDivider'
 
 import { FooterLogo } from './FooterLogo'
 import { LegalSection } from './LegalSection'
@@ -23,7 +24,7 @@ export function Footer() {
         </div>
       </Container>
 
-      <hr className="border-zinc-400/10" />
+      <SectionDivider variant="subtle" />
 
       <Container>
         <LegalSection />

--- a/apps/filecoin-site/src/app/_components/SectionDivider.tsx
+++ b/apps/filecoin-site/src/app/_components/SectionDivider.tsx
@@ -1,0 +1,13 @@
+type SectionDividerProps = {
+  variant: 'light' | 'subtle'
+}
+
+const styles = {
+  light: 'border-zinc-200',
+  subtle: 'border-zinc-400/10',
+  dark: 'border-zinc-950/10',
+}
+
+export function SectionDivider({ variant }: SectionDividerProps) {
+  return <hr className={styles[variant]} />
+}

--- a/apps/filecoin-site/src/app/_components/SectionDivider.tsx
+++ b/apps/filecoin-site/src/app/_components/SectionDivider.tsx
@@ -1,5 +1,5 @@
 type SectionDividerProps = {
-  variant: 'light' | 'subtle'
+  variant: keyof typeof styles
 }
 
 const styles = {

--- a/apps/filecoin-site/src/app/build-on-filecoin/page.tsx
+++ b/apps/filecoin-site/src/app/build-on-filecoin/page.tsx
@@ -6,6 +6,7 @@ import { Card } from '@/components/Card'
 import { Heading } from '@/components/Heading'
 import { PageHeader } from '@/components/PageHeader/PageHeader'
 import { PageSection } from '@/components/PageSection'
+import { SectionDivider } from '@/components/SectionDivider'
 
 import { blockExplorers } from './data/blockExplorers'
 import { communityConnections } from './data/communityConnections'
@@ -90,7 +91,7 @@ export default function BuildOnFilecoin() {
             </CardGrid>
           </div>
 
-          <hr />
+          <SectionDivider variant="dark" />
 
           <div className="flex flex-col gap-20">
             <Heading tag="h3" variant="3xl-medium">
@@ -114,7 +115,7 @@ export default function BuildOnFilecoin() {
             </CardGrid>
           </div>
 
-          <hr />
+          <SectionDivider variant="dark" />
 
           <div className="flex flex-col gap-20">
             <div>

--- a/apps/filecoin-site/src/app/learn/components/ComparisonTable.tsx
+++ b/apps/filecoin-site/src/app/learn/components/ComparisonTable.tsx
@@ -13,6 +13,7 @@ import {
   filecoinVsCloudComparison,
   type ComparisonRow,
 } from '../data/filecoinVsCloudComparison'
+
 import { IconBadge } from '@/_components/IconBadge'
 
 type ComparisonCell = boolean | 'limited'

--- a/apps/filecoin-site/src/app/learn/page.tsx
+++ b/apps/filecoin-site/src/app/learn/page.tsx
@@ -8,6 +8,7 @@ import { Card } from '@/components/Card'
 import { Heading } from '@/components/Heading'
 import { PageHeader } from '@/components/PageHeader/PageHeader'
 import { PageSection } from '@/components/PageSection'
+import { SectionDivider } from '@/components/SectionDivider'
 
 import { ComparisonTable } from './components/ComparisonTable'
 import { ecosystemPartners } from './data/ecosystemPartners'
@@ -97,7 +98,7 @@ export default function Learn() {
                 How Filecoin works
               </Heading>
               <DescriptionText>
-                Imagine you have a file that you want to store. Here’s how
+                Imagine you have a file that you want to store. Here's how
                 Filecoin makes that possible:
               </DescriptionText>
             </div>
@@ -114,7 +115,7 @@ export default function Learn() {
             </ul>
           </div>
 
-          <hr className="border-zinc-400" />
+          <SectionDivider variant="light" />
 
           <div>
             <div>


### PR DESCRIPTION
## 📝 Description

This pull request introduces a reusable `SectionDivider` component to replace hardcoded `<hr>` elements across multiple pages in the Filecoin site. The changes improve code consistency and maintainability while introducing styling variants for different use cases. 