### PR TITLE
Remove tracking wide from site layout

### DIFF
--- a/apps/filecoin-site/src/app/_components/SiteLayout.tsx
+++ b/apps/filecoin-site/src/app/_components/SiteLayout.tsx
@@ -17,7 +17,7 @@ type SiteLayoutProps = {
 export function SiteLayout({ children }: SiteLayoutProps) {
   return (
     <html lang="en" className={inter.className}>
-      <body className="flex min-h-screen flex-col bg-white tracking-wide text-zinc-900">
+      <body className="flex min-h-screen flex-col bg-white text-zinc-900">
         <Navigation />
         <main className="flex-1">{children}</main>
         <Footer />


### PR DESCRIPTION
## 📝 Description

This PR removes the `tracking-wide` class from the site layout.