### PR TITLE
[FILECOIN][UXIT-2934] Add Text Link Style

### DIFF
--- a/apps/ff-site/src/app/_styles/globals.css
+++ b/apps/ff-site/src/app/_styles/globals.css
@@ -366,7 +366,7 @@
 
   /* TEXT LINKS */
   .text-link {
-    @apply text-brand-300! focus:brand-outline! font-normal! no-underline! hover:underline!;
+    @apply text-brand-300 focus:brand-outline no-underline hover:underline;
   }
 
   /* TOC */

--- a/apps/ffdweb-site/src/app/_styles/globals.css
+++ b/apps/ffdweb-site/src/app/_styles/globals.css
@@ -346,7 +346,7 @@
 
   /* TEXT LINKS */
   .text-link {
-    @apply text-brand-primary-300! hover:text-brand-primary-500! focus:brand-outline! no-underline! hover:underline!;
+    @apply text-brand-primary-300 hover:text-brand-primary-500 focus:brand-outline no-underline hover:underline;
   }
 
   /* TOOLTIP */

--- a/apps/filecoin-site/src/app/_styles/globals.css
+++ b/apps/filecoin-site/src/app/_styles/globals.css
@@ -155,6 +155,11 @@
     @apply bg-white;
   }
 
+  /* TEXT LINKS */
+  .text-link {
+    @apply focus:brand-outline text-brand-800 font-normal no-underline hover:underline;
+  }
+
   /* TOOLTIP */
   .tooltip {
     @apply rounded-xl border border-zinc-200 bg-white text-zinc-950 shadow-sm;

--- a/apps/uxit/src/app/_styles/globals.css
+++ b/apps/uxit/src/app/_styles/globals.css
@@ -28,6 +28,6 @@
 
   /* TEXT LINKS */
   .text-link {
-    @apply focus:brand-outline! font-normal! text-indigo-500! no-underline! hover:text-indigo-800! hover:underline!;
+    @apply focus:brand-outline font-normal text-indigo-500 no-underline hover:text-indigo-800 hover:underline;
   }
 }

--- a/packages/ui/src/Markdown/MarkdownLink.tsx
+++ b/packages/ui/src/Markdown/MarkdownLink.tsx
@@ -1,6 +1,7 @@
 import type { ComponentPropsWithoutRef } from 'react'
 
 import * as Sentry from '@sentry/node'
+import { clsx } from 'clsx'
 
 import { SmartTextLink } from '../TextLink/SmartTextLink'
 
@@ -12,6 +13,7 @@ export function MarkdownLink({
   href,
   children,
   baseDomain,
+  className,
   ...props
 }: MarkdownLinkProps) {
   if (!href) {
@@ -27,9 +29,10 @@ export function MarkdownLink({
     <SmartTextLink
       href={href}
       baseDomain={baseDomain}
+      className={clsx('not-prose', className)}
       {...props}
     >
       {children}
     </SmartTextLink>
   )
-} 
+}


### PR DESCRIPTION
## 📝 Description

This PR adds styling to text links and removes the `prose` styling from the markdown text links, to avoid forcing all the styles using `!important` in the Markdown component.