### PR TITLE
Fix: Correct text link color on blog posts

### DIFF
--- a/apps/filecoin-site/src/app/_styles/globals.css
+++ b/apps/filecoin-site/src/app/_styles/globals.css
@@ -243,7 +243,16 @@
 
   /* TEXT LINKS */
   .text-link {
-    @apply focus:brand-outline text-brand-800 font-normal no-underline hover:underline;
+    @apply focus:brand-outline font-normal no-underline hover:underline;
+
+    .light-section &,
+    .gray-section & {
+      @apply text-brand-800;
+    }
+
+    .dark-section & {
+      @apply text-zinc-400;
+    }
   }
 
   /* TOOLTIP */

--- a/apps/filecoin-site/src/app/blog/[slug]/page.tsx
+++ b/apps/filecoin-site/src/app/blog/[slug]/page.tsx
@@ -1,6 +1,7 @@
 import { type SlugParams } from '@filecoin-foundation/utils/types/paramsTypes'
 
 import { MarkdownContent } from '@/components/MarkdownContent'
+import { Section } from '@/components/Section'
 
 import { BlogPostContainer } from '../components/BlogPostContainer'
 import { BlogPostHeader } from '../components/BlogPostHeader'
@@ -19,19 +20,21 @@ export default async function BlogPost({ params }: BlogPostProps) {
   const { image, categories, author, publishedOn, title, content } = data
 
   return (
-    <div className="space-y-8 pb-30">
-      <BlogPostHeader
-        image={{ url: image?.url || headerImage.src }}
-        categories={categories}
-        author={author}
-        date={publishedOn}
-        title={title}
-        slug={slug}
-      />
+    <Section backgroundVariant="light">
+      <div className="space-y-8 pb-30">
+        <BlogPostHeader
+          image={{ url: image?.url || headerImage.src }}
+          categories={categories}
+          author={author}
+          date={publishedOn}
+          title={title}
+          slug={slug}
+        />
 
-      <BlogPostContainer>
-        <MarkdownContent>{content}</MarkdownContent>
-      </BlogPostContainer>
-    </div>
+        <BlogPostContainer>
+          <MarkdownContent>{content}</MarkdownContent>
+        </BlogPostContainer>
+      </div>
+    </Section>
   )
 }


### PR DESCRIPTION
The global `.text-link` style has been updated to be context-aware, applying different colors for light and dark section backgrounds. This resolves an issue where links in the footer had the wrong color.

The blog post page is now wrapped in a `Section` component with a light background variant to ensure links are styled correctly and are clearly visible.

## 📝 Description

Please include a summary of the changes. Provide context and motivation for the change, and describe what problem it solves.

- **Type:** Bug fix / New feature / Documentation / Refactor

## 🛠️ Key Changes

- [Change 1 - Brief description]
- [Change 2 - Brief description]
- ...

## 📌 To-Do Before Merging

- [ ] [Task 1 - Brief description]
- [ ] [Task 2 - Brief description]
- ...

## 🧪 How to Test

- **Setup:** [Setup details]
- **Steps to Test:**
  1. [Step 1 - Brief description]
  2. [Step 2 - Brief description]
  3. ...
- **Expected Results:** [Outcome]
- **Additional Notes:** [Additional info]

## 📸 Screenshots

Attach if there are UI changes.

## 🔖 Resources

Feel free to share any references to documentation, libraries, blog posts, or other resources that you consulted or used during the implementation of the changes.

- [Resource 1]
- [Resource 2]
- ...
