### PR TITLE
[UXIT-3032] Add SectionSubContent component

### DIFF
--- a/apps/filecoin-site/src/app/_components/Footer/Footer.tsx
+++ b/apps/filecoin-site/src/app/_components/Footer/Footer.tsx
@@ -24,7 +24,7 @@ export function Footer() {
         </div>
       </Container>
 
-      <SectionDivider variant="subtle" />
+      <SectionDivider />
 
       <Container>
         <LegalSection />

--- a/apps/filecoin-site/src/app/_components/SectionContent.tsx
+++ b/apps/filecoin-site/src/app/_components/SectionContent.tsx
@@ -1,7 +1,5 @@
 import { clsx } from 'clsx'
 
-import { DescriptionText } from '@filecoin-foundation/ui/DescriptionText'
-
 import { ButtonRow, type ButtonRowProps } from '@/components/ButtonRow'
 import { Heading, type HeadingProps } from '@/components/Heading'
 
@@ -27,9 +25,9 @@ export function SectionContent({
           {title}
         </Heading>
         {description && (
-          <div className="pt-6 text-xl leading-8 font-normal text-balance">
-            <DescriptionText>{description}</DescriptionText>
-          </div>
+          <p className="pt-6 text-xl leading-8 font-normal text-balance">
+            {description}
+          </p>
         )}
       </div>
       {children && <div className="mt-30 flex flex-col gap-30">{children}</div>}

--- a/apps/filecoin-site/src/app/_components/SectionDivider.tsx
+++ b/apps/filecoin-site/src/app/_components/SectionDivider.tsx
@@ -1,13 +1,3 @@
-type SectionDividerProps = {
-  variant: keyof typeof styles
-}
-
-const styles = {
-  light: 'border-zinc-200',
-  subtle: 'border-zinc-400/10',
-  dark: 'border-zinc-950/10',
-}
-
-export function SectionDivider({ variant }: SectionDividerProps) {
-  return <hr className={styles[variant]} />
+export function SectionDivider() {
+  return <hr className="section-divider" />
 }

--- a/apps/filecoin-site/src/app/_components/SectionSubContent.tsx
+++ b/apps/filecoin-site/src/app/_components/SectionSubContent.tsx
@@ -1,0 +1,33 @@
+import { Heading, type HeadingProps } from '@/components/Heading'
+
+type SectionSubContentProps = {
+  title: HeadingProps['children']
+  description?: string
+  children?: React.ReactNode
+}
+
+export function SectionSubContent({
+  title,
+  description,
+  children,
+}: SectionSubContentProps) {
+  return (
+    <div>
+      <div className="max-w-3xl">
+        <Heading
+          tag="h2"
+          variant="3xl-medium"
+          className="section-sub-content-heading-text"
+        >
+          {title}
+        </Heading>
+        {description && (
+          <p className="section-sub-content-description-text pt-6 text-lg leading-6 font-normal text-balance">
+            {description}
+          </p>
+        )}
+      </div>
+      {children && <div className="mt-20">{children}</div>}
+    </div>
+  )
+}

--- a/apps/filecoin-site/src/app/_components/SectionSubContent.tsx
+++ b/apps/filecoin-site/src/app/_components/SectionSubContent.tsx
@@ -1,19 +1,24 @@
+import { ButtonRow, type ButtonRowProps } from '@/components/ButtonRow'
 import { Heading, type HeadingProps } from '@/components/Heading'
 
 type SectionSubContentProps = {
   title: HeadingProps['children']
   description?: string
   children?: React.ReactNode
+  cta?: ButtonRowProps['buttons']
+  centerCTA?: ButtonRowProps['centered']
 }
 
 export function SectionSubContent({
   title,
   description,
   children,
+  cta,
+  centerCTA,
 }: SectionSubContentProps) {
   return (
-    <div>
-      <div className="max-w-3xl">
+    <div className="space-y-20">
+      <div className="max-w-2xl">
         <Heading
           tag="h2"
           variant="3xl-medium"
@@ -27,7 +32,12 @@ export function SectionSubContent({
           </p>
         )}
       </div>
-      {children && <div className="mt-20">{children}</div>}
+      {children}
+      {cta && (
+        <div className="mt-20">
+          <ButtonRow buttons={cta} centered={centerCTA} />
+        </div>
+      )}
     </div>
   )
 }

--- a/apps/filecoin-site/src/app/_styles/globals.css
+++ b/apps/filecoin-site/src/app/_styles/globals.css
@@ -206,6 +206,29 @@
     }
   }
 
+  /* SECTION SUB CONTENT */
+  .section-sub-content-heading-text {
+    .light-section &,
+    .gray-section & {
+      @apply text-zinc-950;
+    }
+
+    .dark-section & {
+      @apply text-zinc-50;
+    }
+  }
+
+  .section-sub-content-description-text {
+    .light-section &,
+    .gray-section & {
+      @apply text-zinc-600;
+    }
+
+    .dark-section & {
+      @apply text-zinc-400;
+    }
+  }
+
   /* SHARE ARTICLE */
   .share-article-list {
     @apply gap-4;

--- a/apps/filecoin-site/src/app/_styles/globals.css
+++ b/apps/filecoin-site/src/app/_styles/globals.css
@@ -237,7 +237,7 @@
     }
 
     .dark-section & {
-      @apply border-zinc-400/10;
+      @apply border-zinc-400/20;
     }
   }
 

--- a/apps/filecoin-site/src/app/_styles/globals.css
+++ b/apps/filecoin-site/src/app/_styles/globals.css
@@ -229,6 +229,18 @@
     }
   }
 
+  /* SECTION DIVIDER */
+  .section-divider {
+    .light-section &,
+    .gray-section & {
+      @apply border-zinc-200;
+    }
+
+    .dark-section & {
+      @apply border-zinc-400/10;
+    }
+  }
+
   /* SHARE ARTICLE */
   .share-article-list {
     @apply gap-4;

--- a/apps/filecoin-site/src/app/blog/components/BlogPostHeader.tsx
+++ b/apps/filecoin-site/src/app/blog/components/BlogPostHeader.tsx
@@ -55,7 +55,7 @@ export function BlogPostHeader({
           />
         </div>
 
-        <SectionDivider variant="light" />
+        <SectionDivider />
 
         <div className="mt-16 mb-8">
           <PostMetadata author={author} date={date} />

--- a/apps/filecoin-site/src/app/build-on-filecoin/page.tsx
+++ b/apps/filecoin-site/src/app/build-on-filecoin/page.tsx
@@ -1,15 +1,13 @@
-import { DescriptionText } from '@filecoin-foundation/ui/DescriptionText'
-
 import { Button } from '@/components/Button'
 import { Card } from '@/components/Card'
 import { CardGrid } from '@/components/CardGrid'
 import { CardGridContainer } from '@/components/CardGridContainer'
-import { Heading } from '@/components/Heading'
 import { LinkCard } from '@/components/LinkCard'
 import { PageHeader } from '@/components/PageHeader'
 import { PageSection } from '@/components/PageSection'
 import { SectionContent } from '@/components/SectionContent'
 import { SectionDivider } from '@/components/SectionDivider'
+import { SectionSubContent } from '@/components/SectionSubContent'
 import { SimpleCard } from '@/components/SimpleCard'
 
 import { blockExplorers } from './data/blockExplorers'
@@ -64,81 +62,64 @@ export default function BuildOnFilecoin() {
           title="Useful tools for builders"
           description="Accelerate development with Filecoin's ecosystem tools."
         >
-          <div className="space-y-30">
-            <div className="flex flex-col gap-20">
-              <Heading tag="h3" variant="3xl-medium">
-                Getting stared
-              </Heading>
-
-              <CardGrid as="ul" variant="smTwoLgThree">
-                {filecoinTools.map(
-                  ({ title, description, difficulty, cta }, index) => (
-                    <SimpleCard
-                      key={title}
-                      title={title}
-                      description={description}
-                      cta={cta}
-                      gradientHeaderAndBadge={{
-                        gradientIndex: index,
-                        badgeText: difficulty,
-                      }}
-                    />
-                  ),
-                )}
-              </CardGrid>
-            </div>
-
-            <SectionDivider />
-
-            <div className="flex flex-col gap-20">
-              <Heading tag="h3" variant="3xl-medium">
-                Developer resources
-              </Heading>
-
-              <CardGridContainer width="6xl">
-                <CardGrid as="ul" variant="mdTwo">
-                  {developerResources.map(
-                    ({ title, description, href, icon }) => (
-                      <LinkCard
-                        key={title}
-                        as="li"
-                        backgroundVariant="light"
-                        title={title}
-                        description={description}
-                        href={href}
-                        icon={icon}
-                      />
-                    ),
-                  )}
-                </CardGrid>
-              </CardGridContainer>
-            </div>
-
-            <SectionDivider />
-
-            <div className="flex flex-col gap-20">
-              <div>
-                <Heading tag="h3" variant="3xl-medium">
-                  Block explorers
-                </Heading>
-                <DescriptionText>
-                  Track transactions, contracts, and onchain activity with
-                  Filecoin-compatible block explorers.
-                </DescriptionText>
-              </div>
-
-              <CardGrid as="ul" variant="smTwoLgThree">
-                {blockExplorers.map(({ title, description, cta }) => (
+          <SectionSubContent title="Getting stared">
+            <CardGrid as="ul" variant="smTwoLgThree">
+              {filecoinTools.map(
+                ({ title, description, difficulty, cta }, index) => (
                   <SimpleCard
                     key={title}
                     title={title}
                     description={description}
                     cta={cta}
+                    gradientHeaderAndBadge={{
+                      gradientIndex: index,
+                      badgeText: difficulty,
+                    }}
                   />
-                ))}
+                ),
+              )}
+            </CardGrid>
+          </SectionSubContent>
+
+          <SectionDivider />
+
+          <SectionSubContent title="Developer resources">
+            <CardGridContainer width="6xl">
+              <CardGrid as="ul" variant="mdTwo">
+                {developerResources.map(
+                  ({ title, description, href, icon }) => (
+                    <LinkCard
+                      key={title}
+                      as="li"
+                      backgroundVariant="light"
+                      title={title}
+                      description={description}
+                      href={href}
+                      icon={icon}
+                    />
+                  ),
+                )}
               </CardGrid>
-            </div>
-          </div>
+            </CardGridContainer>
+          </SectionSubContent>
+
+          <SectionDivider />
+
+          <SectionSubContent
+            title="Block explorers"
+            description="Track transactions, contracts, and onchain activity with Filecoin-compatible block explorers."
+          >
+            <CardGrid as="ul" variant="smTwoLgThree">
+              {blockExplorers.map(({ title, description, cta }) => (
+                <SimpleCard
+                  key={title}
+                  title={title}
+                  description={description}
+                  cta={cta}
+                />
+              ))}
+            </CardGrid>
+          </SectionSubContent>
         </SectionContent>
       </PageSection>
 

--- a/apps/filecoin-site/src/app/build-on-filecoin/page.tsx
+++ b/apps/filecoin-site/src/app/build-on-filecoin/page.tsx
@@ -88,7 +88,7 @@ export default function BuildOnFilecoin() {
               </CardGrid>
             </div>
 
-            <SectionDivider variant="dark" />
+            <SectionDivider />
 
             <div className="flex flex-col gap-20">
               <Heading tag="h3" variant="3xl-medium">
@@ -114,7 +114,7 @@ export default function BuildOnFilecoin() {
               </CardGridContainer>
             </div>
 
-            <SectionDivider variant="dark" />
+            <SectionDivider />
 
             <div className="flex flex-col gap-20">
               <div>

--- a/apps/filecoin-site/src/app/learn/page.tsx
+++ b/apps/filecoin-site/src/app/learn/page.tsx
@@ -107,7 +107,15 @@ export default function Learn() {
       </PageSection>
 
       <PageSection backgroundVariant="light">
-        <SectionDivider variant="light" />
+        <SectionDivider />
+
+        <Heading tag="h3" variant="3xl-medium">
+          The Filecoin ecosystem
+        </Heading>
+        <DescriptionText>
+          Storing a file on Filecoin involves several participants working
+          together.
+        </DescriptionText>
 
         <Heading tag="h3" variant="3xl-medium">
           The Filecoin ecosystem

--- a/apps/filecoin-site/src/app/learn/page.tsx
+++ b/apps/filecoin-site/src/app/learn/page.tsx
@@ -10,6 +10,7 @@ import { PageHeader } from '@/components/PageHeader'
 import { PageSection } from '@/components/PageSection'
 import { SectionContent } from '@/components/SectionContent'
 import { SectionDivider } from '@/components/SectionDivider'
+import { SectionSubContent } from '@/components/SectionSubContent'
 import { SimpleCard } from '@/components/SimpleCard'
 import { SplitSectionContent } from '@/components/SplitSectionContent'
 
@@ -80,67 +81,55 @@ export default function Learn() {
       </PageSection>
 
       <PageSection backgroundVariant="light">
-        <SectionContent
-          centerCTA
-          title="How Filecoin works"
-          description="How data gets stored on Filecoin"
-          cta={
-            <Button href="" variant="primary">
-              Find storage solutions
-            </Button>
-          }
-        >
-          <CardGrid as="ul" variant="smTwoXlThreeWidest">
-            {filecoinStorageFlow.map(({ step, title, description }) => (
-              <li key={description} className="flex flex-col gap-3">
-                <span className="text-brand-500 text-4xl font-medium">
-                  {`0${step}.`}
-                </span>
-                <Heading tag="h4" variant="xl-medium">
-                  {title}
-                </Heading>
-                <DescriptionText>{description}</DescriptionText>
-              </li>
-            ))}
-          </CardGrid>
+        <SectionContent title="How Filecoin works">
+          <SectionSubContent
+            centerCTA
+            title="How data gets stored on Filecoin"
+            cta={
+              <Button href="" variant="primary">
+                Find storage solutions
+              </Button>
+            }
+          >
+            <CardGrid as="ul" variant="smTwoXlThreeWidest">
+              {filecoinStorageFlow.map(({ step, title, description }) => (
+                <li key={description} className="flex flex-col gap-3">
+                  <span className="text-brand-500 text-4xl font-medium">
+                    {`0${step}.`}
+                  </span>
+                  <Heading tag="h4" variant="xl-medium">
+                    {title}
+                  </Heading>
+                  <DescriptionText>{description}</DescriptionText>
+                </li>
+              ))}
+            </CardGrid>
+          </SectionSubContent>
+
+          <SectionDivider />
+
+          <SectionSubContent
+            title="The Filecoin ecosystem"
+            description="Storing a file on Filecoin involves several participants working together."
+          >
+            <CardGrid as="ul" variant="smTwoLgThreeWider">
+              {filecoinParticipants.map(({ title, description, cta }) => (
+                <SimpleCard
+                  key={title}
+                  hasTopBorder
+                  title={title}
+                  description={description}
+                  cta={cta}
+                />
+              ))}
+            </CardGrid>
+          </SectionSubContent>
         </SectionContent>
-      </PageSection>
-
-      <PageSection backgroundVariant="light">
-        <SectionDivider />
-
-        <Heading tag="h3" variant="3xl-medium">
-          The Filecoin ecosystem
-        </Heading>
-        <DescriptionText>
-          Storing a file on Filecoin involves several participants working
-          together.
-        </DescriptionText>
-
-        <Heading tag="h3" variant="3xl-medium">
-          The Filecoin ecosystem
-        </Heading>
-        <DescriptionText>
-          Storing a file on Filecoin involves several participants working
-          together.
-        </DescriptionText>
-
-        <CardGrid as="ul" variant="smTwoLgThreeWider">
-          {filecoinParticipants.map(({ title, description, cta }) => (
-            <SimpleCard
-              key={title}
-              hasTopBorder
-              title={title}
-              description={description}
-              cta={cta}
-            />
-          ))}
-        </CardGrid>
       </PageSection>
 
       <PageSection backgroundVariant="gray">
         <SectionContent title="What powers the Filecoin network">
-          <CardGrid as="ul" variant="smTwoLgThreeWider">
+          <CardGrid as="ul" variant="smTwoLgThree">
             {filecoinStackFeatures.map(({ title, description, cta }) => (
               <SimpleCard
                 key={title}

--- a/apps/filecoin-site/src/app/offer-storage/page.tsx
+++ b/apps/filecoin-site/src/app/offer-storage/page.tsx
@@ -6,6 +6,7 @@ import { PageHeader } from '@/components/PageHeader'
 import { PageSection } from '@/components/PageSection'
 import { SectionContent } from '@/components/SectionContent'
 import { SectionDivider } from '@/components/SectionDivider'
+import { SectionSubContent } from '@/components/SectionSubContent'
 import { SimpleCard } from '@/components/SimpleCard'
 import { SplitSectionContent } from '@/components/SplitSectionContent'
 
@@ -34,42 +35,30 @@ export default function OfferStorage() {
           title="What you need to offer storage on Filecoin"
           description="To offer storage on Filecoin you'll need enterprise-grade infrastructure and deep technical expertise to get started."
         >
-          <div className="space-y-6">
-            <Heading tag="h3" variant="xl-medium">
-              Data center environment
-            </Heading>
-            <p className="text-zinc-400">
-              You'll need to run your infrastructure in a secure, reliable, and
-              always-on environment.
-            </p>
-          </div>
-
-          <CardGrid as="ul" variant="smTwoLgThreeWider">
-            {dataCenterRequirements.map(({ title, description, icon }) => (
-              <Card
-                key={title}
-                as="li"
-                backgroundVariant="dark"
-                title={title}
-                description={description}
-                icon={icon}
-              />
-            ))}
-          </CardGrid>
+          <SectionSubContent
+            title="Data center environment"
+            description="You'll need to run your infrastructure in a secure, reliable, and always-on environment."
+          >
+            <CardGrid as="ul" variant="smTwoLgThreeWider">
+              {dataCenterRequirements.map(({ title, description, icon }) => (
+                <Card
+                  key={title}
+                  as="li"
+                  backgroundVariant="dark"
+                  title={title}
+                  description={description}
+                  icon={icon}
+                />
+              ))}
+            </CardGrid>
+          </SectionSubContent>
 
           <SectionDivider />
 
-          <div className="space-y-20">
-            <div className="space-y-6">
-              <Heading tag="h3" variant="xl-medium">
-                Core infrastructure setup
-              </Heading>
-              <p className="text-zinc-400">
-                This includes high-throughput networking and two powerful CPU
-                nodes required to operate the system reliably and at scale.
-              </p>
-            </div>
-
+          <SectionSubContent
+            title="Core infrastructure setup"
+            description="This includes high-throughput networking and two powerful CPU nodes required to operate the system reliably and at scale."
+          >
             <CardGrid as="ul" variant="lgTwoWide">
               {coreInfrastructureSpecs.map(({ title, list }) => (
                 <li key={title} className="space-y-3">
@@ -84,20 +73,14 @@ export default function OfferStorage() {
                 </li>
               ))}
             </CardGrid>
-          </div>
+          </SectionSubContent>
 
-          <div className="space-y-20">
-            <div className="space-y-6">
-              <Heading tag="h3" variant="xl-medium">
-                Specialized & storage systems
-              </Heading>
-              <p className="text-zinc-400">
-                The Sealing Node prepares and proves data with GPU acceleration,
-                while the JBOD stores large volumes of client data persistently
-                and reliably.
-              </p>
-            </div>
+          <SectionDivider />
 
+          <SectionSubContent
+            title="Specialized & storage systems"
+            description="The Sealing Node prepares and proves data with GPU acceleration, while the JBOD stores large volumes of client data persistently and reliably."
+          >
             <CardGrid as="ul" variant="lgTwoWide">
               {specializedInfrastructureSpecs.map(({ title, list }) => (
                 <li key={title} className="space-y-3">
@@ -112,22 +95,19 @@ export default function OfferStorage() {
                 </li>
               ))}
             </CardGrid>
-          </div>
+          </SectionSubContent>
 
           <SectionDivider />
 
-          <div className="space-y-6">
-            <Heading tag="h3" variant="xl-medium">
-              Begin your storage provider journey
-            </Heading>
-            <p className="mb-20 text-zinc-400">
-              If you're already running infrastructure at this level — or
-              planning to — you might be a great fit.
-            </p>
-            <Button href="" variant="primary">
-              Book a call with our onboarding team
-            </Button>
-          </div>
+          <SectionSubContent
+            title="Begin your storage provider journey"
+            description="If you're already running infrastructure at this level — or planning to — you might be a great fit."
+            cta={
+              <Button href="" variant="primary">
+                Book a call with our onboarding team
+              </Button>
+            }
+          />
         </SectionContent>
       </PageSection>
 

--- a/apps/filecoin-site/src/app/offer-storage/page.tsx
+++ b/apps/filecoin-site/src/app/offer-storage/page.tsx
@@ -57,7 +57,7 @@ export default function OfferStorage() {
             ))}
           </CardGrid>
 
-          <SectionDivider variant="light" />
+          <SectionDivider />
 
           <div className="space-y-20">
             <div className="space-y-6">
@@ -114,7 +114,7 @@ export default function OfferStorage() {
             </CardGrid>
           </div>
 
-          <SectionDivider variant="light" />
+          <SectionDivider />
 
           <div className="space-y-6">
             <Heading tag="h3" variant="xl-medium">


### PR DESCRIPTION
## 📝 Description

This PR introduces `SectionSubContent` to encapsulate the common UI pattern of a sub-heading, an optional description, and its content.

## 🛠️ Key Changes

- Removes `SectionDivider` variant to make it context aware
- Implements `SectionSubContent` on the `BuildOnFilecoin`, `Learn`, and `OfferStorage` pages

## 📸 Screenshots

<img width="1443" height="1168" alt="CleanShot 2025-07-17 at 15 04 40" src="https://github.com/user-attachments/assets/494ed84a-35b0-4329-8b38-edac77b54d9d" />
