### PR TITLE
[FILECOIN][UXIT-3038] Blog Page + Blog Post Style Fixes [skip percy]

### DIFF
--- a/apps/filecoin-site/src/app/_components/Badge.tsx
+++ b/apps/filecoin-site/src/app/_components/Badge.tsx
@@ -4,7 +4,7 @@ export type BadgeProps = {
 
 export function Badge({ children }: BadgeProps) {
   return (
-    <span className="text-brand-950 bg-brand-50 border-brand-100 w-fit rounded-full border px-4 py-1 text-sm capitalize">
+    <span className="text-brand-950 bg-brand-50 border-brand-100 w-fit rounded-full border px-4 py-1 text-sm font-medium capitalize">
       {children}
     </span>
   )

--- a/apps/filecoin-site/src/app/_styles/globals.css
+++ b/apps/filecoin-site/src/app/_styles/globals.css
@@ -39,6 +39,10 @@
 
 @utility icon-button {
   @apply rounded-full border-2 border-zinc-200;
+
+  .share-article-list & {
+    @apply scale-80;
+  }
 }
 
 @layer components {
@@ -243,7 +247,7 @@
 
   /* SHARE ARTICLE */
   .share-article-list {
-    @apply gap-4;
+    @apply gap-2;
   }
 
   /* SOCIAL LINKS */

--- a/apps/filecoin-site/src/app/blog/components/BlogPostHeader.tsx
+++ b/apps/filecoin-site/src/app/blog/components/BlogPostHeader.tsx
@@ -57,7 +57,7 @@ export function BlogPostHeader({
 
         <SectionDivider />
 
-        <div className="mt-16 mb-8">
+        <div className="mt-15 mb-4">
           <PostMetadata author={author} date={date} />
         </div>
 

--- a/apps/filecoin-site/src/app/blog/components/Categories.tsx
+++ b/apps/filecoin-site/src/app/blog/components/Categories.tsx
@@ -6,10 +6,11 @@ type CategoriesProps = {
 
 export function Categories({ categories }: CategoriesProps) {
   const categoriesArray = Array.isArray(categories) ? categories : [categories]
+  const label = categoriesArray.length > 1 ? 'Categories' : 'Category'
 
   return (
     <div className="flex items-center gap-4 text-sm text-zinc-950">
-      <span className="font-semibold">Categories:</span>
+      <span className="font-semibold">{label}:</span>
       <div className="flex flex-wrap gap-4">
         {categoriesArray.map((category) => (
           <Badge key={category}>{category}</Badge>

--- a/apps/filecoin-site/src/app/blog/components/PostMetadata.tsx
+++ b/apps/filecoin-site/src/app/blog/components/PostMetadata.tsx
@@ -17,9 +17,9 @@ export function PostMetadata({ author, date }: PostMetadataProps) {
   if (author) {
     return (
       <div className={clsx('flex items-center gap-2', baseStyles)}>
-        <span>{author}</span>
-        <span className="text-zinc-400">|</span>
         <span>{formattedDate}</span>
+        <span className="text-zinc-400">|</span>
+        <span>{author}</span>
       </div>
     )
   }

--- a/apps/filecoin-site/src/app/blog/page.tsx
+++ b/apps/filecoin-site/src/app/blog/page.tsx
@@ -49,6 +49,7 @@ export default async function Blog() {
               author,
               publishedOn,
             } = post
+
             return (
               <BlogCard
                 key={title}


### PR DESCRIPTION
## 📝 Description

This PR introduces several style refinements to the blog list and post pages to improve visual consistency and alignment with the Figma design.

## 🛠️ Key Changes

- **BlogPostCard**: Author and date positions are flipped — now the date always appears first for a more consistent layout, even when no author is present.
- **Category label**: Font weight increased for better emphasis, per Figma design.
- **Pluralization**: Category label now pluralizes dynamically ("Category" → "Categories") — no external library used, as it's only needed in one place.
- **Spacing adjustments**: BlogPostHeader spacing between elements has been reviewed and refined for better balance.
- **Share buttons**: Share link icons have been scaled down using CSS for now. A follow-up is noted to revisit and unify the `ShareArticle` and `CopyToClipboard` components for consistency and reusability.