### PR TITLE
[FILECOIN][UXIT-3020] Add Pagination to Filecoin Blog

### DIFF
--- a/apps/ff-site/src/app/_styles/globals.css
+++ b/apps/ff-site/src/app/_styles/globals.css
@@ -281,10 +281,6 @@
         @apply focus-visible:outline-2 focus-visible:outline-white;
       }
 
-      &:disabled {
-        @apply cursor-not-allowed;
-      }
-
       &:not(:disabled):hover {
         @apply bg-brand-400;
       }

--- a/apps/ff-site/src/app/_styles/globals.css
+++ b/apps/ff-site/src/app/_styles/globals.css
@@ -273,41 +273,49 @@
   /* PAGINATION */
   .pagination {
     @apply bg-brand-300 text-brand-700 rounded-lg p-1;
-  }
 
-  .pagination-delimiter {
-    @apply text-brand-800;
-  }
+    & .pagination-arrow-button {
+      @apply bg-brand-300 rounded-sm transition;
 
-  .pagination-navigation-button {
-    @apply bg-brand-300 rounded-sm;
+      &:not(:disabled) {
+        @apply focus-visible:outline-2 focus-visible:outline-white;
+      }
 
-    &:not(:disabled) {
-      @apply focus-visible:outline-2 focus-visible:outline-white;
+      &:disabled {
+        @apply cursor-not-allowed;
+      }
+
+      &:not(:disabled):hover {
+        @apply bg-brand-400;
+      }
     }
 
-    &:disabled {
-      @apply cursor-not-allowed;
+    & .pagination-delimiter {
+      @apply text-brand-800;
     }
 
-    &:not(:disabled):hover {
-      @apply bg-brand-400;
-    }
-  }
-
-  .pagination-navigation-number {
-    @apply h-full w-full rounded-sm;
-
-    &[data-current='true'] {
-      @apply bg-brand-800 text-brand-100;
+    & .pagination-index-container {
+      @apply size-10;
     }
 
-    &[data-current='false'] {
-      @apply bg-brand-300 text-brand-700;
+    & .pagination-index-list {
+      @apply -mx-1 gap-1;
     }
 
-    &[data-current='false']:hover {
-      @apply bg-brand-400;
+    & .pagination-number-button {
+      @apply h-full w-full rounded-sm focus-visible:outline-2 focus-visible:outline-white;
+
+      &[data-current='true'] {
+        @apply bg-brand-800 text-brand-100;
+      }
+
+      &[data-current='false'] {
+        @apply bg-brand-300 text-brand-700;
+      }
+
+      &[data-current='false']:hover {
+        @apply bg-brand-400;
+      }
     }
   }
 

--- a/apps/ffdweb-site/src/app/_styles/globals.css
+++ b/apps/ffdweb-site/src/app/_styles/globals.css
@@ -287,10 +287,6 @@
         @apply focus-visible:outline-2 focus-visible:outline-white;
       }
 
-      &:disabled {
-        @apply cursor-not-allowed;
-      }
-
       &:not(:disabled):hover {
         @apply bg-brand-primary-400;
       }

--- a/apps/ffdweb-site/src/app/_styles/globals.css
+++ b/apps/ffdweb-site/src/app/_styles/globals.css
@@ -279,41 +279,49 @@
   /* PAGINATION */
   .pagination {
     @apply bg-brand-primary-300 text-brand-primary-900 p-1;
-  }
 
-  .pagination-delimiter {
-    @apply text-brand-primary-800;
-  }
+    & .pagination-arrow-button {
+      @apply bg-brand-primary-300 transition;
 
-  .pagination-navigation-button {
-    @apply bg-brand-primary-300;
+      &:not(:disabled) {
+        @apply focus-visible:outline-2 focus-visible:outline-white;
+      }
 
-    &:not(:disabled) {
-      @apply focus-visible:outline-2 focus-visible:outline-white;
+      &:disabled {
+        @apply cursor-not-allowed;
+      }
+
+      &:not(:disabled):hover {
+        @apply bg-brand-primary-400;
+      }
     }
 
-    &:disabled {
-      @apply cursor-not-allowed;
+    & .pagination-delimiter {
+      @apply text-brand-primary-800;
     }
 
-    &:not(:disabled):hover {
-      @apply bg-brand-primary-400;
-    }
-  }
-
-  .pagination-navigation-number {
-    @apply h-full w-full;
-
-    &[data-current='true'] {
-      @apply bg-brand-primary-800 text-brand-primary-100;
+    & .pagination-index-container {
+      @apply h-10 w-10 md:h-9 md:w-10;
     }
 
-    &[data-current='false'] {
-      @apply bg-brand-primary-300 text-brand-primary-900;
+    & .pagination-index-list {
+      @apply -mx-1 gap-1;
     }
 
-    &[data-current='false']:hover {
-      @apply bg-brand-primary-400;
+    & .pagination-number-button {
+      @apply h-full w-full focus-visible:outline-2 focus-visible:outline-white;
+
+      &[data-current='true'] {
+        @apply bg-brand-primary-800 text-brand-primary-100;
+      }
+
+      &[data-current='false'] {
+        @apply bg-brand-primary-300 text-brand-primary-900;
+      }
+
+      &[data-current='false']:hover {
+        @apply bg-brand-primary-400;
+      }
     }
   }
 

--- a/apps/filecoin-site/src/app/_styles/globals.css
+++ b/apps/filecoin-site/src/app/_styles/globals.css
@@ -309,6 +309,45 @@
     }
   }
 
+  /* PAGINATION */
+  .pagination {
+    & .pagination-arrow-button {
+      @apply focus:brand-outline font-medium text-zinc-600;
+
+      &:disabled {
+        @apply cursor-not-allowed;
+      }
+
+      &:not(:disabled):hover {
+        @apply bg-zinc-100;
+      }
+    }
+
+    & .pagination-delimiter {
+      @apply text-zinc-950/10;
+    }
+
+    & .pagination-index-container {
+      @apply size-10;
+    }
+
+    & .pagination-index-list {
+      @apply gap-5;
+    }
+
+    & .pagination-number-button {
+      @apply focus:brand-outline h-full w-full cursor-pointer rounded-full focus:outline-offset-1;
+
+      &[data-current='true'] {
+        @apply bg-brand-800 text-white;
+      }
+
+      &[data-current='false']:hover {
+        @apply bg-brand-50;
+      }
+    }
+  }
+
   /* SECTION SUB CONTENT */
   .section-sub-content-heading-text {
     .light-section &,

--- a/apps/filecoin-site/src/app/_styles/globals.css
+++ b/apps/filecoin-site/src/app/_styles/globals.css
@@ -314,10 +314,6 @@
     & .pagination-arrow-button {
       @apply focus:brand-outline font-medium text-zinc-600;
 
-      &:disabled {
-        @apply cursor-not-allowed;
-      }
-
       &:not(:disabled):hover {
         @apply bg-zinc-100;
       }

--- a/apps/filecoin-site/src/app/blog/components/BlogPostList.tsx
+++ b/apps/filecoin-site/src/app/blog/components/BlogPostList.tsx
@@ -1,0 +1,74 @@
+'use client'
+
+import { useSearchParams } from 'next/navigation'
+
+import { Pagination, usePagination } from '@filecoin-foundation/ui/Pagination'
+import { PAGE_KEY } from '@filecoin-foundation/utils/constants/urlParamsConstants'
+import { normalizeQueryParam } from '@filecoin-foundation/utils/urlUtils'
+
+import { CardGrid } from '@/components/CardGrid'
+
+import type { BlogPost } from '../types/blogPostType'
+
+import { BlogCard } from './BlogCard'
+
+type BlogPostListProps = {
+  posts: Array<BlogPost>
+}
+
+const BLOG_POSTS_PER_PAGE = 6
+const PAGINATION_INDEX_MAX_RANGE = 6
+
+export function BlogPostList({ posts }: BlogPostListProps) {
+  const clientSearchParams = useSearchParams()
+  const searchParams = Object.fromEntries(clientSearchParams.entries())
+
+  const { pageCount, paginatedResults } = usePagination({
+    pageQuery: normalizeQueryParam(searchParams, PAGE_KEY),
+    entries: posts,
+    entriesPerPage: BLOG_POSTS_PER_PAGE,
+  })
+
+  return (
+    <>
+      <CardGrid as="ul" variant="mdTwo">
+        {paginatedResults.map((post: BlogPost) => {
+          const {
+            title,
+            slug,
+            excerpt,
+            categories,
+            image,
+            author,
+            publishedOn,
+          } = post
+
+          return (
+            <BlogCard
+              key={slug}
+              title={title}
+              slug={slug}
+              description={excerpt}
+              author={author}
+              date={publishedOn}
+              tags={categories}
+              image={
+                image && {
+                  src: image.url,
+                  alt: title,
+                }
+              }
+            />
+          )
+        })}
+      </CardGrid>
+
+      <div className="mx-auto mt-20 max-w-2xl">
+        <Pagination
+          pageCount={pageCount}
+          numberRange={PAGINATION_INDEX_MAX_RANGE}
+        />
+      </div>
+    </>
+  )
+}

--- a/apps/filecoin-site/src/app/blog/page.tsx
+++ b/apps/filecoin-site/src/app/blog/page.tsx
@@ -1,15 +1,15 @@
+import { Suspense } from 'react'
+
 import { sortPostsByDateDesc } from '@filecoin-foundation/utils/sortBlogPosts'
 
 import { PATHS } from '@/constants/paths'
 
 import { BackgroundImage } from '@/components/BackgroundImage'
 import { Button } from '@/components/Button'
-import { CardGrid } from '@/components/CardGrid'
 import { PageHeader } from '@/components/PageHeader'
 import { PageSection } from '@/components/PageSection'
 
-import { BlogCard } from './components/BlogCard'
-import type { BlogPost } from './types/blogPostType'
+import { BlogPostList } from './components/BlogPostList'
 import { getBlogPostsData } from './utils/getBlogPostData'
 
 export default async function Blog() {
@@ -41,37 +41,9 @@ export default async function Blog() {
       </BackgroundImage>
 
       <PageSection backgroundVariant="light">
-        <CardGrid as="ul" variant="mdTwo">
-          {sortedPosts.map((post: BlogPost) => {
-            const {
-              title,
-              slug,
-              excerpt,
-              categories,
-              image,
-              author,
-              publishedOn,
-            } = post
-
-            return (
-              <BlogCard
-                key={title}
-                title={title}
-                slug={slug}
-                description={excerpt}
-                author={author}
-                date={publishedOn}
-                tags={categories}
-                image={
-                  image && {
-                    src: image.url,
-                    alt: title,
-                  }
-                }
-              />
-            )
-          })}
-        </CardGrid>
+        <Suspense>
+          <BlogPostList posts={sortedPosts} />
+        </Suspense>
       </PageSection>
     </>
   )

--- a/packages/ui/src/Pagination/Pagination.tsx
+++ b/packages/ui/src/Pagination/Pagination.tsx
@@ -20,6 +20,12 @@ export function Pagination({
   pageCount,
   numberRange = MAX_RANGE,
 }: PaginationProps) {
+  if (numberRange > MAX_RANGE) {
+    console.warn(
+      `[Pagination]: The numberRange provided (${numberRange}) exceeds the maximum range allowed (${MAX_RANGE}). The maximum range (${MAX_RANGE}) will be used instead.`,
+    )
+  }
+
   const [page, setPage] = useQueryState(
     PAGE_KEY,
     parseAsInteger

--- a/packages/ui/src/Pagination/Pagination.tsx
+++ b/packages/ui/src/Pagination/Pagination.tsx
@@ -1,20 +1,25 @@
 'use client'
 
-import { CaretLeftIcon, CaretRightIcon, LineVerticalIcon } from '@phosphor-icons/react'
+import { Button } from '@headlessui/react'
 import { useQueryState, parseAsInteger } from 'nuqs'
 
-import { Icon } from '@filecoin-foundation/ui/Icon'
 import { DEFAULT_PAGE_NUMBER } from '@filecoin-foundation/utils/constants/paginationConstants'
 import { PAGE_KEY } from '@filecoin-foundation/utils/constants/urlParamsConstants'
 
-import { useResponsiveRange } from './utils/useResponsiveRange'
+import { PaginationArrowButton } from './components/PaginationArrowButton'
+import { PaginationDelimiter } from './components/PaginationDelimiter'
+import { MAX_RANGE, useResponsiveRange } from './utils/useResponsiveRange'
 import { useVisiblePages } from './utils/useVisiblePages'
 
 type PaginationProps = {
   pageCount: number
+  numberRange?: number
 }
 
-export function Pagination({ pageCount }: PaginationProps) {
+export function Pagination({
+  pageCount,
+  numberRange = MAX_RANGE,
+}: PaginationProps) {
   const [page, setPage] = useQueryState(
     PAGE_KEY,
     parseAsInteger
@@ -22,7 +27,9 @@ export function Pagination({ pageCount }: PaginationProps) {
       .withOptions({ shallow: false }),
   )
 
-  const range = useResponsiveRange()
+  const responsiveRange = useResponsiveRange()
+  const range = Math.min(responsiveRange, numberRange)
+
   const visiblePages = useVisiblePages({ pageCount, currentPage: page, range })
 
   const canGoBack = page > 1
@@ -35,40 +42,30 @@ export function Pagination({ pageCount }: PaginationProps) {
       className="pagination flex w-full justify-between"
     >
       <div className="flex">
-        <button
-          aria-label="Go to previous page"
-          aria-disabled={!canGoBack}
+        <PaginationArrowButton
+          to="prev"
           disabled={!canGoBack}
-          className={
-            'pagination-navigation-button flex items-center gap-x-1.5 p-1 px-2 transition'
-          }
-          onClick={() => setPage(page - 1)}
-        >
-          <Icon component={CaretLeftIcon} size={20} weight="bold" />
-          <span className="hidden sm:mx-1.5 sm:inline">Prev</span>
-        </button>
-
-        <div className="pagination-delimiter flex items-center">
-          <Icon component={LineVerticalIcon} weight="light" />
-        </div>
+          pageSetter={setPage}
+        />
+        <PaginationDelimiter />
       </div>
 
-      <ul className="-mx-1 flex shrink grow justify-center gap-1">
+      <ul className="pagination-index-list flex shrink grow justify-center">
         {visiblePages.map((item, index) => (
           <li
             key={index}
-            className="h-10 w-10 md:h-9 md:w-10"
+            className="pagination-index-container"
             aria-current={item === page ? 'page' : undefined}
           >
             {typeof item === 'number' ? (
-              <button
+              <Button
                 aria-label={`Go to page ${item}`}
                 data-current={item === page}
-                className="pagination-navigation-number focus-visible:outline-2 focus-visible:outline-white"
+                className="pagination-number-button cursor-pointer"
                 onClick={() => setPage(item)}
               >
                 {item}
-              </button>
+              </Button>
             ) : (
               <span className="flex h-full w-full items-baseline justify-center">
                 <span className="mt-1.5">{item}</span>
@@ -79,20 +76,12 @@ export function Pagination({ pageCount }: PaginationProps) {
       </ul>
 
       <div className="flex">
-        <div className="pagination-delimiter flex items-center">
-          <Icon component={LineVerticalIcon} weight="light" />
-        </div>
-
-        <button
-          aria-label="Go to next page"
-          aria-disabled={!canGoForward}
+        <PaginationDelimiter />
+        <PaginationArrowButton
+          to="next"
           disabled={!canGoForward}
-          className="pagination-navigation-button flex items-center gap-x-1.5 p-1 px-2 transition"
-          onClick={() => setPage(page + 1)}
-        >
-          <span className="hidden sm:mx-1.5 sm:inline">Next</span>
-          <Icon component={CaretRightIcon} size={20} weight="bold" />
-        </button>
+          pageSetter={setPage}
+        />
       </div>
     </nav>
   )

--- a/packages/ui/src/Pagination/components/PaginationArrowButton.tsx
+++ b/packages/ui/src/Pagination/components/PaginationArrowButton.tsx
@@ -1,0 +1,52 @@
+import { Button, type ButtonProps } from '@headlessui/react'
+import { CaretLeftIcon, CaretRightIcon } from '@phosphor-icons/react'
+import { clsx } from 'clsx'
+
+import { Icon } from '@filecoin-foundation/ui/Icon'
+
+type PaginationArrowButtonProps = {
+  to: keyof typeof DIRECTIONS
+  disabled: ButtonProps['disabled']
+  pageSetter: (value: number | ((oldValue: number) => number)) => unknown
+}
+
+const DIRECTIONS = {
+  prev: { aria: 'Go to previous page', cta: 'Prev', icon: CaretLeftIcon },
+  next: { aria: 'Go to next page', cta: 'Next', icon: CaretRightIcon },
+}
+
+export function PaginationArrowButton({
+  to,
+  disabled,
+  pageSetter,
+}: PaginationArrowButtonProps) {
+  const direction = DIRECTIONS[to]
+
+  return (
+    <Button
+      aria-label={direction.aria}
+      disabled={disabled}
+      className={clsx(
+        'pagination-arrow-button flex items-center gap-x-1.5 p-1 px-2',
+        to === 'next' && 'flex-row-reverse',
+        disabled ? 'cursor-not-allowed' : 'cursor-pointer',
+      )}
+      onClick={() =>
+        pageSetter((currentPage) => {
+          switch (to) {
+            case 'prev':
+              return currentPage - 1
+            case 'next':
+              return currentPage + 1
+            default:
+              throw new Error(`Unknown direction: ${to}`)
+          }
+        })
+      }
+    >
+      <Icon component={direction.icon} size={20} weight="regular" />
+
+      <span className="hidden sm:mx-1.5 sm:inline">{direction.cta}</span>
+    </Button>
+  )
+}

--- a/packages/ui/src/Pagination/components/PaginationDelimiter.tsx
+++ b/packages/ui/src/Pagination/components/PaginationDelimiter.tsx
@@ -1,0 +1,11 @@
+import { LineVerticalIcon } from '@phosphor-icons/react'
+
+import { Icon } from '@filecoin-foundation/ui/Icon'
+
+export function PaginationDelimiter() {
+  return (
+    <div className="pagination-delimiter flex items-center">
+      <Icon component={LineVerticalIcon} weight="light" />
+    </div>
+  )
+}

--- a/packages/ui/src/Pagination/utils/useResponsiveRange.ts
+++ b/packages/ui/src/Pagination/utils/useResponsiveRange.ts
@@ -1,20 +1,24 @@
 import { useMediaQuery } from 'usehooks-ts'
 
+export const MAX_RANGE = 10
+
 export function useResponsiveRange() {
-  const is5xs = useMediaQuery('only screen and (max-width : 300px)')
-  const is4xs = useMediaQuery('only screen and (max-width : 340px)')
-  const is3Xs = useMediaQuery('only screen and (max-width : 380px)')
-  const is2Xs = useMediaQuery('only screen and (max-width : 420px)')
-  const isXs = useMediaQuery('only screen and (max-width : 480px)')
+  const is6xs = useMediaQuery('only screen and (max-width : 300px)')
+  const is5xs = useMediaQuery('only screen and (max-width : 340px)')
+  const is4Xs = useMediaQuery('only screen and (max-width : 380px)')
+  const is3Xs = useMediaQuery('only screen and (max-width : 420px)')
+  const is2Xs = useMediaQuery('only screen and (max-width : 460px)')
+  const isXs = useMediaQuery('only screen and (max-width : 500px)')
   const isSm = useMediaQuery('only screen and (max-width : 640px)')
   const isMd = useMediaQuery('only screen and (max-width : 768px)')
 
+  if (is6xs) return 1
   if (is5xs) return 2
-  if (is4xs) return 3
+  if (is4Xs) return 3
   if (is3Xs) return 4
   if (is2Xs) return 5
   if (isXs) return 6
   if (isSm) return 7
   if (isMd) return 8
-  return 10
+  return MAX_RANGE
 }


### PR DESCRIPTION
## 📝 Description

This PR reworks `Pagination` and implements it on filecoin-site.

## 🛠️ Key Changes

1. Adds `PaginationArrowButton` and `PaginationDelimiter` to abstract repeated code
2. Adds `numberRange` prop to `Pagination` to be able to control the maximum number of indexes displayed
3. Adds new CSS classes to adapt the style to the filecoin design

> [!NOTE]
> There's a layout shift when navigating due to the difference in card heights. We might want to rework `Card` to clamp the description text so they all have the same height.

## 📌 To-Do Before Merging

- [ ] Remove dummy content 73a6db5ae3a1193f847d228106a4a8c7baaa033b

## 📸 Screenshots

<img width="2782" height="1256" alt="CleanShot 2025-07-24 at 16 59 07@2x" src="https://github.com/user-attachments/assets/eca42c8b-3e9e-4b73-b82e-cf5201a656a2" />