### PR TITLE
[UXIT-3001] - Set default value of communicationOptIn to false in OfferStorageForm

### DIFF
--- a/apps/filecoin-site/src/app/offer-storage/onboarding/components/OfferStorageForm.tsx
+++ b/apps/filecoin-site/src/app/offer-storage/onboarding/components/OfferStorageForm.tsx
@@ -21,7 +21,7 @@ export function OfferStorageForm() {
   const form = useForm<OfferStorageFormData>({
     resolver: zodResolver(OfferStorageFormSchema),
     defaultValues: {
-      communicationOptIn: true,
+      communicationOptIn: false,
     },
   })
 


### PR DESCRIPTION
## 📝 Description

This PR sets the default value of `communicationOptIn` to `false` in OfferStorageForm, as leaving it checked by default is considered an dark pattern.