### PR TITLE
feat(nav): Add mobile navigation design

### DIFF
--- a/apps/filecoin-site/src/app/_components/Navigation/HomeLogoIconLink.tsx
+++ b/apps/filecoin-site/src/app/_components/Navigation/HomeLogoIconLink.tsx
@@ -1,7 +1,9 @@
-import { LogoLink } from '@filecoin-foundation/ui/LogoLink'
+import { LogoLink, type LogoLinkProps } from '@filecoin-foundation/ui/LogoLink'
 
 import IconLogo from '@/assets/logos/filecoin-logo-icon.svg'
 
-export function HomeLogoIconLink() {
-  return <LogoLink logo={IconLogo} height={40} />
+type HomeLogoLinkProps = Pick<LogoLinkProps, 'onNavigate'>
+
+export function HomeLogoIconLink(props: HomeLogoLinkProps) {
+  return <LogoLink logo={IconLogo} height={40} {...props} />
 }

--- a/apps/filecoin-site/src/app/_components/Navigation/MobileNavigation.tsx
+++ b/apps/filecoin-site/src/app/_components/Navigation/MobileNavigation.tsx
@@ -3,15 +3,22 @@
 import { useState } from 'react'
 
 import { ListIcon, XIcon } from '@phosphor-icons/react'
+import { clsx } from 'clsx'
 
 import { IconButton } from '@filecoin-foundation/ui/IconButton'
 import { SlideOver } from '@filecoin-foundation/ui/SlideOver'
+
+import { backgroundVariants } from '@/components/Section'
 
 import { NAV_LINKS } from './constants'
 import { HomeLogoIconLink } from './HomeLogoIconLink'
 import { NavigationLink } from './NavigationLink'
 
-export function MobileNavigation() {
+export type MobileNavigationProps = {
+  backgroundVariant: 'dark' | 'light'
+}
+
+export function MobileNavigation({ backgroundVariant }: MobileNavigationProps) {
   const [open, setOpen] = useState(false)
 
   return (
@@ -23,18 +30,23 @@ export function MobileNavigation() {
       />
 
       <SlideOver open={open} setOpen={setOpen}>
-        <div className="flex flex-col gap-12 px-6 py-8">
+        <div
+          className={clsx(
+            'flex h-full flex-col gap-12 px-6 py-8',
+            backgroundVariants[backgroundVariant],
+          )}
+        >
           <div className="flex items-center justify-between">
-            <HomeLogoIconLink />
+            <HomeLogoIconLink onNavigate={closePanel} />
             <IconButton
               icon={XIcon}
               label="Close mobile navigation"
               onClick={closePanel}
             />
           </div>
-          <ul aria-label="Navigation options" className="flex flex-col gap-2">
+          <ul aria-label="Navigation options" className="mobile-navigation">
             {NAV_LINKS.map(({ path, label }) => (
-              <li key={path}>
+              <li key={path} className="py-1.5">
                 <NavigationLink
                   href={path}
                   label={label}

--- a/apps/filecoin-site/src/app/_components/Navigation/Navigation.tsx
+++ b/apps/filecoin-site/src/app/_components/Navigation/Navigation.tsx
@@ -3,7 +3,23 @@ import { Section, type SectionProps } from '@/components/Section'
 
 import { DesktopNavigation } from './DesktopNavigation'
 import { HomeLogoIconLink } from './HomeLogoIconLink'
-import { MobileNavigation } from './MobileNavigation'
+import {
+  MobileNavigation,
+  type MobileNavigationProps,
+} from './MobileNavigation'
+
+type VariantMapping = Record<
+  SectionProps['backgroundVariant'],
+  MobileNavigationProps['backgroundVariant']
+>
+
+const mobileNavigationVariantMapping: VariantMapping = {
+  light: 'light',
+  gray: 'light',
+  transparent: 'light',
+  dark: 'dark',
+  transparentDark: 'dark',
+}
 
 type NavigationProps = {
   backgroundVariant: SectionProps['backgroundVariant']
@@ -15,7 +31,11 @@ export function Navigation({ backgroundVariant }: NavigationProps) {
       <Container>
         <nav className="flex items-center justify-between py-8 lg:justify-start lg:gap-24">
           <HomeLogoIconLink />
-          <MobileNavigation />
+          <MobileNavigation
+            backgroundVariant={
+              mobileNavigationVariantMapping[backgroundVariant]
+            }
+          />
           <DesktopNavigation />
         </nav>
       </Container>

--- a/apps/filecoin-site/src/app/_components/Navigation/NavigationLink.tsx
+++ b/apps/filecoin-site/src/app/_components/Navigation/NavigationLink.tsx
@@ -27,7 +27,7 @@ export function NavigationLink({ href, label, ...rest }: NavigationLinkProps) {
       className={clsx(
         TOUCH_TARGET_NAV_LINK.touchAreaPadding,
         TOUCH_TARGET_NAV_LINK.touchAreaOffset,
-        'navigation-link focus:brand-outline inline-block text-base font-semibold',
+        'navigation-link',
       )}
       {...rest}
     >

--- a/apps/filecoin-site/src/app/_components/Section.tsx
+++ b/apps/filecoin-site/src/app/_components/Section.tsx
@@ -1,17 +1,14 @@
 import { clsx } from 'clsx'
 
+type BackgroundVariant = keyof typeof backgroundVariants
+
 export type SectionProps = {
-  backgroundVariant: keyof typeof backgroundVariants
+  backgroundVariant: BackgroundVariant
   as?: React.ElementType
   children: React.ReactNode
 }
 
-export type LimitedBackgroundVariant = Extract<
-  typeof backgroundVariants,
-  'light' | 'dark'
->
-
-const backgroundVariants = {
+export const backgroundVariants = {
   dark: 'dark-section bg-zinc-950 text-zinc-50',
   gray: 'light-section bg-gray-200 text-zinc-950',
   light: 'light-section bg-white text-zinc-950',

--- a/apps/filecoin-site/src/app/_styles/globals.css
+++ b/apps/filecoin-site/src/app/_styles/globals.css
@@ -367,20 +367,34 @@
   }
 
   /* NAVIGATION */
-  .navigation-link {
+  .mobile-navigation {
+    @apply flex flex-col gap-2 divide-y;
+
     .light-section & {
-      @apply text-zinc-600;
+      @apply divide-zinc-950/15;
+    }
+
+    .dark-section & {
+      @apply divide-zinc-50/15;
+    }
+  }
+
+  .navigation-link {
+    @apply focus:brand-outline inline-block text-base;
+
+    .light-section & {
+      @apply text-zinc-950;
 
       &[aria-current='true'] {
-        @apply text-zinc-950;
+        @apply text-brand-900;
       }
     }
 
     .dark-section & {
-      @apply text-zinc-300;
+      @apply text-zinc-50;
 
       &[aria-current='true'] {
-        @apply text-zinc-50;
+        @apply text-brand-100;
       }
     }
   }

--- a/packages/ui/src/LogoLink.tsx
+++ b/packages/ui/src/LogoLink.tsx
@@ -2,7 +2,7 @@ import type { ComponentType } from 'react'
 
 import Link, { type LinkProps } from 'next/link'
 
-type LogoLinkProps = {
+export type LogoLinkProps = {
   logo: ComponentType<React.SVGProps<SVGSVGElement>>
   onNavigate?: LinkProps<unknown>['onNavigate']
   color?: `text-${string}`


### PR DESCRIPTION
The slide-over menu now automatically closes when a navigation link or the home logo is clicked, providing more intuitive behavior.

Additionally, the background of the mobile menu now adapts to be either light or dark based on the section it's opened from. This ensures the menu content is always readable and has appropriate contrast.

Changes include:
- Adding an `onNavigate` callback to `NavigationLink` and `LogoLink` to trigger the menu to close.
- Passing a `backgroundVariant` prop to `MobileNavigation` to set the correct background color.
- Adding dedicated CSS for mobile navigation links for consistent styling.

## 📝 Description

Please include a summary of the changes. Provide context and motivation for the change, and describe what problem it solves.

- **Type:** Bug fix / New feature / Documentation / Refactor

## 🛠️ Key Changes

- [Change 1 - Brief description]
- [Change 2 - Brief description]
- ...

## 📌 To-Do Before Merging

- [ ] [Task 1 - Brief description]
- [ ] [Task 2 - Brief description]
- ...

## 🧪 How to Test

- **Setup:** [Setup details]
- **Steps to Test:**
  1. [Step 1 - Brief description]
  2. [Step 2 - Brief description]
  3. ...
- **Expected Results:** [Outcome]
- **Additional Notes:** [Additional info]

## 📸 Screenshots

Attach if there are UI changes.

## 🔖 Resources

Feel free to share any references to documentation, libraries, blog posts, or other resources that you consulted or used during the implementation of the changes.

- [Resource 1]
- [Resource 2]
- ...
