### PR TITLE
[SHARED] Isolate ff-site specific outputs in app-level turbo config [skip percy]

### DIFF
--- a/apps/ff-site/turbo.json
+++ b/apps/ff-site/turbo.json
@@ -1,0 +1,12 @@
+{
+  "extends": ["//"],
+  "tasks": {
+    "build": {
+      "outputs": [
+        ".next/**",
+        "!.next/cache/**",
+        "src/app/_data/cmsConfigSchema.json"
+      ]
+    }
+  }
+}

--- a/turbo.json
+++ b/turbo.json
@@ -24,11 +24,7 @@
         ".env.production",
         ".env"
       ],
-      "outputs": [
-        ".next/**",
-        "!.next/cache/**",
-        "apps/ff-site/src/app/_data/cmsConfigSchema.json"
-      ]
+      "outputs": [".next/**", "!.next/cache/**"]
     },
     "dev": {
       "persistent": true,


### PR DESCRIPTION
## 📝 Description

The global turbo.json configuration has an app-specific output (`apps/ff-site/src/app/_data/cmsConfigSchema.json`) defined at the workspace level, which could cause incorrect dependency detection between apps.

We moved the ff-site specific output (`cmsConfigSchema.json`) from the global `turbo.json` to an app-specific `apps/ff-site/turbo.json` file.

## 🛠️ Key Changes

- Remove app-specific output from root `turbo.json`
- Create `apps/ff-site/turbo.json` with the specific output
- Uses `extends: ["//"]` to inherit all global configuration

## 🧪 How to Test

-  [x] `npx turbo build --filter=filecoin-foundation-site` works
-  [x] `npx turbo build --filter=ffdweb-site` works
- [x] The `cmsConfigSchema.json` file is still generated for `ff-site`

