### PR TITLE
[SHARED][UXIT-3115] Move app-specific environment variables to app-level turbo configs [skip percy]

### DIFF
--- a/apps/ff-site/turbo.json
+++ b/apps/ff-site/turbo.json
@@ -2,6 +2,17 @@
   "extends": ["//"],
   "tasks": {
     "build": {
+      "env": [
+        "AIRTABLE_READ_ONLY_TOKEN",
+        "ENCRYPTION_ENDPOINT_ACCESS_KEY",
+        "ENCRYPTION_SECRET_KEY",
+        "GITHUB_AUTH_TOKEN",
+        "NEWSLETTER_SUBSCRIPTION_API_KEY",
+        "NEWSLETTER_SUBSCRIPTION_API_URL",
+        "NEWSLETTER_SUBSCRIPTION_PUBLICATION_ID",
+        "PERCY_TOKEN_FF_SITE",
+        "SENTRY_AUTH_TOKEN_FF_SITE"
+      ],
       "outputs": [
         ".next/**",
         "!.next/cache/**",

--- a/apps/ffdweb-site/turbo.json
+++ b/apps/ffdweb-site/turbo.json
@@ -1,0 +1,9 @@
+{
+  "extends": ["//"],
+  "tasks": {
+    "build": {
+      "env": ["PERCY_TOKEN_FFDWEB_SITE", "SENTRY_AUTH_TOKEN_FFDWEB_SITE"],
+      "outputs": [".next/**", "!.next/cache/**"]
+    }
+  }
+}

--- a/turbo.json
+++ b/turbo.json
@@ -4,20 +4,6 @@
   "tasks": {
     "build": {
       "dependsOn": ["^build"],
-      "env": [
-        "AIRTABLE_READ_ONLY_TOKEN",
-        "ENCRYPTION_ENDPOINT_ACCESS_KEY",
-        "ENCRYPTION_SECRET_KEY",
-        "GITHUB_AUTH_TOKEN",
-        "NEWSLETTER_SUBSCRIPTION_API_KEY",
-        "NEWSLETTER_SUBSCRIPTION_API_URL",
-        "NEWSLETTER_SUBSCRIPTION_PUBLICATION_ID",
-        "PERCY_TOKEN_FF_SITE",
-        "PERCY_TOKEN_FFDWEB_SITE",
-        "SENTRY_AUTH_TOKEN_FF_SITE",
-        "SENTRY_AUTH_TOKEN_FFDWEB_SITE",
-        "SENTRY_TELEMETRY"
-      ],
       "inputs": [
         "$TURBO_DEFAULT$",
         ".env.production.local",


### PR DESCRIPTION
## 📝 Description

Move app-specific environment variables to app-level turbo configs for better separation of concerns.

- **Type:** Refactor

## 🛠️ Key Changes

- `ff-site` and `ffdweb-site` now have their own `turbo.json` with app-specific env vars
- Root `turbo.json` only contains shared configurations
- Removes unused `SENTRY_TELEMETRY` variable