### PR TITLE
[SHARED] Ignore docs.fileverse.io in link checker [skip percy]

### DIFF
--- a/.lycheeignore
+++ b/.lycheeignore
@@ -12,3 +12,6 @@ sealstorage.io
 
 # Sites that block automated requests
 dorahacks.io
+
+# Sites with server errors (500 Internal Server Error)
+docs.fileverse.io


### PR DESCRIPTION

## 📝 Description

Adds docs.fileverse.io to .lycheeignore due to 500 Internal Server Error.

This prevents the link checker from failing when it encounters the broken Fileverse documentation endpoint.

## 🛠️ Key Changes

- [Change 1 - Brief description]
- Added docs.fileverse.io to .lycheeignore file
- Added descriptive comment indicating 500 Internal Server Error
- Prevents link checker from failing on this temporarily broken endpoint
