### PR TITLE
UXIT-3056/review-interactive-components

### DIFF
--- a/apps/filecoin-site/src/app/_components/Footer/NewsletterForm.tsx
+++ b/apps/filecoin-site/src/app/_components/Footer/NewsletterForm.tsx
@@ -36,7 +36,7 @@ export function NewsletterForm() {
           />
           <Button
             disabled={formState.isSubmitting}
-            className="absolute right-0 -mr-1 flex h-12 w-12 cursor-pointer items-center justify-center"
+            className="focus:brand-outline absolute right-0 -mr-1 flex h-12 w-12 cursor-pointer items-center justify-center"
             type="submit"
             aria-label="Submit newsletter subscription"
           >

--- a/apps/filecoin-site/src/app/_components/LinkCard.tsx
+++ b/apps/filecoin-site/src/app/_components/LinkCard.tsx
@@ -37,16 +37,18 @@ export function LinkCard({
   return (
     <Tag
       className={clsx(
-        'relative flex flex-row border-t border-[var(--color-border-muted)] pt-8',
+        'group relative flex flex-row border-t border-[var(--color-border-muted)] pt-8',
         description ? 'items-start gap-6' : 'items-center gap-5',
       )}
     >
       <IconBadge component={icon.component} size="sm" variant={icon.variant} />
 
       <div className={clsx(description && 'space-y-5')}>
-        <Heading tag={headingTag} variant="card-heading">
-          {title}
-        </Heading>
+        <span className="group-focus-within:text-[var(--color-card-heading-hover)] group-hover:text-[var(--color-card-heading-hover)]">
+          <Heading tag={headingTag} variant="card-heading">
+            {title}
+          </Heading>
+        </span>
 
         {description && (
           <p className="tracking-tight text-[var(--color-text-paragraph-muted)]">

--- a/apps/filecoin-site/src/app/_components/LogoSection/LogoItem.tsx
+++ b/apps/filecoin-site/src/app/_components/LogoSection/LogoItem.tsx
@@ -18,12 +18,12 @@ export function LogoItem({
       height={size}
       aria-label={href ? undefined : alt}
       aria-hidden={href ? 'true' : undefined}
-      className="max-w-full text-[var(--color-logo)] transition-colors duration-200 hover:text-[var(--color-logo-hover)]"
+      className="max-w-full text-[var(--color-logo)] group-focus-within:text-[var(--color-logo-hover)] group-hover:text-[var(--color-logo-hover)]"
     />
   )
 
   return (
-    <li className="flex items-center">
+    <li className="group flex items-center">
       {href ? (
         <a
           href={href}

--- a/apps/filecoin-site/src/app/_components/SimpleCard.tsx
+++ b/apps/filecoin-site/src/app/_components/SimpleCard.tsx
@@ -9,7 +9,7 @@ export type SimpleCardProps = {
   description: string
   as: 'li' | 'div'
   badge?: BadgeProps['children']
-  border?: keyof typeof borderClasses
+  border?: keyof typeof variants
   cta?: {
     href: CTALinkProps['href']
     text: CTALinkProps['children']
@@ -22,9 +22,9 @@ export type SimpleCardData = {
   cta: NonNullable<SimpleCardProps['cta']>
 }
 
-const borderClasses = {
-  none: 'border-none',
-  all: 'border border-[var(--color-border)]',
+const variants = {
+  none: 'border-none group-focus-within:bg-[var(--color-bg-card-hover)] group-hover:bg-[var(--color-bg-card-hover)]',
+  all: 'border border-[var(--color-border)] focus-within:bg-[var(--color-bg-card-hover)] hover:bg-[var(--color-bg-card-hover)]',
   'only-top': 'border-t border-[var(--color-border)]',
 }
 
@@ -41,9 +41,9 @@ export function SimpleCard({
   return (
     <Tag
       className={clsx(
-        'simple-card h-full w-full',
+        'group h-full w-full',
         cta && 'relative',
-        borderClasses[border],
+        variants[border],
       )}
     >
       <div
@@ -63,9 +63,11 @@ export function SimpleCard({
             hasOnlyTopBorder ? 'mb-6' : 'mb-12',
           )}
         >
-          <Heading tag="h3" variant="card-heading">
-            {title}
-          </Heading>
+          <span className="group-focus-within:text-[var(--color-card-heading-hover)] group-hover:text-[var(--color-card-heading-hover)]">
+            <Heading tag="h3" variant="card-heading">
+              {title}
+            </Heading>
+          </span>
           <p className="tracking-tight text-[var(--color-text-paragraph-muted)]">
             {description}
           </p>

--- a/apps/filecoin-site/src/app/_components/SimpleCardWithGradient.tsx
+++ b/apps/filecoin-site/src/app/_components/SimpleCardWithGradient.tsx
@@ -27,7 +27,7 @@ export function SimpleCardWithGradient({
   const index = gradientIndex % GRADIENT_STEPS.length
 
   return (
-    <li className="relative flex h-full flex-col border border-[var(--color-border)]">
+    <li className="group relative flex h-full flex-col border border-[var(--color-border)]">
       <div
         aria-hidden="true"
         className={clsx(

--- a/apps/filecoin-site/src/app/_components/SimpleCardWithLogo.tsx
+++ b/apps/filecoin-site/src/app/_components/SimpleCardWithLogo.tsx
@@ -38,7 +38,7 @@ export function SimpleCardWithLogo({
   logo,
 }: SimpleCardWithLogoProps) {
   return (
-    <li className="relative flex h-full flex-col border border-[var(--color-border)] sm:flex-row">
+    <li className="group relative flex h-full flex-col border border-[var(--color-border)] sm:flex-row">
       <div
         className="grid h-44 w-full flex-shrink-0 place-items-center sm:h-full sm:w-42"
         style={{ backgroundColor: logo.bgColor }}

--- a/apps/filecoin-site/src/app/_styles/globals.css
+++ b/apps/filecoin-site/src/app/_styles/globals.css
@@ -55,7 +55,7 @@
 }
 
 @utility icon-button {
-  @apply rounded-full border border-zinc-300 hover:border-zinc-400 hover:bg-zinc-50;
+  @apply rounded-full border border-[var(--color-border-icon-button)] text-[var(--color-text-base)] hover:border-[var(--color-border-icon-button-hover)] hover:bg-[var(--color-bg-icon-button-hover)];
 
   .share-article-list & {
     @apply scale-70;
@@ -78,7 +78,14 @@
   --color-border-muted: theme('colors.zinc.950 / 10%');
 
   --color-logo: theme('colors.zinc.400');
-  --color-logo-hover: theme('colors.zinc.400 / 80%');
+  --color-logo-hover: theme('colors.zinc.500');
+
+  --color-card-heading-hover: theme('colors.brand.800');
+  --color-bg-card-hover: theme('colors.zinc.50');
+
+  --color-border-icon-button: theme('colors.zinc.300');
+  --color-border-icon-button-hover: theme('colors.zinc.400');
+  --color-bg-icon-button-hover: theme('colors.zinc.100');
 }
 
 .dark-section {
@@ -97,6 +104,13 @@
 
   --color-logo: theme('colors.zinc.400');
   --color-logo-hover: theme('colors.zinc.50');
+
+  --color-card-heading-hover: theme('colors.brand.500');
+  --color-bg-card-hover: theme('colors.zinc.800');
+
+  --color-border-icon-button: theme('colors.zinc.600');
+  --color-border-icon-button-hover: theme('colors.zinc.500');
+  --color-bg-icon-button-hover: theme('colors.zinc.700');
 }
 
 @layer components {

--- a/apps/filecoin-site/src/app/_styles/globals.css
+++ b/apps/filecoin-site/src/app/_styles/globals.css
@@ -55,7 +55,7 @@
 }
 
 @utility icon-button {
-  @apply rounded-full border-2 border-zinc-200;
+  @apply rounded-full border border-zinc-300 hover:border-zinc-400 hover:bg-zinc-50;
 
   .share-article-list & {
     @apply scale-70;

--- a/apps/filecoin-site/src/app/blog/components/BlogCard.tsx
+++ b/apps/filecoin-site/src/app/blog/components/BlogCard.tsx
@@ -44,9 +44,11 @@ export function BlogCard({
 
         <div className="flex flex-col gap-4 py-4">
           <TagGroup tags={tags} />
-          <Heading tag="h2" variant="card-heading">
-            {title}
-          </Heading>
+          <span className="group-focus-within:text-[var(--color-card-heading-hover)] group-hover:text-[var(--color-card-heading-hover)]">
+            <Heading tag="h2" variant="card-heading">
+              {title}
+            </Heading>
+          </span>
 
           <p className="text-zinc-600">{description}</p>
 

--- a/packages/ui/src/IconButton.tsx
+++ b/packages/ui/src/IconButton.tsx
@@ -12,7 +12,7 @@ export function IconButton({ icon, label, onClick }: IconButtonProps) {
   return (
     <Button
       aria-label={label}
-      className="icon-button focus:brand-outline grid size-12 place-items-center"
+      className="icon-button focus:brand-outline grid size-12 cursor-pointer place-items-center"
       onClick={onClick}
     >
       <Icon component={icon} />


### PR DESCRIPTION
This commit improves accessibility and user experience by providing clearer visual feedback for interactive elements.

- A new `.brand-outline` utility class is created for a consistent, branded focus ring on buttons and other interactive elements.
- Card components (`LinkCard`, `SimpleCard`, `BlogCard`, etc.) are refactored to use Tailwind's `group-hover` and `group-focus-within` utilities. This makes the entire card feel more interactive by applying hover/focus styles to child elements (like headings) when the parent card is hovered or focused.

## 📝 Description

Please include a summary of the changes. Provide context and motivation for the change, and describe what problem it solves.

- **Type:** Bug fix / New feature / Documentation / Refactor

## 🛠️ Key Changes

- [Change 1 - Brief description]
- [Change 2 - Brief description]
- ...

## 📌 To-Do Before Merging

- [ ] [Task 1 - Brief description]
- [ ] [Task 2 - Brief description]
- ...

## 🧪 How to Test

- **Setup:** [Setup details]
- **Steps to Test:**
  1. [Step 1 - Brief description]
  2. [Step 2 - Brief description]
  3. ...
- **Expected Results:** [Outcome]
- **Additional Notes:** [Additional info]

## 📸 Screenshots

Attach if there are UI changes.

## 🔖 Resources

Feel free to share any references to documentation, libraries, blog posts, or other resources that you consulted or used during the implementation of the changes.

- [Resource 1]
- [Resource 2]
- ...
