### PR TITLE
[FILECOIN][UXIT-3132] Rework Homepage - Part 3 [skip percy] 

### DIFF
--- a/apps/filecoin-site/src/app/(homepage)/components/ComparisonTable/Column.tsx
+++ b/apps/filecoin-site/src/app/(homepage)/components/ComparisonTable/Column.tsx
@@ -1,6 +1,5 @@
 import type { SVGProps } from 'react'
 
-import { CheckIcon, XIcon } from '@phosphor-icons/react/dist/ssr'
 import { clsx } from 'clsx'
 
 type ColumnProps = {
@@ -12,14 +11,28 @@ type ColumnProps = {
 
 export type ColumnPropsData = Omit<ColumnProps, 'perspective'>
 
-const ICON_CONFIG = {
+type ColumnStyleConfig = {
+  borderColor: string
+  dividerColor: string
+  textColor: string
+  backgroundColor: string
+}
+
+const COLUMN_STYLE_CONFIG: Record<
+  ColumnProps['perspective'],
+  ColumnStyleConfig
+> = {
   advantage: {
-    Icon: CheckIcon,
-    color: 'text-brand-700',
+    borderColor: 'border-[var(--color-border-muted)]',
+    dividerColor: 'divide-[var(--color-border-muted)]',
+    textColor: 'text-[var(--color-text-base)]',
+    backgroundColor: 'bg-transparent',
   },
   disadvantage: {
-    Icon: XIcon,
-    color: 'text-[var(--color-text-paragraph)]',
+    borderColor: 'border-zinc-950/5',
+    dividerColor: 'divide-zinc-950/5',
+    textColor: 'text-[var(--color-text-paragraph)]',
+    backgroundColor: 'bg-zinc-50',
   },
 }
 
@@ -29,32 +42,38 @@ export function Column({
   features,
   logo: Logo,
 }: ColumnProps) {
-  const { Icon, color } = ICON_CONFIG[perspective]
+  const styles = COLUMN_STYLE_CONFIG[perspective]
 
   return (
-    <div className="text-center">
-      <div className="py-6 text-2xl font-medium md:py-18">
-        <div className="flex min-h-10 items-center gap-3 md:justify-center">
-          {Logo && <Logo className="h-10 w-10" />}
+    <div
+      aria-label={`${perspective} features: ${title}`}
+      className={clsx(
+        'flex flex-col items-center rounded-2xl border',
+        styles.borderColor,
+        styles.backgroundColor,
+      )}
+    >
+      <div
+        className={clsx(
+          'w-full border-b py-8 text-2xl font-medium',
+          styles.borderColor,
+        )}
+      >
+        <div className="flex min-h-10 items-center justify-center gap-3">
+          {Logo && <Logo className="h-8 w-8" />}
           {title}
         </div>
       </div>
 
       <ul
         className={clsx(
-          'divide-[var(--color-border)] md:space-y-3 md:divide-y',
-          perspective === 'disadvantage' &&
-            'text-[var(--color-text-paragraph)]',
+          'flex w-full flex-col items-center divide-y',
+          styles.dividerColor,
+          styles.textColor,
         )}
       >
         {features.map((feature) => (
-          <li
-            key={feature}
-            className="flex items-center gap-3 py-6 md:flex-col md:px-4 md:py-10"
-          >
-            <span className={color}>
-              <Icon size={20} />
-            </span>
+          <li key={feature} className="w-full py-6 text-center">
             {feature}
           </li>
         ))}

--- a/apps/filecoin-site/src/app/(homepage)/components/ComparisonTable/ComparisonTable.tsx
+++ b/apps/filecoin-site/src/app/(homepage)/components/ComparisonTable/ComparisonTable.tsx
@@ -1,5 +1,3 @@
-import { SectionDivider } from '@/components/SectionDivider'
-
 import {
   filecoin,
   traditionalCloud,
@@ -9,25 +7,19 @@ import { Column } from './Column'
 
 export function ComparisonTable() {
   return (
-    <div className="grid grid-cols-1 md:grid-cols-2 md:divide-x md:divide-[var(--color-border)]">
-      <div className="order-3 md:order-1">
-        <Column
-          perspective="advantage"
-          title={filecoin.title}
-          features={filecoin.features}
-          logo={filecoin.logo}
-        />
-      </div>
-      <div className="order-2 py-10 md:hidden">
-        <SectionDivider />
-      </div>
-      <div className="order-1 md:order-2">
-        <Column
-          perspective="disadvantage"
-          title={traditionalCloud.title}
-          features={traditionalCloud.features}
-        />
-      </div>
+    <div className="grid grid-cols-1 gap-6 md:grid-cols-2">
+      <Column
+        perspective="advantage"
+        title={filecoin.title}
+        features={filecoin.features}
+        logo={filecoin.logo}
+      />
+
+      <Column
+        perspective="disadvantage"
+        title={traditionalCloud.title}
+        features={traditionalCloud.features}
+      />
     </div>
   )
 }

--- a/apps/filecoin-site/src/app/(homepage)/page.tsx
+++ b/apps/filecoin-site/src/app/(homepage)/page.tsx
@@ -127,6 +127,7 @@ export default async function Home() {
       <PageSection backgroundVariant="light">
         <SectionContent
           centerCTA
+          centerTitle
           title="How Filecoin storage compares to traditional cloud storage"
           description="Compare decentralized storage against the traditional cloud storage."
           cta={[

--- a/apps/filecoin-site/src/app/_components/SectionContent.tsx
+++ b/apps/filecoin-site/src/app/_components/SectionContent.tsx
@@ -1,3 +1,4 @@
+import clsx from 'clsx'
 import slugify from 'slugify'
 
 import { ButtonRow, type ButtonRowProps } from '@/components/ButtonRow'
@@ -13,6 +14,7 @@ type SectionContentProps = {
   children?: React.ReactNode
   cta?: ButtonRowProps['buttons']
   centerCTA?: ButtonRowProps['centered']
+  centerTitle?: boolean
 }
 
 export function SectionContent({
@@ -21,13 +23,14 @@ export function SectionContent({
   children,
   cta,
   centerCTA,
+  centerTitle,
 }: SectionContentProps) {
   return (
     <div
       className="section-content"
       id={slugify(title.toString(), { lower: true })}
     >
-      <div className="max-w-3xl">
+      <div className={clsx('max-w-3xl', centerTitle && 'mx-auto text-center')}>
         <Heading tag="h2" variant="section-heading">
           {title}
         </Heading>


### PR DESCRIPTION
## 📝 Description

- Added `centerTitle` prop to `SectionContent` 
- Updated `ComparisonTable` and `Column` component to match Figma designs

- **Type:** Refactor

## 📸 Screenshots

<img width="1269" height="1040" alt="Screenshot 2025-08-19 at 21 14 39" src="https://github.com/user-attachments/assets/d44645ee-abe5-4892-9fbc-1c9cd6e3e5f0" />

