### PR TITLE
[FILECOIN][UXIT-3146] Community Page - Add social media links [skip percy]

### DIFF
--- a/apps/filecoin-site/src/app/_constants/siteMetadata.ts
+++ b/apps/filecoin-site/src/app/_constants/siteMetadata.ts
@@ -28,6 +28,10 @@ const FILECOIN_URLS = {
       href: 'https://discord.gg/yeQ2hcd2TD',
       label: 'Discord',
     },
+    reddit: {
+      href: 'https://www.reddit.com/r/Filecoin/',
+      label: 'Reddit',
+    },
     slack: {
       href: 'https://filecoinproject.slack.com/ssb/redirect',
       label: 'Slack',
@@ -36,10 +40,22 @@ const FILECOIN_URLS = {
       href: 'https://t.me/filecoin',
       label: 'Telegram',
     },
+    telegramKorea: {
+      href: 'https://t.me/filecoinkor',
+      label: 'Telegram Korea',
+    },
     twitter: {
       href: 'https://twitter.com/filecoin',
-      label: 'X',
+      label: 'X (Twitter)',
       handle: '@filecoin',
+    },
+    weChat: {
+      href: 'https://filecointldr.io/filecoin-wechat',
+      label: 'WeChat',
+    },
+    youTube: {
+      href: 'https://www.youtube.com/@FilecoinProject',
+      label: 'YouTube',
     },
   },
 } as const

--- a/apps/filecoin-site/src/app/community/data/socialMedia.ts
+++ b/apps/filecoin-site/src/app/community/data/socialMedia.ts
@@ -1,0 +1,83 @@
+import {
+  DiscordLogoIcon,
+  RedditLogoIcon,
+  SlackLogoIcon,
+  TelegramLogoIcon,
+  TwitterLogoIcon,
+  WechatLogoIcon,
+  YoutubeLogoIcon,
+} from '@phosphor-icons/react/dist/ssr'
+
+import { FILECOIN_URLS } from '@/constants/siteMetadata'
+
+import type { LinkCardData } from '@/components/LinkCard'
+
+const {
+  slack,
+  twitter,
+  discord,
+  youTube,
+  reddit,
+  weChat,
+  telegram,
+  telegramKorea,
+} = FILECOIN_URLS.social
+
+export const socialMedia: Array<LinkCardData> = [
+  {
+    title: slack.label,
+    description:
+      'Connect with builders and contributors across themed channels in the Filecoin Slack workspace.',
+    href: slack.href,
+    icon: SlackLogoIcon,
+  },
+  {
+    title: twitter.label,
+    description:
+      'Follow for real-time updates, community highlights, and ecosystem announcements.',
+    href: twitter.href,
+    icon: TwitterLogoIcon,
+  },
+  {
+    title: discord.label,
+    description:
+      'Hang out with builders, share feedback, and join voice chats across Filecoin projects.',
+    href: discord.href,
+    icon: DiscordLogoIcon,
+  },
+  {
+    title: youTube.label,
+    description:
+      'Watch recordings of community calls, talks, demos, and tutorials from across the ecosystem.',
+    href: youTube.href,
+    icon: YoutubeLogoIcon,
+  },
+  {
+    title: reddit.label,
+    description:
+      'Ask questions, share ideas, and discover community-driven discussions on r/Filecoin.',
+    href: reddit.href,
+    icon: RedditLogoIcon,
+  },
+  {
+    title: weChat.label,
+    description:
+      'Connect with the Chinese-speaking Filecoin community for updates, resources, and support.',
+    href: weChat.href,
+    icon: WechatLogoIcon,
+  },
+  {
+    title: telegram.label,
+    description:
+      'Join the global Filecoin Telegram to chat with the community, ask questions, and stay in the loop.',
+    href: telegram.href,
+    icon: TelegramLogoIcon,
+  },
+  {
+    title: telegramKorea.label,
+    description:
+      'Join the Korean-speaking Filecoin community for local updates, support, and conversation.',
+    href: telegramKorea.href,
+    icon: TelegramLogoIcon,
+  },
+]

--- a/apps/filecoin-site/src/app/community/page.tsx
+++ b/apps/filecoin-site/src/app/community/page.tsx
@@ -13,6 +13,7 @@ import { Button } from '@/components/Button'
 import { CardGrid } from '@/components/CardGrid'
 import { CardGridContainer } from '@/components/CardGridContainer'
 import { ImageGrid } from '@/components/ImageGrid'
+import { LinkCard } from '@/components/LinkCard'
 import { Navigation } from '@/components/Navigation/Navigation'
 import { PageHeader } from '@/components/PageHeader'
 import { PageSection } from '@/components/PageSection'
@@ -26,6 +27,7 @@ import { COMMUNITY_SEO } from './constants/seo'
 import { communityConnectionImages } from './data/communityConnectionImages'
 import { ecosystemResources } from './data/ecosystemResources'
 import { getInvolvedWithCommunity } from './data/getInvolvedWithCommunity'
+import { socialMedia } from './data/socialMedia'
 
 export default function BuildOnFilecoin() {
   return (
@@ -87,6 +89,19 @@ export default function BuildOnFilecoin() {
               <Image key={alt} src={data} alt={alt} />
             ))}
           </ImageGrid>
+          <CardGrid as="ul" variant="smThree">
+            {socialMedia.map(({ title, description, href, icon }) => (
+              <LinkCard
+                key={title}
+                as="li"
+                title={title}
+                headingTag="h3"
+                description={description}
+                href={href}
+                icon={{ component: icon }}
+              />
+            ))}
+          </CardGrid>
         </SectionContent>
       </PageSection>
 


### PR DESCRIPTION
## 📝 Description

- Updated `siteMetadata.ts` to include new social media links: Reddit, Telegram Korea, WeChat, and YouTube
- Modified the `community` page to display these social media links using the `LinkCard` component within a `CardGrid`

- **Type:** Refactor

## 📸 Screenshots

<img width="1398" height="906" alt="Screenshot 2025-08-20 at 10 47 06" src="https://github.com/user-attachments/assets/7dd8f95e-a471-44ac-a6e9-6f5a602c0fbe" />

<img width="622" height="966" alt="Screenshot 2025-08-20 at 10 47 21" src="https://github.com/user-attachments/assets/da541c3c-e580-432a-b1ca-21f7454c657d" />
