### PR TITLE
[FILECOIN][UXIT-3147] Clean up FILECOIN_URLS [skip percy]

### DIFF
--- a/apps/filecoin-site/src/app/(homepage)/page.tsx
+++ b/apps/filecoin-site/src/app/(homepage)/page.tsx
@@ -6,7 +6,8 @@ import { StructuredDataScript } from '@filecoin-foundation/ui/StructuredDataScri
 import { getFeaturedBlogPosts } from '@filecoin-foundation/utils/getFeaturedBlogPosts'
 
 import { PATHS } from '@/constants/paths'
-import { FILECOIN_URLS, SEO } from '@/constants/siteMetadata'
+import { SEO } from '@/constants/siteMetadata'
+import { FILECOIN_DOCS_BASE_URL } from '@/constants/siteMetadata'
 
 import { graphicsData } from '@/data/graphicsData'
 import { trustedByLogos } from '@/data/trustedByLogos'
@@ -139,7 +140,7 @@ export default async function Home() {
               'Filecoin makes it easy for IPFS users to reliably store their data directly on the Filecoin network. The result is a decentralized, storage layer opening up an entirely new class of applications and use cases.',
             ]}
             cta={
-              <Button href={FILECOIN_URLS.docs} variant="primary">
+              <Button href={FILECOIN_DOCS_BASE_URL} variant="primary">
                 Learn more about IPFS
               </Button>
             }
@@ -184,7 +185,7 @@ export default async function Home() {
                 Start building
               </Button>,
               <Button
-                href={FILECOIN_URLS.docs}
+                href={FILECOIN_DOCS_BASE_URL}
                 variant="tertiary"
                 icon={BookIcon}
               >

--- a/apps/filecoin-site/src/app/_constants/navigation.ts
+++ b/apps/filecoin-site/src/app/_constants/navigation.ts
@@ -17,10 +17,9 @@ export type ExpandedNavItem = {
   }>
 }
 
-const { social: socialLinks, github } = FILECOIN_URLS
+const { social: socialLinks, github, securityBugBounty } = FILECOIN_URLS
 
-const { security, ecosystemExplorer, grants, securityBugBounty, events } =
-  FILECOIN_FOUNDATION_URLS
+const { security, ecosystemExplorer, grants, events } = FILECOIN_FOUNDATION_URLS
 
 const social: Array<NavItem> = [
   {

--- a/apps/filecoin-site/src/app/_constants/navigation.ts
+++ b/apps/filecoin-site/src/app/_constants/navigation.ts
@@ -1,5 +1,9 @@
 import { PATHS } from './paths'
-import { FILECOIN_URLS } from './siteMetadata'
+import {
+  FILECOIN_DOCS_BASE_URL,
+  FILECOIN_FOUNDATION_URLS,
+  FILECOIN_URLS,
+} from './siteMetadata'
 
 export type NavItem = { label: string; href: string }
 
@@ -13,13 +17,10 @@ export type ExpandedNavItem = {
   }>
 }
 
-const {
-  social: socialLinks,
-  docs,
-  github,
-  security,
-  ecosystemExplorer,
-} = FILECOIN_URLS
+const { social: socialLinks, github } = FILECOIN_URLS
+
+const { security, ecosystemExplorer, grants, securityBugBounty, events } =
+  FILECOIN_FOUNDATION_URLS
 
 const social: Array<NavItem> = [
   {
@@ -45,7 +46,7 @@ const social: Array<NavItem> = [
 ]
 
 const resources: Array<NavItem> = [
-  { label: 'Docs', href: docs },
+  { label: 'Docs', href: FILECOIN_DOCS_BASE_URL },
   { label: 'GitHub', href: github },
   { label: 'Security', href: security },
   { label: 'Ecosystem Explorer', href: ecosystemExplorer },
@@ -89,7 +90,7 @@ export const navigationBis: Array<NavItem | ExpandedNavItem> = [
           {
             label: 'Documentation',
             description: 'Official documentation for Filecoin',
-            href: FILECOIN_URLS.docs,
+            href: FILECOIN_DOCS_BASE_URL,
           },
           {
             label: 'Cookbook',
@@ -109,12 +110,12 @@ export const navigationBis: Array<NavItem | ExpandedNavItem> = [
           {
             label: 'Grants',
             description: 'Funding opportunities to build in the ecosystem',
-            href: FILECOIN_URLS.grants,
+            href: grants,
           },
           {
             label: 'Bug Bounty',
             description: 'Help find vulnerabilities and get rewarded',
-            href: FILECOIN_URLS.securityBugBounty,
+            href: securityBugBounty,
           },
         ],
       },
@@ -179,7 +180,7 @@ export const navigationBis: Array<NavItem | ExpandedNavItem> = [
           {
             label: 'Events',
             description: 'Join meetups, hackathons, and conferences',
-            href: FILECOIN_URLS.events,
+            href: events,
           },
           {
             label: 'Orbit',

--- a/apps/filecoin-site/src/app/_constants/siteMetadata.ts
+++ b/apps/filecoin-site/src/app/_constants/siteMetadata.ts
@@ -15,7 +15,6 @@ const FILECOIN_FOUNDATION_URLS = {
   events: 'https://fil.org/events',
   grants: 'https://fil.org/grants',
   security: 'https://fil.org/security',
-  securityBugBounty: 'https://immunefi.com/bug-bounty/filecoin/',
   ecosystemExplorer: 'https://fil.org/ecosystem-explorer',
   emails: {
     contact: 'hello@fil.org',

--- a/apps/filecoin-site/src/app/_constants/siteMetadata.ts
+++ b/apps/filecoin-site/src/app/_constants/siteMetadata.ts
@@ -11,14 +11,37 @@ const SEO = {
     "Preserve humanity's most important information on Filecoin, the decentralized storage network with verifiable integrity, global redundancy, and no centralized control. Build apps, store data securely, or become a storage provider today.",
 } as const
 
-const FILECOIN_URLS = {
-  docs: 'https://docs.filecoin.io/',
+const FILECOIN_FOUNDATION_URLS = {
   events: 'https://fil.org/events',
   grants: 'https://fil.org/grants',
-  github: 'https://github.com/filecoin-project',
   security: 'https://fil.org/security',
   securityBugBounty: 'https://immunefi.com/bug-bounty/filecoin/',
   ecosystemExplorer: 'https://fil.org/ecosystem-explorer',
+  emails: {
+    contact: 'hello@fil.org',
+    devgrants: 'devgrants@fil.org',
+  },
+} as const
+
+const FILECOIN_DOCS_BASE_URL = 'https://docs.filecoin.io/'
+
+const FILECOIN_DOCS_URLS = {
+  basicsBlockhainPoRep: `${FILECOIN_DOCS_BASE_URL}basics/the-blockchain/proofs#proof-of-replication-porep`,
+  basicsBlockhainPoSt: `${FILECOIN_DOCS_BASE_URL}basics/the-blockchain/proofs#proof-of-spacetime-post`,
+  basicsHowStorageWorks: `${FILECOIN_DOCS_BASE_URL}basics/how-storage-works/filecoin-plus`,
+  basicsWhatIsFilecoin: `${FILECOIN_DOCS_BASE_URL}basics/what-is-filecoin`,
+  builderCookbook: `${FILECOIN_DOCS_BASE_URL}builder-cookbook/overview`,
+  networksMainnetRCPs: `${FILECOIN_DOCS_BASE_URL}networks/mainnet/rpcs`,
+  smartContractDevelopingFilecoinSol: `${FILECOIN_DOCS_BASE_URL}smart-contracts/developing-contracts/filecoin.sol`,
+  smartContractFundamentalsErc20: `${FILECOIN_DOCS_BASE_URL}smart-contracts/fundamentals/erc-20-quickstart`,
+  smartContractFundamentalsFVM: `${FILECOIN_DOCS_BASE_URL}smart-contracts/fundamentals/the-fvm`,
+  storageProviderBlockRewards: `${FILECOIN_DOCS_BASE_URL}storage-providers/filecoin-economics/block-rewards#block-rewards`,
+  storageProviderBlockRewardsImpact: `${FILECOIN_DOCS_BASE_URL}storage-providers/filecoin-economics/block-rewards#impact-of-storage-capacity-on-block-rewards`,
+} as const
+
+const FILECOIN_URLS = {
+  github: 'https://github.com/filecoin-project',
+  securityBugBounty: 'https://immunefi.com/bug-bounty/filecoin/',
   social: {
     bluesky: {
       href: 'https://bsky.app/profile/filecoin.io',
@@ -58,12 +81,8 @@ const FILECOIN_URLS = {
       label: 'YouTube',
     },
   },
-} as const
-
-const FILECOIN_FOUNDATION_URLS = {
-  emails: {
-    contact: 'hello@fil.org',
-    devgrants: 'devgrants@fil.org',
+  video: {
+    whatIsFilecoin: 'https://www.youtube.com/embed/26ZdMAo23mM',
   },
 } as const
 
@@ -78,6 +97,8 @@ const ROOT_METADATA = {
 export {
   BASE_DOMAIN,
   BASE_URL,
+  FILECOIN_DOCS_BASE_URL,
+  FILECOIN_DOCS_URLS,
   FILECOIN_FOUNDATION_URLS,
   FILECOIN_URLS,
   ORGANIZATION_NAME,

--- a/apps/filecoin-site/src/app/build-on-filecoin/data/developerResources.ts
+++ b/apps/filecoin-site/src/app/build-on-filecoin/data/developerResources.ts
@@ -1,11 +1,14 @@
 import {
-  DropIcon,
-  BracketsCurlyIcon,
   BookIcon,
+  BracketsCurlyIcon,
+  DropIcon,
   PlugIcon,
 } from '@phosphor-icons/react/dist/ssr'
 
-import { FILECOIN_URLS } from '@/constants/siteMetadata'
+import {
+  FILECOIN_DOCS_BASE_URL,
+  FILECOIN_DOCS_URLS,
+} from '@/constants/siteMetadata'
 
 import type { LinkCardData } from '@/components/LinkCard'
 
@@ -13,7 +16,7 @@ export const developerResources: Array<LinkCardData> = [
   {
     title: 'Documentation',
     description: 'Comprehensive guides and tutorials to build on Filecoin.',
-    href: FILECOIN_URLS.docs,
+    href: FILECOIN_DOCS_BASE_URL,
     icon: BookIcon,
   },
   {
@@ -27,14 +30,14 @@ export const developerResources: Array<LinkCardData> = [
     title: 'RPC Endpoints',
     description:
       'Reliable endpoints for connecting your dApps to the Filecoin network.',
-    href: `${FILECOIN_URLS.docs}networks/mainnet/rpcs`,
+    href: FILECOIN_DOCS_URLS.networksMainnetRCPs,
     icon: PlugIcon,
   },
   {
     title: 'Filecoin.sol',
     description:
       'Solidity libraries for seamless integration with the Filecoin Virtual Machine.',
-    href: `${FILECOIN_URLS.docs}smart-contracts/developing-contracts/filecoin.sol`,
+    href: FILECOIN_DOCS_URLS.smartContractDevelopingFilecoinSol,
     icon: BracketsCurlyIcon,
   },
 ]

--- a/apps/filecoin-site/src/app/build-on-filecoin/data/filecoinTools.ts
+++ b/apps/filecoin-site/src/app/build-on-filecoin/data/filecoinTools.ts
@@ -1,4 +1,4 @@
-import { FILECOIN_URLS } from '@/constants/siteMetadata'
+import { FILECOIN_DOCS_URLS } from '@/constants/siteMetadata'
 
 import type { SimpleCardData } from '@/components/SimpleCard'
 
@@ -15,7 +15,7 @@ export const filecoinTools: Array<FilecoinTool> = [
       'Deploy your first storage-backed smart contract quickly and securely.',
     difficulty: 'Beginner',
     cta: {
-      href: `${FILECOIN_URLS.docs}smart-contracts/fundamentals/erc-20-quickstart`,
+      href: FILECOIN_DOCS_URLS.smartContractFundamentalsErc20,
       text: CTA_TEXT,
     },
   },
@@ -34,7 +34,7 @@ export const filecoinTools: Array<FilecoinTool> = [
       'Deep-dive technical recipes for advanced architecture and FVM programming patterns.',
     difficulty: 'Advanced',
     cta: {
-      href: `${FILECOIN_URLS.docs}builder-cookbook/overview`,
+      href: FILECOIN_DOCS_URLS.builderCookbook,
       text: CTA_TEXT,
     },
   },

--- a/apps/filecoin-site/src/app/build-on-filecoin/data/tutorialsAndGuides.ts
+++ b/apps/filecoin-site/src/app/build-on-filecoin/data/tutorialsAndGuides.ts
@@ -1,4 +1,4 @@
-import { FILECOIN_URLS } from '@/constants/siteMetadata'
+import { FILECOIN_DOCS_URLS } from '@/constants/siteMetadata'
 
 import type { SimpleCardData } from '@/components/SimpleCard'
 
@@ -15,7 +15,7 @@ export const tutorialsAndGuides: Array<TutorialsAndGuides> = [
       'A quick intro to Filecoin’s role as a decentralized, verifiable storage network and why developers use it.',
     difficulty: 'Beginner',
     cta: {
-      href: `${FILECOIN_URLS.docs}basics/what-is-filecoin`,
+      href: FILECOIN_DOCS_URLS.basicsWhatIsFilecoin,
       text: CTA_TEXT,
     },
   },
@@ -35,7 +35,7 @@ export const tutorialsAndGuides: Array<TutorialsAndGuides> = [
       'Use the Calibration testnet to build safely. Claim testFIL from the faucet and connect via an RPC endpoint.',
     difficulty: 'Beginner',
     cta: {
-      href: `${FILECOIN_URLS.docs}builder-cookbook/overview`,
+      href: FILECOIN_DOCS_URLS.builderCookbook,
       text: CTA_TEXT,
     },
   },
@@ -45,7 +45,7 @@ export const tutorialsAndGuides: Array<TutorialsAndGuides> = [
       'Upload a file using a storage API or SDK, get a CID, and retrieve it through an IPFS gateway.',
     difficulty: 'Beginner',
     cta: {
-      href: `${FILECOIN_URLS.docs}builder-cookbook/overview`,
+      href: FILECOIN_DOCS_URLS.builderCookbook,
       text: CTA_TEXT,
     },
   },
@@ -55,7 +55,7 @@ export const tutorialsAndGuides: Array<TutorialsAndGuides> = [
       'Use the JavaScript SDK or HTTP API to store and retrieve files directly in your application logic.',
     difficulty: 'Intermediate',
     cta: {
-      href: `${FILECOIN_URLS.docs}builder-cookbook/overview`,
+      href: FILECOIN_DOCS_URLS.builderCookbook,
       text: CTA_TEXT,
     },
   },
@@ -65,7 +65,7 @@ export const tutorialsAndGuides: Array<TutorialsAndGuides> = [
       'Deploy a simple smart contract to store references to Filecoin data on the FEVM.',
     difficulty: 'Intermediate',
     cta: {
-      href: `${FILECOIN_URLS.docs}builder-cookbook/overview`,
+      href: FILECOIN_DOCS_URLS.builderCookbook,
       text: CTA_TEXT,
     },
   },
@@ -75,7 +75,7 @@ export const tutorialsAndGuides: Array<TutorialsAndGuides> = [
       'Create a minimal dApp with a frontend, storage backend, and FVM smart contract working together.',
     difficulty: 'Intermediate',
     cta: {
-      href: `${FILECOIN_URLS.docs}builder-cookbook/overview`,
+      href: FILECOIN_DOCS_URLS.builderCookbook,
       text: CTA_TEXT,
     },
   },
@@ -85,7 +85,7 @@ export const tutorialsAndGuides: Array<TutorialsAndGuides> = [
       'Learn patterns for NFTs, AI datasets, hybrid cloud storage, and cross-chain integrations.',
     difficulty: 'Advanced',
     cta: {
-      href: `${FILECOIN_URLS.docs}builder-cookbook/overview`,
+      href: FILECOIN_DOCS_URLS.builderCookbook,
       text: CTA_TEXT,
     },
   },

--- a/apps/filecoin-site/src/app/build-on-filecoin/page.tsx
+++ b/apps/filecoin-site/src/app/build-on-filecoin/page.tsx
@@ -3,7 +3,7 @@ import Image from 'next/image'
 import { StructuredDataScript } from '@filecoin-foundation/ui/StructuredDataScript'
 
 import { PATHS } from '@/constants/paths'
-import { FILECOIN_URLS } from '@/constants/siteMetadata'
+import { FILECOIN_DOCS_BASE_URL } from '@/constants/siteMetadata'
 
 import { graphicsData } from '@/data/graphicsData'
 
@@ -48,7 +48,7 @@ export default function BuildOnFilecoin() {
           title="Build on Filecoin: open, scalable, verifiable storage"
           description="Filecoin is a programmable, permissionless network from the ground up with cryptographic verification and global redundancy. Integrate decentralized storage that scales with your needs and safeguards data integrity at every layer."
           cta={
-            <Button href={FILECOIN_URLS.docs} variant="primary">
+            <Button href={FILECOIN_DOCS_BASE_URL} variant="primary">
               Explore documentation
             </Button>
           }

--- a/apps/filecoin-site/src/app/learn/data/learnAboutFilecoinProtocol.ts
+++ b/apps/filecoin-site/src/app/learn/data/learnAboutFilecoinProtocol.ts
@@ -1,4 +1,7 @@
-import { FILECOIN_URLS } from '@/constants/siteMetadata'
+import {
+  FILECOIN_DOCS_BASE_URL,
+  FILECOIN_DOCS_URLS,
+} from '@/constants/siteMetadata'
 
 import type { SimpleCardData } from '@/components/SimpleCard'
 
@@ -10,7 +13,7 @@ export const learnAboutFilecoinProtocol: Array<SimpleCardData> = [
     description:
       'Files are retrieved via content identifiers (CIDs) instead of location-based URLs prone to deterioration.',
     cta: {
-      href: `${FILECOIN_URLS.docs}basics/the-blockchain/proofs#proof-of-replication-porep`,
+      href: FILECOIN_DOCS_URLS.basicsBlockhainPoRep,
       text: CTA_TEXT,
     },
   },
@@ -19,7 +22,7 @@ export const learnAboutFilecoinProtocol: Array<SimpleCardData> = [
     description:
       'Clients make programmable deals with independent storage providers in a global marketplace.',
     cta: {
-      href: `${FILECOIN_URLS.docs}basics/the-blockchain/proofs#proof-of-spacetime-post`,
+      href: FILECOIN_DOCS_URLS.basicsBlockhainPoSt,
       text: CTA_TEXT,
     },
   },
@@ -37,7 +40,7 @@ export const learnAboutFilecoinProtocol: Array<SimpleCardData> = [
     description:
       'The native token aligns economic incentives and rewards useful storage over time.',
     cta: {
-      href: `${FILECOIN_URLS.docs}smart-contracts/fundamentals/the-fvm`,
+      href: FILECOIN_DOCS_URLS.smartContractFundamentalsFVM,
       text: CTA_TEXT,
     },
   },
@@ -46,7 +49,7 @@ export const learnAboutFilecoinProtocol: Array<SimpleCardData> = [
     description:
       'The smart-contract layer that lets developers build logic, automation, and apps on top of Filecoin storage.',
     cta: {
-      href: `${FILECOIN_URLS.docs}smart-contracts/fundamentals/the-fvm`,
+      href: FILECOIN_DOCS_URLS.smartContractFundamentalsFVM,
       text: CTA_TEXT,
     },
   },
@@ -55,7 +58,7 @@ export const learnAboutFilecoinProtocol: Array<SimpleCardData> = [
     description:
       'An incentive system that aims to increase the amount of useful data stored on the Filecoin network.',
     cta: {
-      href: `${FILECOIN_URLS.docs}basics/how-storage-works/filecoin-plus`,
+      href: `${FILECOIN_DOCS_BASE_URL}basics/how-storage-works/filecoin-plus`,
       text: CTA_TEXT,
     },
   },

--- a/apps/filecoin-site/src/app/learn/page.tsx
+++ b/apps/filecoin-site/src/app/learn/page.tsx
@@ -3,7 +3,7 @@ import Image from 'next/image'
 import { clsx } from 'clsx'
 
 import { PATHS } from '@/constants/paths'
-import { FILECOIN_URLS } from '@/constants/siteMetadata'
+import { FILECOIN_DOCS_BASE_URL, FILECOIN_URLS } from '@/constants/siteMetadata'
 
 import { graphicsData } from '@/data/graphicsData'
 
@@ -26,8 +26,6 @@ import { learnAboutFilecoinProtocol } from './data/learnAboutFilecoinProtocol'
 import { resilientInternetCta } from './data/resilientInternetCta'
 import { whatIsFilecoinUsedFor } from './data/whatIsFilecoinUsedFor'
 
-const WHAT_IS_FILECOIN_VIDEO_URL = 'https://www.youtube.com/embed/26ZdMAo23mM'
-
 export default function Learn() {
   return (
     <>
@@ -38,7 +36,7 @@ export default function Learn() {
             title="The authenticity layer of a more resilient internet"
             description="Filecoin is the world’s largest decentralized storage network. By leveraging cryptographic verification and global redundancy, Filecoin safeguards humanity's most important information, keeping it free from centralized control."
             cta={
-              <Button href={FILECOIN_URLS.docs} variant="primary">
+              <Button href={FILECOIN_DOCS_BASE_URL} variant="primary">
                 Explore documentation
               </Button>
             }
@@ -60,7 +58,7 @@ export default function Learn() {
             "Today, a handful of corporations control most of the world's data, creating centralized gatekeepers that limit transparency and introduce single points of failure. Filecoin offers a fundamentally different approach to data storage by distributing data across a decentralized, global network, protected by cryptographic proofs.",
           ]}
         >
-          <YouTubeVideoEmbed videoUrl={WHAT_IS_FILECOIN_VIDEO_URL} />
+          <YouTubeVideoEmbed videoUrl={FILECOIN_URLS.video.whatIsFilecoin} />
         </SectionContent>
       </PageSection>
 
@@ -98,7 +96,7 @@ export default function Learn() {
           title="Learn about the Filecoin protocol"
           description="For technically curious people who want to go deeper into how Filecoin actually works."
           cta={
-            <Button href={FILECOIN_URLS.docs} variant="primary">
+            <Button href={FILECOIN_DOCS_BASE_URL} variant="primary">
               Explore documentation
             </Button>
           }

--- a/apps/filecoin-site/src/app/provide-storage/data/filecoinEarningsInsights.ts
+++ b/apps/filecoin-site/src/app/provide-storage/data/filecoinEarningsInsights.ts
@@ -1,4 +1,4 @@
-import { FILECOIN_URLS } from '@/constants/siteMetadata'
+import { FILECOIN_DOCS_URLS } from '@/constants/siteMetadata'
 
 import type { SimpleCardData } from '@/components/SimpleCard'
 
@@ -10,7 +10,7 @@ export const filecoinEarningsInsights: Array<SimpleCardData> = [
     description:
       "Providers are compensated for reliable storage via the network's reward system.",
     cta: {
-      href: `${FILECOIN_URLS.docs}storage-providers/filecoin-economics/block-rewards#block-rewards`,
+      href: FILECOIN_DOCS_URLS.storageProviderBlockRewards,
       text: CTA_TEXT,
     },
   },
@@ -19,7 +19,7 @@ export const filecoinEarningsInsights: Array<SimpleCardData> = [
     description:
       "Growing your storage capacity unlocks greater block rewards, reflecting your increased contribution to the network's foundation.",
     cta: {
-      href: `${FILECOIN_URLS.docs}storage-providers/filecoin-economics/block-rewards#impact-of-storage-capacity-on-block-rewards`,
+      href: FILECOIN_DOCS_URLS.storageProviderBlockRewardsImpact,
       text: CTA_TEXT,
     },
   },
@@ -28,7 +28,7 @@ export const filecoinEarningsInsights: Array<SimpleCardData> = [
     description:
       'Historically, some storage providers have recouped their costs within 30 months, depending on uptime and operational efficiency.',
     cta: {
-      href: `${FILECOIN_URLS.docs}storage-providers/filecoin-economics/block-rewards#block-rewards`,
+      href: FILECOIN_DOCS_URLS.storageProviderBlockRewards,
       text: 'Learn more',
     },
   },


### PR DESCRIPTION
## 📝 Description

- Replaced instances of FILECOIN_URLS.docs with `FILECOIN_DOCS_BASE_URL `
- Introduced `FILECOIN_DOCS_URLS` for structured documentation URLs
- Updated navigation and resource components to reflect the new constants

- **Type:** Refactor

