### PR TITLE
[UXIT-2591] Add broken link checker on FFDW

### DIFF
--- a/apps/ffdweb-site/cypress/e2e/about.cy.ts
+++ b/apps/ffdweb-site/cypress/e2e/about.cy.ts
@@ -14,6 +14,10 @@ describe('About Page', () => {
     })
   })
 
+  it(tests.links.prompt, () => {
+    tests.links.fn(PATHS.ABOUT.path)
+  })
+
   it(tests.visualSnapshot.prompt, () => {
     tests.visualSnapshot.fn({
       path: PATHS.ABOUT.path,

--- a/apps/ffdweb-site/cypress/e2e/blog_index.cy.ts
+++ b/apps/ffdweb-site/cypress/e2e/blog_index.cy.ts
@@ -14,6 +14,10 @@ describe('Blog Index Page', () => {
     })
   })
 
+  it(tests.links.prompt, () => {
+    tests.links.fn(PATHS.BLOG.path)
+  })
+
   it(tests.visualSnapshot.prompt, () => {
     tests.visualSnapshot.fn({
       path: PATHS.BLOG.path,

--- a/apps/ffdweb-site/cypress/e2e/blog_slug.cy.ts
+++ b/apps/ffdweb-site/cypress/e2e/blog_slug.cy.ts
@@ -27,4 +27,10 @@ describe('Blog Slug Page', () => {
       })
     })
   })
+
+  it(tests.links.prompt, () => {
+    cy.task<string>('getRandomSlug', CONTENT_FOLDER).then((slug) => {
+      tests.links.fn(`${PATHS.BLOG.path}/${slug}`)
+    })
+  })
 })

--- a/apps/ffdweb-site/cypress/e2e/digest_index.cy.ts
+++ b/apps/ffdweb-site/cypress/e2e/digest_index.cy.ts
@@ -14,6 +14,10 @@ describe('Digest Index Page', () => {
     })
   })
 
+  it(tests.links.prompt, () => {
+    tests.links.fn(PATHS.DIGEST.path)
+  })
+
   it(tests.visualSnapshot.prompt, () => {
     tests.visualSnapshot.fn({
       path: PATHS.DIGEST.path,

--- a/apps/ffdweb-site/cypress/e2e/digest_slug.cy.ts
+++ b/apps/ffdweb-site/cypress/e2e/digest_slug.cy.ts
@@ -26,4 +26,10 @@ describe('Digest Slug Page', () => {
       })
     })
   })
+
+  it(tests.links.prompt, () => {
+    cy.task<string>('getRandomSlug', CONTENT_FOLDER).then((slug) => {
+      tests.links.fn(`${PATHS.DIGEST.path}/${slug}`)
+    })
+  })
 })

--- a/apps/ffdweb-site/cypress/e2e/faqs.cy.ts
+++ b/apps/ffdweb-site/cypress/e2e/faqs.cy.ts
@@ -14,6 +14,10 @@ describe('FAQs Page', () => {
     })
   })
 
+  it(tests.links.prompt, () => {
+    tests.links.fn(PATHS.FAQS.path)
+  })
+
   it(tests.visualSnapshot.prompt, () => {
     tests.visualSnapshot.fn({
       path: PATHS.FAQS.path,

--- a/apps/ffdweb-site/cypress/e2e/home.cy.ts
+++ b/apps/ffdweb-site/cypress/e2e/home.cy.ts
@@ -14,6 +14,10 @@ describe('Home Page', () => {
     })
   })
 
+  it(tests.links.prompt, () => {
+    tests.links.fn(PATHS.HOME.path)
+  })
+
   it(tests.visualSnapshot.prompt, () => {
     tests.visualSnapshot.fn({
       path: PATHS.HOME.path,

--- a/apps/ffdweb-site/cypress/e2e/learning_resources.cy.ts
+++ b/apps/ffdweb-site/cypress/e2e/learning_resources.cy.ts
@@ -14,6 +14,10 @@ describe('Learning Resources Page', () => {
     })
   })
 
+  it(tests.links.prompt, () => {
+    tests.links.fn(PATHS.LEARNING_RESOURCES.path)
+  })
+
   it(tests.visualSnapshot.prompt, () => {
     tests.visualSnapshot.fn({
       path: PATHS.LEARNING_RESOURCES.path,

--- a/apps/ffdweb-site/cypress/e2e/privacy_policy.cy.ts
+++ b/apps/ffdweb-site/cypress/e2e/privacy_policy.cy.ts
@@ -15,6 +15,10 @@ describe('Privacy Policy Page', () => {
     })
   })
 
+  it(tests.links.prompt, () => {
+    tests.links.fn(PATHS.PRIVACY_POLICY.path)
+  })
+
   it(tests.visualSnapshot.prompt, () => {
     tests.visualSnapshot.fn({
       path: PATHS.PRIVACY_POLICY.path,

--- a/apps/ffdweb-site/cypress/e2e/projects_index.cy.ts
+++ b/apps/ffdweb-site/cypress/e2e/projects_index.cy.ts
@@ -14,6 +14,10 @@ describe('Projects Index Page', () => {
     })
   })
 
+  it(tests.links.prompt, () => {
+    tests.links.fn(PATHS.PROJECTS.path)
+  })
+
   it(tests.visualSnapshot.prompt, () => {
     tests.visualSnapshot.fn({
       path: PATHS.PROJECTS.path,

--- a/apps/ffdweb-site/cypress/e2e/projects_slug.cy.ts
+++ b/apps/ffdweb-site/cypress/e2e/projects_slug.cy.ts
@@ -27,4 +27,10 @@ describe('Projects Slug Page', () => {
       })
     })
   })
+
+  it(tests.links.prompt, () => {
+    cy.task<string>('getRandomSlug', CONTENT_FOLDER).then((slug) => {
+      tests.links.fn(`${PATHS.PROJECTS.path}/${slug}`)
+    })
+  })
 })

--- a/apps/ffdweb-site/cypress/e2e/terms_of_use.cy.ts
+++ b/apps/ffdweb-site/cypress/e2e/terms_of_use.cy.ts
@@ -15,6 +15,10 @@ describe('Terms of Use Page', () => {
     })
   })
 
+  it(tests.links.prompt, () => {
+    tests.links.fn(PATHS.TERMS_OF_USE.path)
+  })
+
   it(tests.visualSnapshot.prompt, () => {
     tests.visualSnapshot.fn({
       path: PATHS.TERMS_OF_USE.path,

--- a/apps/ffdweb-site/cypress/support/index.ts
+++ b/apps/ffdweb-site/cypress/support/index.ts
@@ -2,6 +2,7 @@
 
 import '@percy/cypress'
 
+import { verifyLinks } from '@filecoin-foundation/cypress/links'
 import { testPageMetaData } from '@filecoin-foundation/cypress/metadata'
 
 import { testVisualSnapshot } from './testVisualSnapshot'
@@ -10,6 +11,10 @@ export const tests = {
   metadata: {
     prompt: 'should have valid metadata',
     fn: testPageMetaData,
+  },
+  links: {
+    prompt: 'should check links',
+    fn: verifyLinks,
   },
   visualSnapshot: {
     prompt: 'should match visual snapshot',


### PR DESCRIPTION
## 📝 Description

This PR implements the shared cypress link checker test on FFDW.

<img width="1654" height="996" alt="CleanShot 2025-08-20 at 17 11 25@2x" src="https://github.com/user-attachments/assets/75b4f4c4-802e-4107-a717-bb0863a2daf8" />
