### PR TITLE
[FILECOIN][UXIT-3175] Announcement component fixes [skip percy]

### DIFF
--- a/apps/filecoin-site/src/app/(homepage)/components/Announcement.tsx
+++ b/apps/filecoin-site/src/app/(homepage)/components/Announcement.tsx
@@ -13,20 +13,20 @@ export type AnnouncementProps = {
 
 export function Announcement({ children, href, centered }: AnnouncementProps) {
   return (
-    <div className={clsx('flex', centered && 'justify-center')}>
+    <div className={clsx('group flex', centered && 'justify-center')}>
       <Link
         href={href}
         aria-label={`${children} - Click to learn more`}
         className="group focus:brand-outline rounded-full"
       >
         <aside
-          className="gap relative flex items-center rounded-full border border-[var(--color-announcement-border)] bg-[var(--color-announcement-background)] p-1 group-focus:bg-[var(--color-announcement-background-hover)] hover:bg-[var(--color-announcement-background-hover)]"
+          className="gap relative flex items-center rounded-full border border-[var(--color-announcement-border)] bg-[var(--color-announcement-background)] p-1 group-hover:bg-[var(--color-announcement-background-hover)] group-focus:bg-[var(--color-announcement-background-hover)]"
           role="banner"
         >
           <span className="ml-4 text-sm font-medium sm:text-base">
             {children}
           </span>
-          <span className="ml-4 grid size-8 shrink-0 place-items-center rounded-full bg-[var(--color-announcement-icon-background)] text-[--color-announcement-icon]">
+          <span className="ml-4 grid size-8 shrink-0 place-items-center rounded-full bg-[var(--color-announcement-icon-background)] text-[--color-announcement-icon] group-hover:bg-[var(--color-announcement-icon-background-hover)] group-focus:bg-[var(--color-announcement-icon-background-hover)]">
             <Icon component={ArrowRightIcon} size={16} />
           </span>
         </aside>

--- a/apps/filecoin-site/src/app/_styles/globals.css
+++ b/apps/filecoin-site/src/app/_styles/globals.css
@@ -141,6 +141,7 @@
   --color-announcement-border: theme('colors.zinc.800');
   --color-announcement-icon: theme('colors.zinc.200');
   --color-announcement-icon-background: theme('colors.zinc.800');
+  --color-announcement-icon-background-hover: theme('colors.zinc.700');
 }
 
 @layer components {


### PR DESCRIPTION
## 📝 Description

- add `--color-announcement-icon-background-hover`
- add `group-focus` and `group-hover` styles

- **Type:** Bug fix 

## 📸 Screenshots

<img width="786" height="526" alt="Screenshot 2025-08-21 at 13 21 24" src="https://github.com/user-attachments/assets/f64de747-8a55-4b21-a09c-9e403e535e19" />
