### PR TITLE
[FILECOIN][UXIT-3185] Add NavigationLanguageToggle to Main Navigation

### DIFF
--- a/apps/filecoin-site/src/app/_components/Navigation/DesktopNavigation.tsx
+++ b/apps/filecoin-site/src/app/_components/Navigation/DesktopNavigation.tsx
@@ -11,6 +11,7 @@ import { backgroundVariants } from '@/components/Section'
 import type { SectionProps } from '../Section'
 
 import { variantMapping } from './constants'
+import { NavigationLanguageToggle } from './NavigationLanguageToggle'
 import {
   NavigationMainLink,
   baseStyle,
@@ -28,40 +29,40 @@ export function DesktopNavigation({
   const desktopBackgroundVariant = variantMapping[backgroundVariant]
 
   return (
-    <ul
-      aria-label="Main navigation menu"
-      className="hidden xl:flex xl:items-center xl:gap-9"
-    >
-      {navigationBis.map((item) => {
-        if ('items' in item) {
-          return (
-            <NavigationMenu
-              key={item.label}
-              as="li"
-              label={item.label}
-              labelClassName={clsx(
-                baseStyle,
-                desktopStyle,
-                'inline-flex items-center gap-2',
-              )}
-              panelClassName={clsx(
-                'rounded-xl',
-                backgroundVariants[desktopBackgroundVariant],
-              )}
-            >
-              <div className="rounded-xl border border-[var(--color-navigation-menu-panel-border)] bg-[var(--color-navigation-menu-panel-background)] py-6">
-                <NavigationMenuPanel items={item.items} />
-              </div>
-            </NavigationMenu>
-          )
-        }
+    <div className="hidden xl:flex xl:w-full xl:items-center xl:justify-between xl:gap-4">
+      <ul aria-label="Main navigation menu" className="flex items-center gap-9">
+        {navigationBis.map((item) => {
+          if ('items' in item) {
+            return (
+              <NavigationMenu
+                key={item.label}
+                as="li"
+                label={item.label}
+                labelClassName={clsx(
+                  baseStyle,
+                  desktopStyle,
+                  'inline-flex items-center gap-2',
+                )}
+                panelClassName={clsx(
+                  'rounded-xl',
+                  backgroundVariants[desktopBackgroundVariant],
+                )}
+              >
+                <div className="rounded-xl border border-[var(--color-navigation-menu-panel-border)] bg-[var(--color-navigation-menu-panel-background)] py-6">
+                  <NavigationMenuPanel items={item.items} />
+                </div>
+              </NavigationMenu>
+            )
+          }
 
-        return (
-          <li key={item.href}>
-            <NavigationMainLink on="desktop" {...item} />
-          </li>
-        )
-      })}
-    </ul>
+          return (
+            <li key={item.href}>
+              <NavigationMainLink on="desktop" {...item} />
+            </li>
+          )
+        })}
+      </ul>
+      <NavigationLanguageToggle />
+    </div>
   )
 }

--- a/apps/filecoin-site/src/app/_components/Navigation/NavigationLanguageToggle.tsx
+++ b/apps/filecoin-site/src/app/_components/Navigation/NavigationLanguageToggle.tsx
@@ -1,0 +1,34 @@
+'use client'
+
+import { useState } from 'react'
+
+import { Button } from '@headlessui/react'
+import { clsx } from 'clsx'
+
+import { desktopStyle } from './NavigationMainLink'
+
+const languages = [
+  { key: 'en', label: 'EN', ariaLabel: 'Switch to English' },
+  { key: 'zh', label: '中文', ariaLabel: 'Switch to Chinese' },
+] as const
+
+export function NavigationLanguageToggle() {
+  const [locale, setLocale] = useState<'en' | 'zh'>('en')
+
+  return (
+    <div className="flex items-center gap-6 font-medium">
+      {languages.map(({ key, label, ariaLabel }) => (
+        <Button
+          key={key}
+          type="button"
+          aria-label={ariaLabel}
+          aria-current={locale === key}
+          className={clsx(desktopStyle, 'focus:brand-outline')}
+          onClick={() => setLocale(key)}
+        >
+          {label}
+        </Button>
+      ))}
+    </div>
+  )
+}


### PR DESCRIPTION
## 📝 Description

This PR introduces the `NavigationLanguageToggle` component, allowing users to switch between English and Mandarin.  
The toggle’s core logic is not fully implemented yet — final behavior will be completed once we integrate with Transifex.  

- **Type:** New Feature

## 🛠️ Key Changes

- Added new `NavigationLanguageToggle` component
- Integrated `NavigationLanguageToggle` into the navigation

## 📸 Screenshots

<img width="2608" height="200" alt="Navigation Language Toggle Screenshot" src="https://github.com/user-attachments/assets/5970939b-55ad-4ebe-b07a-2640305d73ed" />