### PR TITLE
[FILECOIN][UXIT-3189] Include Open Graph and Twitter Metadata [skip percy]

### DIFF
--- a/apps/filecoin-site/src/app/(homepage)/page.tsx
+++ b/apps/filecoin-site/src/app/(homepage)/page.tsx
@@ -125,7 +125,7 @@ export default async function Home() {
             ]}
           />
 
-          <SectionImage {...graphicsData.learnLibrarySection} />
+          <SectionImage {...graphicsData.classicLibraryInterior} />
         </SectionContent>
       </PageSection>
 
@@ -145,8 +145,8 @@ export default async function Home() {
             }
           />
           <Image
-            src={graphicsData.homepageIPFSIllustration.data}
-            alt={graphicsData.homepageIPFSIllustration.alt}
+            src={graphicsData.IPFSIllustration.data}
+            alt={graphicsData.IPFSIllustration.alt}
             className="h-72 min-w-80 object-contain"
           />
         </SectionContentWrapper>
@@ -269,5 +269,5 @@ export const metadata = createMetadata({
   title: { absolute: SEO.title },
   description: SEO.description,
   path: PATHS.HOME.path,
-  image: '', // #todo: add image
+  image: graphicsData.classicLibraryInterior.data.src,
 })

--- a/apps/filecoin-site/src/app/_data/graphicsData.ts
+++ b/apps/filecoin-site/src/app/_data/graphicsData.ts
@@ -1,9 +1,9 @@
 import type { StaticImageProps } from '@filecoin-foundation/utils/types/imageType'
 
-import buildpPageGradient from '@/assets/graphics/build-gradient.svg'
+import buildOnFilecoinGradient from '@/assets/graphics/build-gradient.svg'
 import caseStudiesGradient from '@/assets/graphics/case-studies-gradient.svg'
 import classicLibraryInterior from '@/assets/graphics/classic-library-interior.webp'
-import communityGradient from '@/assets/graphics/community-gradient.svg'
+import communityHubGradient from '@/assets/graphics/community-gradient.svg'
 import dataCenterServerRow from '@/assets/graphics/data-center-server-row.webp'
 import digitalMediaConversionSetup from '@/assets/graphics/digital-media-conversion-setup.webp'
 import earthAtNight from '@/assets/graphics/earth-at-night.png'
@@ -21,24 +21,28 @@ import starsSpinning from '@/assets/graphics/stars-spinning.webp'
 
 export const graphicsData = {
   buildOnFilecoinGradient: {
-    data: buildpPageGradient,
+    data: buildOnFilecoinGradient,
     alt: '',
   },
-  buildOnFilecoinHero: {
-    data: dataCenterServerRow,
-    alt: 'Row of black server towers with glowing blue Filecoin logos in a dark data center.',
-  },
-  buildOnFilecoinSection: {
-    data: spiralGalaxyStarsSpace,
-    alt: 'A detailed view of a spiral galaxy with bright stars, glowing nebulae, and swirling blue and golden star fields in deep space.',
-  },
-  caseStudies: {
+  caseStudiesGradient: {
     data: caseStudiesGradient,
     alt: '',
   },
-  communityHero: {
-    data: communityGradient,
+  classicLibraryInterior: {
+    data: classicLibraryInterior,
+    alt: 'Interior of a grand historic library with high vaulted wooden ceiling, rows of tall bookshelves, and marble busts lining the hall.',
+  },
+  communityHubGradient: {
+    data: communityHubGradient,
     alt: '',
+  },
+  dataCenterServerRow: {
+    data: dataCenterServerRow,
+    alt: 'Row of black server towers with glowing blue Filecoin logos in a dark data center.',
+  },
+  digitalMediaConversionSetup: {
+    data: digitalMediaConversionSetup,
+    alt: 'Collection of digital and analog media formats including VHS tapes, cassettes, CDs, USB drive, film reels, and photographs.',
   },
   earthAtNight: {
     data: earthAtNight,
@@ -48,48 +52,44 @@ export const graphicsData = {
     data: imageFallback,
     alt: 'Image coming soon',
   },
+  filecoinMiningRig: {
+    data: filecoinMiningRig,
+    alt: 'Blue Filecoin mining rig with scattered and stacked Filecoin-branded coins on the floor.',
+  },
+  filecoinServerRack: {
+    data: filecoinServerRack,
+    alt: 'Filecoin-branded blue server racks with one open unit revealing rows of storage drives.',
+  },
+  filecoinStorageDevice: {
+    data: filecoinStorageDevice,
+    alt: 'Black storage device with Filecoin logo and glowing green indicator lights.',
+  },
   homepageGradient: {
     data: homepageGradient,
     alt: '',
   },
-  homepageIPFSIllustration: {
+  IPFSIllustration: {
     data: IPFSIllustration,
     alt: 'Illustration showing the IPFS cube logo in the center with Filecoin logos surrounding it.',
-  },
-  learnHero: {
-    data: filecoinServerRack,
-    alt: 'Filecoin-branded blue server racks with one open unit revealing rows of storage drives.',
-  },
-  learnLibrarySection: {
-    data: classicLibraryInterior,
-    alt: 'Interior of a grand historic library with high vaulted wooden ceiling, rows of tall bookshelves, and marble busts lining the hall.',
   },
   planetsShadow: {
     data: planetsShadow,
     alt: '',
   },
-  provideStorageHero: {
-    data: filecoinMiningRig,
-    alt: 'Blue Filecoin mining rig with scattered and stacked Filecoin-branded coins on the floor.',
-  },
-  provideStorageSection: {
-    data: serverBladeChassis,
-    alt: 'Front view of a server blade chassis with multiple slots, each marked with glowing Filecoin logos.',
-  },
-  provideStorageSection2: {
-    data: filecoinStorageDevice,
-    alt: 'Black storage device with Filecoin logo and glowing green indicator lights.',
-  },
   rocketLaunch: {
     data: rocketLaunch,
     alt: 'A rocket launching into the sky with bright flames and smoke clouds rising from the launch pad, reflected in the water below.',
   },
+  serverBladeChassis: {
+    data: serverBladeChassis,
+    alt: 'Front view of a server blade chassis with multiple slots, each marked with glowing Filecoin logos.',
+  },
+  spiralGalaxyStarsSpace: {
+    data: spiralGalaxyStarsSpace,
+    alt: 'A detailed view of a spiral galaxy with bright stars, glowing nebulae, and swirling blue and golden star fields in deep space.',
+  },
   starsSpinning: {
     data: starsSpinning,
     alt: 'Long-exposure photograph of the night sky showing star trails swirling in circular motion.',
-  },
-  storeDataHero: {
-    data: digitalMediaConversionSetup,
-    alt: 'Collection of digital and analog media formats including VHS tapes, cassettes, CDs, USB drive, film reels, and photographs.',
   },
 } as const satisfies Record<string, StaticImageProps>

--- a/apps/filecoin-site/src/app/_utils/createMetadata.ts
+++ b/apps/filecoin-site/src/app/_utils/createMetadata.ts
@@ -5,7 +5,7 @@ import {
 
 import { FILECOIN_URLS, ORGANIZATION_NAME } from '@/constants/siteMetadata'
 
-// import { graphicsData } from '@/data/graphicsData'
+import { graphicsData } from '@/data/graphicsData'
 
 export type MetadataParams = Omit<
   SharedMetadataParams,
@@ -15,7 +15,7 @@ export type MetadataParams = Omit<
 export function createMetadata(args: MetadataParams) {
   return sharedCreateMetadata({
     ...args,
-    fallbackImage: '', // #todo: add image
+    fallbackImage: graphicsData.fallback.data.src,
     orgName: ORGANIZATION_NAME,
     orgHandle: FILECOIN_URLS.social.twitter.handle,
   })

--- a/apps/filecoin-site/src/app/build-on-filecoin/page.tsx
+++ b/apps/filecoin-site/src/app/build-on-filecoin/page.tsx
@@ -79,7 +79,7 @@ export default function BuildOnFilecoin() {
         </SectionContent>
 
         <div className="mt-15 md:mt-20">
-          <SectionImage {...graphicsData.buildOnFilecoinSection} />
+          <SectionImage {...graphicsData.spiralGalaxyStarsSpace} />
         </div>
       </PageSection>
 
@@ -209,5 +209,5 @@ export const metadata = createMetadata({
   title: { absolute: BUILD_ON_FILECOIN_SEO.title },
   description: BUILD_ON_FILECOIN_SEO.description,
   path: PATHS.BUILD_ON_FILECOIN.path,
-  image: graphicsData.buildOnFilecoinSection.data.src,
+  image: graphicsData.spiralGalaxyStarsSpace.data.src,
 })

--- a/apps/filecoin-site/src/app/build-on-filecoin/page.tsx
+++ b/apps/filecoin-site/src/app/build-on-filecoin/page.tsx
@@ -209,4 +209,5 @@ export const metadata = createMetadata({
   title: { absolute: BUILD_ON_FILECOIN_SEO.title },
   description: BUILD_ON_FILECOIN_SEO.description,
   path: PATHS.BUILD_ON_FILECOIN.path,
+  image: graphicsData.buildOnFilecoinSection.data.src,
 })

--- a/apps/filecoin-site/src/app/case-studies/page.tsx
+++ b/apps/filecoin-site/src/app/case-studies/page.tsx
@@ -40,7 +40,7 @@ export default function CaseStudies() {
           />
         </PageSection>
 
-        <graphicsData.caseStudies.data className="absolute -top-[840px] right-0 -z-10 hidden w-[600px] overflow-visible sm:block" />
+        <graphicsData.caseStudiesGradient.data className="absolute -top-[840px] right-0 -z-10 hidden w-[600px] overflow-visible sm:block" />
       </div>
 
       <PageSection paddingVariant="topOnly" backgroundVariant="dark">

--- a/apps/filecoin-site/src/app/community-hub/page.tsx
+++ b/apps/filecoin-site/src/app/community-hub/page.tsx
@@ -49,7 +49,7 @@ export default function CommunityHub() {
           />
         </PageSection>
 
-        <graphicsData.communityHero.data className="absolute -top-[25vw] left-[8vw] -z-10 w-[133vw]" />
+        <graphicsData.communityHubGradient.data className="absolute -top-[25vw] left-[8vw] -z-10 w-[133vw]" />
       </div>
 
       <PageSection backgroundVariant="dark">
@@ -128,7 +128,7 @@ export default function CommunityHub() {
           }
         />
         <div className="mt-40">
-          <SectionImage {...graphicsData.buildOnFilecoinSection} />
+          <SectionImage {...graphicsData.spiralGalaxyStarsSpace} />
         </div>
       </PageSection>
     </>

--- a/apps/filecoin-site/src/app/provide-storage/page.tsx
+++ b/apps/filecoin-site/src/app/provide-storage/page.tsx
@@ -81,7 +81,7 @@ export default function ProvideStorage() {
           title="Optimize your storage potential"
           description="The Filecoin network empowers storage providers through a sustainable, incentive-driven marketplace built for longevity and reliability."
         >
-          <SectionImage {...graphicsData.provideStorageSection} />
+          <SectionImage {...graphicsData.serverBladeChassis} />
 
           <CardGrid as="ul" variant="smTwoLgThreeWider">
             {filecoinEarningsInsights.map(({ title, description, cta }) => (
@@ -170,7 +170,7 @@ export default function ProvideStorage() {
       </PageSection>
 
       <PageSection backgroundVariant="dark">
-        <SectionImage {...graphicsData.provideStorageSection2} />
+        <SectionImage {...graphicsData.filecoinStorageDevice} />
 
         <SectionContent
           title="Empower a more open and resilient web"
@@ -193,4 +193,5 @@ export const metadata = createMetadata({
   title: { absolute: PROVIDE_STORAGE_SEO.title },
   description: PROVIDE_STORAGE_SEO.description,
   path: PATHS.PROVIDE_STORAGE.path,
+  image: graphicsData.filecoinStorageDevice.data.src,
 })

--- a/apps/filecoin-site/src/app/store-data/page.tsx
+++ b/apps/filecoin-site/src/app/store-data/page.tsx
@@ -125,4 +125,5 @@ export const metadata = createMetadata({
   title: { absolute: STORE_DATA_SEO.title },
   description: STORE_DATA_SEO.description,
   path: PATHS.STORE_DATA.path,
+  image: graphicsData.digitalMediaConversionSetup.data.src,
 })


### PR DESCRIPTION
## 📝 Description

* Added image sources for the `homepage`, `community-hub`, `provide-storage`, and `store-data` pages (see social card screenshots below) - the rest uses `fallback` image.
* Renamed some `graphicsData` images as some of the naming wasn't relevant anymore - for example, instead of `learnHero` I reused the name of the image file (`classicLibraryInterior`).

- **Type:** Bug fix / Refactor

### List of pages with fallback image on social cards:

- `blog`
- `case-studies`
- `learn`
- `provide-storage/onboarding`
- `privacy-policy`
- `terms-of-use`

## 📸 Screenshots

### Homepage
<img width="1733" height="1045" alt="Screenshot 2025-08-26 at 14 10 37" src="https://github.com/user-attachments/assets/5e97847c-0810-4100-9fe8-96b807edcd8e" />

### Store Data
<img width="1733" height="1045" alt="Screenshot 2025-08-26 at 14 11 22" src="https://github.com/user-attachments/assets/809ad547-eeca-4dc2-bb7e-3fd08e2b04ba" />

### Provide Storage
<img width="1733" height="1045" alt="Screenshot 2025-08-26 at 14 11 33" src="https://github.com/user-attachments/assets/68872ead-c6d6-457d-a16e-3dcb5ee41477" />

### Build on Filecoin
<img width="1733" height="1045" alt="Screenshot 2025-08-26 at 14 11 45" src="https://github.com/user-attachments/assets/cce057d5-f3ed-4a35-b674-d95cc3858418" />

### Blog Post
<img width="1733" height="1045" alt="Screenshot 2025-08-26 at 14 12 18" src="https://github.com/user-attachments/assets/86cf0f35-5958-47cc-ad92-23cf62ebfb1e" />
