### PR TITLE
UXIT-3196/fix-warnings

### DIFF
--- a/apps/filecoin-site/next.config.ts
+++ b/apps/filecoin-site/next.config.ts
@@ -3,6 +3,7 @@ import type { NextConfig } from 'next'
 import {
   outputFileTracingExcludes,
   outputFileTracingIncludes,
+  outputFileTracingRoot,
   webpackRules,
 } from '@filecoin-foundation/next-config'
 
@@ -10,6 +11,7 @@ import {
 const nextConfig: NextConfig = {
   outputFileTracingIncludes,
   outputFileTracingExcludes,
+  outputFileTracingRoot,
   images: {
     qualities: [75, 85, 100],
   },

--- a/apps/filecoin-site/src/app/_components/ImageGrid.tsx
+++ b/apps/filecoin-site/src/app/_components/ImageGrid.tsx
@@ -4,26 +4,37 @@ import type { ImageProps } from 'next/image'
 
 import { clsx } from 'clsx'
 
+import { buildImageSizeProp } from '@filecoin-foundation/utils/buildImageSizeProp'
+
 type ImageGridProps = {
   children: Array<React.ReactElement<ImageProps>>
   variant: keyof typeof variants
 }
 
+const sharedGridStyle =
+  'auto-rows-[192px] grid-cols-1 gap-1 md:auto-rows-[300px] md:grid-cols-3'
+
 const variants = {
   oneMdThree: {
-    gridStyle:
-      'auto-rows-[192px] grid-cols-1 gap-1 md:auto-rows-[300px] md:grid-cols-3',
-    getCellStyle: () => '',
+    getGridStyle: () => sharedGridStyle,
+    getCellStyle: () => undefined,
+    getImageSizes: () => buildImageSizeProp({ startSize: '100vw', md: '33vw' }),
   },
   oneMdThreeCollage: {
-    gridStyle:
-      'auto-rows-[192px] grid-cols-1 gap-1 md:auto-rows-[300px] md:grid-cols-3',
-    getCellStyle: (i: number) =>
-      clsx(
-        'h-full w-full',
+    getGridStyle: () => sharedGridStyle,
+    getCellStyle: (i: number) => {
+      return clsx(
         i === 0 && 'md:col-span-2 md:row-span-2',
         i === 2 && 'md:col-start-3 md:row-span-2',
-      ),
+      )
+    },
+    getImageSizes: (i: number) => {
+      if (i === 0) {
+        return buildImageSizeProp({ startSize: '100vw', md: '66vw' })
+      }
+
+      return buildImageSizeProp({ startSize: '100vw', md: '33vw' })
+    },
   },
 } as const
 
@@ -31,19 +42,20 @@ export function ImageGrid({ children, variant }: ImageGridProps) {
   const variantConfig = variants[variant]
 
   return (
-    <div className={clsx('grid', variantConfig.gridStyle)}>
+    <div className={clsx('grid', variantConfig.getGridStyle())}>
       {React.Children.map(children, (child, i) => {
         return (
           <div
             className={clsx(
               'relative h-full w-full',
-              variantConfig?.getCellStyle(i),
+              variantConfig.getCellStyle(i),
             )}
           >
             {React.cloneElement(child, {
               ...child.props,
-              className: clsx(child.props.className, 'object-cover'),
+              className: clsx('object-cover', child.props.className),
               fill: true,
+              sizes: variantConfig.getImageSizes(i),
             })}
           </div>
         )

--- a/apps/filecoin-site/src/app/_components/SiteLayout.tsx
+++ b/apps/filecoin-site/src/app/_components/SiteLayout.tsx
@@ -19,6 +19,7 @@ const funnelSans = localFont({
   display: 'swap',
   variable: '--font-funnel-sans',
   fallback: ['Arial', 'Helvetica', 'sans-serif'],
+  preload: false,
 })
 
 const aspekta = localFont({
@@ -26,6 +27,7 @@ const aspekta = localFont({
   display: 'swap',
   variable: '--font-aspekta',
   fallback: ['Arial', 'Helvetica', 'sans-serif'],
+  preload: false,
 })
 
 export function SiteLayout({ children }: SiteLayoutProps) {

--- a/apps/filecoin-site/src/app/_components/SiteLayout.tsx
+++ b/apps/filecoin-site/src/app/_components/SiteLayout.tsx
@@ -13,17 +13,9 @@ type SiteLayoutProps = {
   children: React.ReactNode
 }
 
+// funnelSans also has an italic version in the same directory. We don't use italics as of now so it's not imported here.
 const funnelSans = localFont({
-  src: [
-    {
-      path: '../_fonts/Funnel_Sans/FunnelSans[wght].woff2',
-      style: 'normal',
-    },
-    {
-      path: '../_fonts/Funnel_Sans/FunnelSans-Italic[wght].woff2',
-      style: 'italic',
-    },
-  ],
+  src: '../_fonts/Funnel_Sans/FunnelSans[wght].woff2',
   display: 'swap',
   variable: '--font-funnel-sans',
   fallback: ['Arial', 'Helvetica', 'sans-serif'],

--- a/apps/filecoin-site/src/app/learn/page.tsx
+++ b/apps/filecoin-site/src/app/learn/page.tsx
@@ -47,7 +47,7 @@ export default function Learn() {
           priority
           src={graphicsData.earthAtNight.data}
           alt={graphicsData.earthAtNight.alt}
-          className="absolute top-0 right-0 -z-10 h-[110vh] translate-x-1/3 rotate-[15deg] transform object-contain object-right-top sm:translate-x-0 sm:rotate-0"
+          className="absolute top-0 right-0 -z-10 h-[110vh] w-auto translate-x-1/3 rotate-[15deg] transform object-contain object-right-top sm:translate-x-0 sm:rotate-0"
         />
       </div>
 

--- a/apps/filecoin-site/src/app/store-data/components/StorageProviderCard/StorageProviderCard.tsx
+++ b/apps/filecoin-site/src/app/store-data/components/StorageProviderCard/StorageProviderCard.tsx
@@ -16,6 +16,8 @@ export type StorageProviderCardProps = {
   logo: StaticImageData
 }
 
+const LOGO_SIZE = 40
+
 export function StorageProviderCard({
   name,
   description,
@@ -29,11 +31,12 @@ export function StorageProviderCard({
       <article className="focus-within:brand-outline relative flex h-full flex-col justify-between space-y-8 overflow-hidden rounded-2xl border border-[var(--color-border-muted)] p-8 pb-16 focus-within:bg-zinc-50 hover:bg-zinc-50">
         <div className="flex items-center gap-3">
           <Image
-            src={logo}
+            src={logo.src}
             alt={`${name}'s logo`}
-            width={40}
-            height={40}
-            className="rounded-full"
+            width={LOGO_SIZE}
+            height={LOGO_SIZE}
+            sizes={`${LOGO_SIZE}px`}
+            className="w-auto rounded-full"
           />
 
           <Heading tag="h3" variant="card-heading">

--- a/apps/uxit/next.config.mjs
+++ b/apps/uxit/next.config.mjs
@@ -1,5 +1,8 @@
 // @ts-check
-import { outputFileTracingExcludes } from '@filecoin-foundation/next-config'
+import {
+  outputFileTracingExcludes,
+  outputFileTracingRoot,
+} from '@filecoin-foundation/next-config'
 
 const webpackRules = [
   {
@@ -14,6 +17,7 @@ const outputFileTracingIncludes = {
 
 /** @type {import('next').NextConfig} */
 const nextConfig = {
+  outputFileTracingRoot,
   outputFileTracingIncludes,
   outputFileTracingExcludes,
   webpack: (config) => {

--- a/packages/cypress/src/links/verifyLinks.ts
+++ b/packages/cypress/src/links/verifyLinks.ts
@@ -35,6 +35,6 @@ function isClientOrServerError(status: number) {
   )
 }
 
-function getErrorMessage(response: Cypress.Response<any>) {
+function getErrorMessage(response: Cypress.Response<unknown>) {
   return `Status code: ${response.status} (${response.statusText})`
 }

--- a/packages/next-config/src/createNextConfig.js
+++ b/packages/next-config/src/createNextConfig.js
@@ -5,6 +5,7 @@ import {
   createSentryConfig,
   outputFileTracingIncludes,
   outputFileTracingExcludes,
+  outputFileTracingRoot,
   webpackRules as baseWebpackRules,
 } from '@filecoin-foundation/next-config'
 
@@ -32,6 +33,7 @@ export function createNextConfig({
       },
       outputFileTracingIncludes,
       outputFileTracingExcludes,
+      outputFileTracingRoot,
       webpack: (config) => {
         config.module.rules.push(...baseWebpackRules, ...extraWebpackRules)
         return config

--- a/packages/next-config/src/index.js
+++ b/packages/next-config/src/index.js
@@ -1,7 +1,4 @@
-export { createNextConfig } from './createNextConfig.js'
-export { createSentryConfig } from './createSentryConfig.js'
-export {
-  outputFileTracingIncludes,
-  outputFileTracingExcludes,
-} from './tracing.js'
-export { webpackRules } from './webpackRules.js'
+export * from './createNextConfig.js'
+export * from './createSentryConfig.js'
+export * from './tracing.js'
+export * from './webpackRules.js'

--- a/packages/next-config/src/tracing.js
+++ b/packages/next-config/src/tracing.js
@@ -21,3 +21,7 @@ export const outputFileTracingExcludes = {
     'scripts/**',
   ],
 }
+
+// This represents the root of the monorepo relative to each apps/**/next.config.ts
+/** @type {NextConfig['outputFileTracingRoot']} */
+export const outputFileTracingRoot = '../../'


### PR DESCRIPTION
This commit introduces the `outputFileTracingRoot` configuration to correctly handle Next.js's standalone output in a monorepo setup.

By setting `outputFileTracingRoot` to the monorepo root (`'../../'`), we ensure that all necessary files and dependencies are correctly traced and included in the final build output.

The new configuration has been added to the shared `@filecoin-foundation/next-config` package and applied to the `filecoin-site` and `uxit` applications.

## 📝 Description

Please include a summary of the changes. Provide context and motivation for the change, and describe what problem it solves.

- **Type:** Bug fix / New feature / Documentation / Refactor

## 🛠️ Key Changes

- [Change 1 - Brief description]
- [Change 2 - Brief description]
- ...

## 📌 To-Do Before Merging

- [ ] [Task 1 - Brief description]
- [ ] [Task 2 - Brief description]
- ...

## 🧪 How to Test

- **Setup:** [Setup details]
- **Steps to Test:**
  1. [Step 1 - Brief description]
  2. [Step 2 - Brief description]
  3. ...
- **Expected Results:** [Outcome]
- **Additional Notes:** [Additional info]

## 📸 Screenshots

Attach if there are UI changes.

## 🔖 Resources

Feel free to share any references to documentation, libraries, blog posts, or other resources that you consulted or used during the implementation of the changes.

- [Resource 1]
- [Resource 2]
- ...
