### PR TITLE
[SHARED][UXIT-3278] Fix outputFileTracingRoot error [skip percy]

### DIFF
--- a/packages/next-config/src/tracing.js
+++ b/packages/next-config/src/tracing.js
@@ -1,5 +1,8 @@
 // @ts-check
 
+import path from 'path'
+import { fileURLToPath } from 'url'
+
 /**
  * @typedef {import('next').NextConfig} NextConfig
  */
@@ -22,6 +25,10 @@ export const outputFileTracingExcludes = {
   ],
 }
 
+const __filename = fileURLToPath(import.meta.url)
+const __dirname = path.dirname(__filename)
+const monorepoRoot = path.resolve(__dirname, '../../')
+
 // This represents the root of the monorepo relative to each apps/**/next.config.ts
 /** @type {NextConfig['outputFileTracingRoot']} */
-export const outputFileTracingRoot = '../../'
+export const outputFileTracingRoot = monorepoRoot

--- a/packages/next-config/src/tracing.js
+++ b/packages/next-config/src/tracing.js
@@ -27,7 +27,7 @@ export const outputFileTracingExcludes = {
 
 const __filename = fileURLToPath(import.meta.url)
 const __dirname = path.dirname(__filename)
-const monorepoRoot = path.resolve(__dirname, '../../')
+const monorepoRoot = path.resolve(__dirname, '../../../')
 
 // This represents the root of the monorepo relative to each apps/**/next.config.ts
 /** @type {NextConfig['outputFileTracingRoot']} */


### PR DESCRIPTION
## 📝 Description

This PR:
- Updates the `outputFileTracingRoot` to dynamically resolve to the monorepo root instead of a hardcoded relative path.

- **Type:** Bug fix


## 📸 Screenshots

### No warning when running `npm run dev`
<img width="1172" height="286" alt="Screenshot 2025-09-16 at 10 31 05" src="https://github.com/user-attachments/assets/1b04138f-d064-4671-b174-8fe664a2aa23" />


## 🔖 Resources
- [Next.js documentation](https://nextjs.org/docs/app/api-reference/config/next-config-js/output)

