### PR TITLE
[SHARED][UXIT-3233] Customize PR titles for Decap CMS submissions [skip percy]

### DIFF
--- a/apps/ff-site/public/admin/config.yml
+++ b/apps/ff-site/public/admin/config.yml
@@ -7,6 +7,12 @@ backend:
   branch: main
   repo: FilecoinFoundationWeb/filecoin-foundation
   base_url: https://decap-proxy.filecoin-foundation.workers.dev/
+  commit_messages:
+    create: "[DECAP CMS][FF] Create {{collection}} '{{slug}}'"
+    update: "[DECAP CMS][FF] Update {{collection}} '{{slug}}'"
+    delete: "[DECAP CMS][FF] Delete {{collection}} '{{slug}}'"
+    uploadMedia: "[DECAP CMS][FF] Upload media '{{path}}'"
+    deleteMedia: "[DECAP CMS][FF] Delete media '{{path}}'"
 
 publish_mode: editorial_workflow
 media_folder: "apps/ff-site/public/assets/images"

--- a/apps/ffdweb-site/public/admin/config.yml
+++ b/apps/ffdweb-site/public/admin/config.yml
@@ -7,6 +7,12 @@ backend:
   branch: main
   repo: FilecoinFoundationWeb/filecoin-foundation
   base_url: https://decap-proxy.filecoin-foundation.workers.dev/
+  commit_messages:
+    create: "[DECAP CMS][FFDW] Create {{collection}} '{{slug}}'"
+    update: "[DECAP CMS][FFDW] Update {{collection}} '{{slug}}'"
+    delete: "[DECAP CMS][FFDW] Delete {{collection}} '{{slug}}'"
+    uploadMedia: "[DECAP CMS][FFDW] Upload media '{{path}}'"
+    deleteMedia: "[DECAP CMS][FFDW] Delete media '{{path}}'"
 
 publish_mode: editorial_workflow
 media_folder: "apps/ffdweb-site/public/assets/images"


### PR DESCRIPTION
## 📝 Description

This PR adds custom commit message templates to both FF and FFDW DECAP CMS configurations.

## 🛠️ Key Changes
- FF Site: Added commit message templates with [DECAP CMS][FF] prefix for all CMS operations
- FFDW Site: Added commit message templates with [DECAP CMS][FFDW] prefix for all CMS operations

This change improves the maintainability and readability of the project's git history by making CMS operations more transparent and organized. All CMS-generated commits are now clearly identifiable with consistent prefixes
