### PR TITLE
[FF][UXIT-3233] Enhance Ecosystem Explorer submission PR details [skip percy]

### DIFF
--- a/apps/ff-site/src/app/ecosystem-explorer/project-form/actions/submitProject.ts
+++ b/apps/ff-site/src/app/ecosystem-explorer/project-form/actions/submitProject.ts
@@ -39,7 +39,7 @@ export async function submitProject({
 
   const pullRequest = await submitProjectToGithub({
     slug,
-    message: 'New Ecosystem Project',
+    message: '[SUBMISSION][FF] Create Ecosystem Explorer entry',
     markdown: {
       template: markdownTemplate,
       path: `${WORKSPACE_ROOT}/${PATHS.ECOSYSTEM_EXPLORER.entriesPath}/${slug}.md`,

--- a/apps/ff-site/src/app/ecosystem-explorer/project-form/services/github/api/createPr.ts
+++ b/apps/ff-site/src/app/ecosystem-explorer/project-form/services/github/api/createPr.ts
@@ -8,12 +8,16 @@ const octokit = new Octokit({ auth: process.env.GITHUB_AUTH_TOKEN })
 
 type CreatePRParams = {
   title: string
+  body: string
+  reviewers: string[]
   branchName: string
   commitSha: string
 }
 
 export async function createPR({
   title,
+  body,
+  reviewers,
   branchName,
   commitSha,
 }: CreatePRParams) {
@@ -25,6 +29,8 @@ export async function createPR({
     head: branchName,
     base: repoConfig.baseBranch,
     title,
+    body,
+    reviewers,
   })
   return newPullRequest
 }

--- a/apps/ff-site/src/app/ecosystem-explorer/project-form/utils/submitProjectToGithub.ts
+++ b/apps/ff-site/src/app/ecosystem-explorer/project-form/utils/submitProjectToGithub.ts
@@ -29,8 +29,16 @@ export async function submitProjectToGithub({
   message,
 }: SubmitProjectToGitHubParams) {
   const todayISO = getTodayISO()
-  const branchName = `ecosystem-submission/${slug}-${todayISO}`
+  const branchName = `ff/create-new-ecosystem-explorer-entry/${slug}-${todayISO}`
   const formattedMessage = `${message}: ${slug}`
+  const reviewers = ['matthendrian', 'charlymartin']
+  const body = `
+  ## 📝 Description
+  
+  This is an automated pull request to create a new **Ecosystem Explorer** entry for \`${slug}\`.
+  
+  Please review and merge.
+  `
 
   const [markdownBlob, logoBlob] = await Promise.all([
     createBlob(markdown.template, 'utf-8'),
@@ -57,6 +65,8 @@ export async function submitProjectToGithub({
 
   const newPullRequest = await createPR({
     title: formattedMessage,
+    body,
+    reviewers,
     commitSha: newCommit.sha,
     branchName,
   })


### PR DESCRIPTION
## 📝 Description

This PR enhances the automated PR creation process for Ecosystem Explorer submissions by adding better structure and details to the generated pull requests. The changes improve the workflow for handling ecosystem project submissions by providing clearer categorization, automatic reviewer assignment, and structured PR descriptions.

- **Type:** New feature

## 🛠️ Key Changes

- Updated commit message format from "New Ecosystem Project" to "[SUBMISSION][FF] Create Ecosystem Explorer entry" for better categorization
- Enhanced createPR function to accept body and reviewers parameters
- Implemented structured PR description template for ecosystem submissions
- Added automatic reviewer assignment (matthendrian, charlymartin)
- Updated branch naming convention from ecosystem-submission/{slug}-{date} to ff/create-new-ecosystem-explorer-entry/{slug}-{date}

## 🧪 How to Test

- **Setup:** Deploy changes to staging environment
- **Steps to Test:**
  1. Navigate to the Ecosystem Explorer project submission form
  2. Fill out and submit a test project entry
  3. Verify the generated PR has the new title format "[SUBMISSION][FF] Create Ecosystem Explorer entry: {slug}"
  4. Check that the PR includes the structured description template
  5. Confirm reviewers are automatically assigned
  6. Validate the branch naming follows the new convention
- **Expected Results:** Automated PRs should have improved structure, clear descriptions, and proper reviewer assignments
- **Additional Notes:** Changes are backwards compatible and don't affect existing submissions
