### PR TITLE
[FF][UXIT-3271] Configure Airtable client timeout and retry logic

### DIFF
--- a/apps/ff-site/src/app/orbit/schema/AirtableRecordSchema.ts
+++ b/apps/ff-site/src/app/orbit/schema/AirtableRecordSchema.ts
@@ -1,0 +1,13 @@
+import { z } from 'zod'
+
+import { AIRTABLE_ORBIT_EVENTS_CONFIG } from '../constants/airtableOrbitEventsConfig'
+
+const { TITLE, CITY, START_DATE, REGISTRATION_LINK } =
+  AIRTABLE_ORBIT_EVENTS_CONFIG.FIELDS
+
+export const AirtableRecordSchema = z.object({
+  [TITLE]: z.string(),
+  [CITY]: z.string(),
+  [START_DATE]: z.coerce.date(),
+  [REGISTRATION_LINK]: z.url().optional(),
+})

--- a/apps/ff-site/src/app/orbit/services/airtable.ts
+++ b/apps/ff-site/src/app/orbit/services/airtable.ts
@@ -7,6 +7,7 @@ import {
   AIRTABLE_ORBIT_EVENTS_CONFIG,
   APPROVED_STATUS_VALUE,
 } from '../constants/airtableOrbitEventsConfig'
+import { AirtableRecordSchema } from '../schema/AirtableRecordSchema'
 
 const airtable = new Airtable({
   apiKey: process.env.AIRTABLE_READ_ONLY_TOKEN,
@@ -16,13 +17,6 @@ const airtable = new Airtable({
 
 const { BASE_ID, EVENTS_TABLE_ID, FIELDS } = AIRTABLE_ORBIT_EVENTS_CONFIG
 const { TITLE, CITY, START_DATE, REGISTRATION_LINK } = FIELDS
-
-const airtableRecordSchema = z.object({
-  [TITLE]: z.string(),
-  [CITY]: z.string(),
-  [START_DATE]: z.coerce.date(),
-  [REGISTRATION_LINK]: z.url().optional(),
-})
 
 export async function fetchAndParseAirtableEvents() {
   const rawAirtableRecords = await fetchAirtableRecords()
@@ -59,7 +53,7 @@ function fetchAirtableRecords() {
 
 function validateRawRecords(rawRecords: Records<FieldSet>) {
   const cleanRecords = rawRecords.map((record) => record.fields)
-  return z.array(airtableRecordSchema).parse(cleanRecords)
+  return z.array(AirtableRecordSchema).parse(cleanRecords)
 }
 
 function getHumanReadableRecords(

--- a/apps/ff-site/src/app/orbit/services/airtable.ts
+++ b/apps/ff-site/src/app/orbit/services/airtable.ts
@@ -8,7 +8,11 @@ import {
   APPROVED_STATUS_VALUE,
 } from '../constants/airtableOrbitEventsConfig'
 
-const airtable = new Airtable({ apiKey: process.env.AIRTABLE_READ_ONLY_TOKEN })
+const airtable = new Airtable({
+  apiKey: process.env.AIRTABLE_READ_ONLY_TOKEN,
+  requestTimeout: 3_000,
+  noRetryIfRateLimited: true,
+})
 
 const { BASE_ID, EVENTS_TABLE_ID, FIELDS } = AIRTABLE_ORBIT_EVENTS_CONFIG
 const { TITLE, CITY, START_DATE, REGISTRATION_LINK } = FIELDS
@@ -22,6 +26,7 @@ const airtableRecordSchema = z.object({
 
 export async function fetchAndParseAirtableEvents() {
   const rawAirtableRecords = await fetchAirtableRecords()
+
   const validatedRecords = validateRawRecords(rawAirtableRecords)
   const humanReadableRecords = getHumanReadableRecords(validatedRecords)
 
@@ -39,9 +44,9 @@ function fetchAirtableRecords() {
       fields: Object.values(FIELDS),
       returnFieldsByFieldId: true,
       filterByFormula: `AND(
-      {${FIELDS.STATUS}} = '${APPROVED_STATUS_VALUE}',
-      IS_AFTER({${FIELDS.START_DATE}}, '${todayISO}')
-    )`,
+        {${FIELDS.STATUS}} = '${APPROVED_STATUS_VALUE}',
+        IS_AFTER({${FIELDS.START_DATE}}, '${todayISO}')
+      )`,
       sort: [
         {
           field: FIELDS.START_DATE,

--- a/apps/ff-site/src/app/orbit/services/airtable.ts
+++ b/apps/ff-site/src/app/orbit/services/airtable.ts
@@ -9,9 +9,13 @@ import {
 } from '../constants/airtableOrbitEventsConfig'
 import { AirtableRecordSchema } from '../schema/AirtableRecordSchema'
 
+const DEFAULT_REQUEST_TIMEOUT_MS = 3_000
+
 const airtable = new Airtable({
   apiKey: process.env.AIRTABLE_READ_ONLY_TOKEN,
-  requestTimeout: 3_000,
+  requestTimeout: process.env.AIRTABLE_REQUEST_TIMEOUT_MS
+    ? Number(process.env.AIRTABLE_REQUEST_TIMEOUT_MS)
+    : DEFAULT_REQUEST_TIMEOUT_MS,
   noRetryIfRateLimited: true,
 })
 

--- a/apps/ff-site/turbo.json
+++ b/apps/ff-site/turbo.json
@@ -11,7 +11,8 @@
         "NEWSLETTER_SUBSCRIPTION_API_URL",
         "NEWSLETTER_SUBSCRIPTION_PUBLICATION_ID",
         "PERCY_TOKEN_FF_SITE",
-        "SENTRY_AUTH_TOKEN_FF_SITE"
+        "SENTRY_AUTH_TOKEN_FF_SITE",
+        "AIRTABLE_REQUEST_TIMEOUT_MS"
       ],
       "outputs": [
         ".next/**",


### PR DESCRIPTION


## 📝 Description

This PR updates the Airtable API client as follows:
1. `noRetryIfRateLimited` is set to `true` to disable automatic retries. This ensures the application fails fast when rate-limited, providing more predictable execution times.
2. A `requestTimeout` of 3 seconds is introduced to prevent requests from hanging and potentially causing serverless function timeouts.

This solves the current [time-out issue](https://filecoinfoundation.slack.com/archives/C06MTEQ3SP6/p1758626653393969) on the orbit page by erroring out instead of infinitely retrying. I suspect the issue to be the 1k API limit on the Airtable account, [to be confirmed](https://filecoinfoundation.slack.com/archives/C08MDPD487R/p1758705408468849) with the Fil-B team.

## 🛠️ Key Changes

It also moves the zod schema in its own file.

## 📸 Screenshots

<img width="1662" height="750" alt="CleanShot 2025-09-24 at 10 28 51@2x" src="https://github.com/user-attachments/assets/59046944-0149-4e14-97e9-1a049589ef53" />

## 🔖 Resources

https://airtable.com/pricing
