### PR TITLE
[SHARED][UXIT-3198] Move ignoredClientErrors from edge to client

### DIFF
--- a/apps/ff-site/instrumentation-client.ts
+++ b/apps/ff-site/instrumentation-client.ts
@@ -1,5 +1,7 @@
 import * as Sentry from '@sentry/nextjs'
 
+import { ignoredClientErrors } from '@filecoin-foundation/sentry-config'
+
 Sentry.init({
   dsn: process.env.NEXT_PUBLIC_SENTRY_DSN,
   tracesSampleRate: 0.05,
@@ -7,6 +9,7 @@ Sentry.init({
   replaysOnErrorSampleRate: 1.0,
   replaysSessionSampleRate: 0.01,
   environment: process.env.NODE_ENV,
+  ignoreErrors: ignoredClientErrors,
 })
 
 export const onRouterTransitionStart = Sentry.captureRouterTransitionStart

--- a/apps/ff-site/sentry.edge.config.ts
+++ b/apps/ff-site/sentry.edge.config.ts
@@ -5,11 +5,8 @@
 
 import * as Sentry from '@sentry/nextjs'
 
-import { ignoredClientErrors } from '@filecoin-foundation/sentry-config'
-
 Sentry.init({
   dsn: process.env.NEXT_PUBLIC_SENTRY_DSN,
   tracesSampleRate: 0.05,
   debug: false,
-  ignoreErrors: ignoredClientErrors,
 })

--- a/apps/ff-site/src/content/events/virtual-fil-dev-summit-7.md
+++ b/apps/ff-site/src/content/events/virtual-fil-dev-summit-7.md
@@ -1,5 +1,5 @@
 ---
-title: "Virtual FIL Dev Summit 7 "
+title: "Virtual FIL Dev Summit 7"
 description: Join the Virtual FIL Dev Summit Kickoff Sessions to dive deep on
   new improvements and proposals across the Filecoin community! These 2-3 hour
   virtual sessions will spotlight new opportunities, learnings, and ideas across
@@ -19,11 +19,6 @@ end-date: 2025-10-17
 external-link: https://events.zoom.us/ev/AqlQpbuJ_rxk_SUKcZ8_yHWV0RIjo4Y2Z4lI5QYpaz_uwNK38ikG~AnKGnxGBk2m1zd1NuYJADtpPFJUoxTwCJ4hHHAenUtJq18UIbsESZfjLAA
 image:
   src: /assets/images/devsummit7_virtual_main.png
-program:
-  title: ""
-  events: []
-schedule:
-  title: ""
 seo:
   description: Join the Virtual FIL Dev Summit this October! A month-long series
     of sessions uniting developers, builders, and storage providers to shape the

--- a/apps/ffdweb-site/instrumentation-client.ts
+++ b/apps/ffdweb-site/instrumentation-client.ts
@@ -1,4 +1,6 @@
-import * as Sentry from "@sentry/nextjs";
+import * as Sentry from '@sentry/nextjs'
+
+import { ignoredClientErrors } from '@filecoin-foundation/sentry-config'
 
 Sentry.init({
   dsn: process.env.NEXT_PUBLIC_SENTRY_DSN,
@@ -7,7 +9,8 @@ Sentry.init({
   replaysOnErrorSampleRate: 1.0,
   replaysSessionSampleRate: 0.01,
   environment: process.env.NODE_ENV,
+  ignoreErrors: ignoredClientErrors,
 })
 
-export const onRouterTransitionStart = Sentry.captureRouterTransitionStart;
+export const onRouterTransitionStart = Sentry.captureRouterTransitionStart
 export const onRequestError = Sentry.captureRequestError

--- a/apps/ffdweb-site/sentry.edge.config.ts
+++ b/apps/ffdweb-site/sentry.edge.config.ts
@@ -5,11 +5,8 @@
 
 import * as Sentry from '@sentry/nextjs'
 
-import { ignoredClientErrors } from '@filecoin-foundation/sentry-config'
-
 Sentry.init({
   dsn: process.env.NEXT_PUBLIC_SENTRY_DSN,
   tracesSampleRate: 0.05,
   debug: false,
-  ignoreErrors: ignoredClientErrors,
 })

--- a/apps/filecoin-site/instrumentation-client.ts
+++ b/apps/filecoin-site/instrumentation-client.ts
@@ -1,5 +1,7 @@
 import * as Sentry from '@sentry/nextjs'
 
+import { ignoredClientErrors } from '@filecoin-foundation/sentry-config'
+
 Sentry.init({
   dsn: process.env.NEXT_PUBLIC_SENTRY_DSN,
   tracesSampleRate: 0.05,
@@ -7,6 +9,7 @@ Sentry.init({
   replaysOnErrorSampleRate: 1.0,
   replaysSessionSampleRate: 0.01,
   environment: process.env.NODE_ENV,
+  ignoreErrors: ignoredClientErrors,
 })
 
 export const onRouterTransitionStart = Sentry.captureRouterTransitionStart

--- a/apps/filecoin-site/sentry.edge.config.ts
+++ b/apps/filecoin-site/sentry.edge.config.ts
@@ -5,11 +5,8 @@
 
 import * as Sentry from '@sentry/nextjs'
 
-import { ignoredClientErrors } from '@filecoin-foundation/sentry-config'
-
 Sentry.init({
   dsn: process.env.NEXT_PUBLIC_SENTRY_DSN,
   tracesSampleRate: 0.05,
   debug: false,
-  ignoreErrors: ignoredClientErrors,
 })

--- a/packages/sentry-config/src/ignoredErrors.ts
+++ b/packages/sentry-config/src/ignoredErrors.ts
@@ -1,5 +1,3 @@
-type IgnoredErrors = Array<RegExp | string>
-
 export const ignoredClientErrors = [
   /uncaught exception in worker/i, // Noise from Cloudflare edge workers – not actionable
   /hydration failed/i, // Next.js hydration mismatch during client reloads – not actionable
@@ -7,4 +5,4 @@ export const ignoredClientErrors = [
   /^ReferenceError:/,
   /^SyntaxError:/,
   /^NotFoundError:/,
-] satisfies IgnoredErrors
+]


### PR DESCRIPTION
## 📝 Description

This PR moves `ignoredClientErrors` configuration from edge runtime to client-side instrumentation files across all apps. I initially confused `edge` for `client`, but `edge` refers to middleware and `const runtime = 'edge'` files, which we don't use.

We received this [error](https://filecoin-foundation-qk.sentry.io/issues/6897220810?project=4507390577999872) after the initial `ignoreErrors` was (incorrectly) set up.`TypeError` should have been ignored; hopefully it will be now!

This PR also removes the types from sentry-config as we _may need an appropriate loader to handle this file type, currently no loaders are configured to process this file. See https://webpack.js.org/concepts#loaders_

Finally, it fixes a Zod error introduced by https://github.com/FilecoinFoundationWeb/filecoin-foundation/pull/1796 to fix the build.