### PR TITLE
Update filecoin-site base domain to filecoin.io

### DIFF
--- a/.github/workflows/apps-link-checker.yml
+++ b/.github/workflows/apps-link-checker.yml
@@ -20,7 +20,7 @@ jobs:
             base_url: https://ffdweb.org
             subpath: "src/**/*.md"
           - app: filecoin-site
-            base_url: https://filecoin-site.vercel.app/
+            base_url: https://filecoin.io/
             subpath: "content/**/*.md"
 
     env:

--- a/apps/filecoin-site/src/app/_constants/siteMetadata.ts
+++ b/apps/filecoin-site/src/app/_constants/siteMetadata.ts
@@ -1,6 +1,6 @@
 import type { Metadata } from 'next'
 
-const BASE_DOMAIN = 'filecoin-site.vercel.app'
+const BASE_DOMAIN = 'filecoin.io'
 const BASE_URL = `https://${BASE_DOMAIN}`
 const ORGANIZATION_NAME = 'Filecoin'
 


### PR DESCRIPTION
## 📝 Description

This PR updates the base domain for the filecoin-site application from the Vercel preview URL to the production domain. The changes ensure that all site metadata and link checking workflows reference the correct production domain.

- **Type:** Configuration / Deployment

## 🛠️ Key Changes

- Updated `BASE_DOMAIN` constant in `apps/filecoin-site/src/app/_constants/siteMetadata.ts` from `filecoin-site.vercel.app` to `filecoin.io`
- Updated the link checker workflow configuration in `.github/workflows/apps-link-checker.yml` to use `https://filecoin.io/` instead of the Vercel preview URL

## 📌 To-Do Before Merging

- [ ] Verify that `filecoin.io` is properly configured and accessible
- [ ] Confirm DNS/domain routing is set up correctly for the production environment

## 🧪 How to Test

- **Setup:** No special setup required
- **Steps to Test:**
  1. Verify the link checker workflow runs successfully with the new domain
  2. Confirm that site metadata references are correct by checking the built application
- **Expected Results:** Link checker workflow completes without errors; site metadata correctly reflects `filecoin.io` as the base domain

## 🔖 Resources

- N/A

https://claude.ai/code/session_017SSe41qAQGLmbKEM8BjK14