### PR TITLE
Redirect legacy /blog/posts/* URLs to /blog/* to fix broken inbound links

### DIFF
--- a/apps/filecoin-site/redirects.ts
+++ b/apps/filecoin-site/redirects.ts
@@ -945,4 +945,14 @@ export const redirects = [
     destination: '/zh-cn/blog/bridging-the-filecoin-and-ethereum-communities',
     permanent: true,
   },
+  {
+    source: '/blog/posts/:slug',
+    destination: '/blog/:slug',
+    permanent: true,
+  },
+  {
+    source: '/zh-cn/blog/posts/:slug',
+    destination: '/zh-cn/blog/:slug',
+    permanent: true,
+  },
 ]


### PR DESCRIPTION
The blog moved from /blog/posts/<slug> to /blog/<slug>, but the long tail of
external links to the old path was 404ing. Add a wildcard 308 permanent
redirect (plus a zh-cn equivalent) so search engines and inbound links flow
to the new canonical URLs while preserving SEO. Placed after the existing
specific /blog/posts/<old> -> /blog/<renamed> entries so those still win
on first-match order.