### PR TITLE
fix(ui-filecoin): parse prerelease software versions in parseVersionString

### DIFF
--- a/.changeset/software-version-prerelease.md
+++ b/.changeset/software-version-prerelease.md
@@ -1,0 +1,5 @@
+---
+"@filecoin-foundation/ui-filecoin": patch
+---
+
+parse prerelease software versions (e.g. `1.28.2-rc1`) in `parseVersionString` / `SoftwareVersion`

--- a/packages/ui-filecoin/src/components/Table/SoftwareVersion.test.ts
+++ b/packages/ui-filecoin/src/components/Table/SoftwareVersion.test.ts
@@ -1,0 +1,46 @@
+import { describe, it, expect } from '@jest/globals'
+
+import { parseVersionString } from './SoftwareVersion'
+
+describe('parseVersionString', () => {
+  it('parses a stable release version', () => {
+    expect(
+      parseVersionString('1.28.1+calibnet+git_16cce66a_2026-05-19T15:30:00+00:00'),
+    ).toEqual({
+      version: '1.28.1',
+      network: 'calibnet',
+      commit: '16cce66a',
+      date: '2026-05-19T15:30:00+00:00',
+    })
+  })
+
+  it('parses a prerelease (release candidate) version', () => {
+    expect(
+      parseVersionString(
+        '1.28.2-rc1+calibnet+git_d36dfd8f_2026-05-28T15:41:36+04:00',
+      ),
+    ).toEqual({
+      version: '1.28.2-rc1',
+      network: 'calibnet',
+      commit: 'd36dfd8f',
+      date: '2026-05-28T15:41:36+04:00',
+    })
+  })
+
+  it('parses a dotted prerelease (e.g. beta.1) version', () => {
+    expect(
+      parseVersionString(
+        '1.28.2-beta.1+mainnet+git_abc123_2026-05-28T15:41:36+04:00',
+      ),
+    ).toEqual({
+      version: '1.28.2-beta.1',
+      network: 'mainnet',
+      commit: 'abc123',
+      date: '2026-05-28T15:41:36+04:00',
+    })
+  })
+
+  it('returns undefined for an unrecognized string', () => {
+    expect(parseVersionString('not-a-version')).toBeUndefined()
+  })
+})

--- a/packages/ui-filecoin/src/components/Table/SoftwareVersion.tsx
+++ b/packages/ui-filecoin/src/components/Table/SoftwareVersion.tsx
@@ -33,7 +33,9 @@ export function SoftwareVersion({ info, githubUrl }: SoftwareVersionProps) {
 }
 
 export function parseVersionString(input: string) {
-  const regex = /^(\d+\.\d+\.\d+)\+([a-z]+)\+(git_[a-f0-9]+)_(.+)$/
+  // The semver core may carry a prerelease suffix (e.g. `-rc1`, `-beta.1`).
+  const regex =
+    /^(\d+\.\d+\.\d+(?:-[0-9A-Za-z.]+)?)\+([a-z]+)\+(git_[a-f0-9]+)_(.+)$/
   const match = input.match(regex)
 
   if (!match) {


### PR DESCRIPTION
## What
`parseVersionString` (and therefore `<SoftwareVersion>`) now accepts software versions that carry a semver **prerelease** suffix.

## Why
The regex required the semver core `\d+\.\d+\.\d+` to be immediately followed by `+`:

```
/^(\d+\.\d+\.\d+)\+([a-z]+)\+(git_[a-f0-9]+)_(.+)$/
```

So a version like `1.28.2-rc1+calibnet+git_<sha>_<date>` fails to parse and `<SoftwareVersion>` renders *"The software version could not be parsed."* Release-candidate / beta builds use exactly this format.

## How
Allow an optional prerelease segment on the semver core:

```
/^(\d+\.\d+\.\d+(?:-[0-9A-Za-z.]+)?)\+([a-z]+)\+(git_[a-f0-9]+)_(.+)$/
```

- Adds jest coverage for stable, `-rc1`, `-beta.1`, and unrecognized strings (`npm test` — 4 passing).
- Changeset: `patch` bump for `@filecoin-foundation/ui-filecoin`.

Closes #2336. Reported downstream at FilOzone/filecoin-cloud#319.
