### PR TITLE
Add Slack community redirect

### DIFF
--- a/apps/filecoin-site/redirects.ts
+++ b/apps/filecoin-site/redirects.ts
@@ -1,5 +1,10 @@
 export const redirects = [
   {
+    source: '/slack',
+    destination: 'https://rebrand.ly/filecoin-project-slack',
+    permanent: false,
+  },
+  {
     source: '/blog/ann-filecoin-token-sale-and-new-paper',
     destination:
       '/blog/announcing-the-filecoin-token-sale-and-upgraded-whitepaper',


### PR DESCRIPTION
## 📝 Description

This PR adds a new redirect rule to route `/slack` to the Filecoin Project Slack workspace via a branded short link. This provides a convenient way for users to access the community Slack channel from the main website.

- **Type:** New feature

## 🛠️ Key Changes

- Added redirect rule mapping `/slack` to `https://rebrand.ly/filecoin-project-slack` with non-permanent status

## 📌 To-Do Before Merging

- [ ] Verify the rebrand.ly short link is active and points to the correct Slack workspace
- [ ] Confirm the redirect is non-permanent (307/308) to allow future updates if needed

## 🧪 How to Test

- **Setup:** N/A
- **Steps to Test:**
  1. Navigate to `/slack` on the filecoin-site domain
  2. Verify the redirect takes you to the Filecoin Project Slack workspace
- **Expected Results:** User is redirected to the Slack workspace via the rebrand.ly short link
- **Additional Notes:** This is a simple configuration change that leverages the existing redirect infrastructure

## 🔖 Resources

- Rebrand.ly short link management

https://claude.ai/code/session_017NC22Wk5ckjQ2h38E9WfM9