### PR TITLE
fix(filecoin-site): add /slack, /discord and /intro redirects

### DIFF
--- a/apps/filecoin-site/redirects.ts
+++ b/apps/filecoin-site/redirects.ts
@@ -1,5 +1,21 @@
 export const redirects = [
   {
+    source: '/slack',
+    destination: 'https://rebrand.ly/filecoin-project-slack',
+    permanent: false,
+  },
+  {
+    source: '/discord',
+    destination: 'https://discord.gg/yeQ2hcd2TD',
+    permanent: false,
+  },
+  {
+    source: '/intro',
+    destination:
+      'https://docs.filecoin.io/intro/intro-to-filecoin/what-is-filecoin/',
+    permanent: false,
+  },
+  {
     source: '/blog/ann-filecoin-token-sale-and-new-paper',
     destination:
       '/blog/announcing-the-filecoin-token-sale-and-upgraded-whitepaper',


### PR DESCRIPTION
## Problem

`https://filecoin.io/slack` returns **404** in production — reported by community members on Slack and Reddit, since it's the primary invite path (docs.filecoin.io links through it everywhere). `/discord` and `/intro` are broken the same way.

These vanity redirects existed on the previous filecoin.io site (most recently in `vercel.json` of `filecoin-project/filecoin.io`) but weren't carried over into this rebuild's `redirects.ts`.

## Fix

Adds the three redirects to `apps/filecoin-site/redirects.ts`:

| Path | Destination | Why |
|---|---|---|
| `/slack` | `rebrand.ly/filecoin-project-slack` | Rebrandly is updated by the community team's Zapier flow whenever the Slack invite rotates — keeping it as the destination means future invite rotations need no site deploy |
| `/discord` | `discord.gg/yeQ2hcd2TD` | same destination as the old site |
| `/intro` | `docs.filecoin.io/intro/intro-to-filecoin/what-is-filecoin/` | same destination as the old site |

`permanent: false` (307) on all three so browsers don't cache destinations that may change.

## Verification after deploy

```
curl -sI https://www.filecoin.io/slack | grep -iE 'HTTP|location'
```

Expect 307 → `https://rebrand.ly/filecoin-project-slack`.