### PR TITLE
fix(filecoin-site): resolve markdownlint errors in ProPGF blog posts

### DIFF
--- a/apps/filecoin-site/content/blog/posts/en/Announcing-Filecoin-ProPGF-Batch-3-Selection-Committee.md
+++ b/apps/filecoin-site/content/blog/posts/en/Announcing-Filecoin-ProPGF-Batch-3-Selection-Committee.md
@@ -21,7 +21,7 @@ As Proactive Public Goods Funding (ProPGF) enters its third batch, our goal is t
 
 The Batch 3 Selection Committee brings together experts from across decentralized storage, crypto-economics, public goods funding, governance, ecosystem development, and open source operations. Members were chosen for their domain expertise, and demonstrated commitment to strengthening the Filecoin ecosystem.
 
-### Selection Committee Members (Batch 3):
+### Selection Committee Members (Batch 3)
 
 * Akersh Srivastava - Head of Product, Filecoin Foundation
 * Clara Tsao - A Founding Officer, Filecoin Foundation
@@ -55,7 +55,7 @@ The Selection Committee plays a pivotal role in ensuring milestone-based funding
 
 ### 1. Assessing Alignment with Filecoin Network Growth
 
-* **Core Infrastructure Maintenance **Committee members assess whether a project contributes to the foundational work that keeps the protocol reliable, performant, and safe. This includes implementations, critical libraries, dependencies, and essential services that the rest of the ecosystem builds on top of.
+* **Core Infrastructure Maintenance**: Committee members assess whether a project contributes to the foundational work that keeps the protocol reliable, performant, and safe. This includes implementations, critical libraries, dependencies, and essential services that the rest of the ecosystem builds on top of.
 * **RFP Responses**: Committee members evaluate whether a project meaningfully responds to published RFPs and delivers support or innovation work in service of ecosystem pods (working group structures focused on product-market fit exploration in key verticals, including Web3 Builders and Web2 Object Storage).
 
 ### 2. Reviewing Application Responses Thoughtfully

--- a/apps/filecoin-site/content/blog/posts/en/ProPGF-Batch-3-Call-for-Builders.md
+++ b/apps/filecoin-site/content/blog/posts/en/ProPGF-Batch-3-Call-for-Builders.md
@@ -16,11 +16,11 @@ Filecoin is in the middle of one of the most exciting transformations of any dec
 
 [FIL-ProPGF Batch 3](https://filpgf.io/propgf/) is the funding round powering that transformation. The General Track is $2M of grants for outside teams — companies, builder collectives, and independent projects — ready to ship work that advances [Filecoin's 2026 goals](https://www.filecoin.io/blog/the-2026-filecoin-network-strategy) and helps the network capture the moment. A quick note on scope: Batch 3 also funds core infrastructure (the “kernel”) in parallel — the protocol-level and core-client work that keeps Filecoin running. This post and the RFP below are funded via FIL-ProPGF Batch 3 General Track as well. This RFP is a public, opinionated view of the four areas where outside teams can have the biggest impact this year. It's a guide, not a gate. Strong proposals outside these areas will still be read on their merits.
 
-### A Living Document 
+## A Living Document 
 
 This RFP is the clear starting set of requests for Batch 3, but we expect to refine it through working sessions at the Filecoin Dev Summit in New York, starting June 9, and in the days following, as ecosystem leaders and the broader community weigh in. Check back after the Summit, and if you see a gap before then, contact us on Telegram or Slack.
 
-### Understanding “Pods”
+## Understanding “Pods”
 
 A pod is a small, mission-focused team inside the Filecoin ecosystem with a specific product or go-to-market mandate. For example, one pod ships Filecoin’s [developer-facing storage platform](https://filecoin.cloud/); another runs [enterprise sales into traditional storage buyers](https://fil.one/); a third focuses on [onboarding very large datasets](https://www.karmahq.xyz/project/large-data-onboarding-pod-ldo-pod/about). Pods own product and revenue for their slice of the ecosystem, and they’re shipping at a faster cadence than ever. The grants below fund work alongside the pods — work that helps them succeed while sitting outside what any one pod should reasonably do on its own.
 
@@ -89,7 +89,7 @@ A strong proposal: A protocol-engineering team ships a fee-and-burn module that 
 #### How to apply
 
 * Applications open: May 26, 2026, on filpgf.io. [(Apply here)](https://filpgf.io/propgf/#funding-round-timeline)
-*  Funding: $2M total · $300K soft cap per project · \~$200K average grant · six-month default horizon · milestone-based payouts.
+* Funding: $2M total · $300K soft cap per project · \~$200K average grant · six-month default horizon · milestone-based payouts.
 * Decision waves: Wave 1 by June 30, 2026; Wave 2 by July 15, 2026. Agreements and compliance are complete by July 30, 2026.
 * Review: Three-phase flow — AI-assisted shortlist, committee vetting, final allocation — evaluated against Filecoin’s 2026 network objectives.
 


### PR DESCRIPTION
## Problem

Two blog posts on `main` (added via TinaCMS content updates) carry 4 markdownlint errors. Since the husky pre-commit hook runs `npm run lint:md` over the whole repo, **every local commit is currently blocked** for all contributors unless they bypass hooks with `--no-verify` (as noted in #2343).

```text
Announcing-Filecoin-ProPGF-Batch-3-Selection-Committee.md:24:42  MD026  Trailing punctuation in heading
Announcing-Filecoin-ProPGF-Batch-3-Selection-Committee.md:58:36  MD037  Spaces inside emphasis markers
ProPGF-Batch-3-Call-for-Builders.md:19                           MD001  Heading levels should only increment by one
ProPGF-Batch-3-Call-for-Builders.md:92:1                         MD030  Spaces after list markers
```

## Fix (formatting only, no wording changes)

**Announcing-Filecoin-ProPGF-Batch-3-Selection-Committee.md**
- MD026: drop the trailing colon from the `### Selection Committee Members (Batch 3):` heading
- MD037: `**Core Infrastructure Maintenance **Committee members...` → `**Core Infrastructure Maintenance**: Committee members...`, matching the sibling `**RFP Responses**:` bullet

**ProPGF-Batch-3-Call-for-Builders.md**
- MD001: promote `A Living Document` and `Understanding “Pods”` from h3 to h2 — they are top-level sections, siblings of `## Four Focus Areas`. The front matter `title:` acts as the page h1, so body sections start at h2 (same structure as every other blog post, e.g. `Announcing-Filecoin-ProPGF-Batch-3-General-Track.md`)
- MD030: `*  Funding:` (two spaces) → `* Funding:` (one space)

## Verification

- `npm run lint:md`: **0 errors** across 1478 files (was 4)
- Pre-commit hook passes again without `--no-verify`

Note: these files are TinaCMS-managed, so a future CMS save could reintroduce formatting issues — but this unblocks local commits for everyone now.