### PR TITLE
Update Akave storage provider details and add customizable CTA labels

### DIFF
--- a/apps/filecoin-site/src/app/[locale]/store-data/components/StorageProviderCard/StorageProviderCard.tsx
+++ b/apps/filecoin-site/src/app/[locale]/store-data/components/StorageProviderCard/StorageProviderCard.tsx
@@ -20,9 +20,11 @@ export type StorageProviderCardProps = {
   description: string
   labels: Array<string>
   pricing?: StorageProviderPricePerMonthProps['pricing']
+  priceLabel?: string
   bestFor: Array<string>
   keyFeatures: Array<string>
   url: string
+  ctaLabel?: string
   logo: IconProps['component']
   isFeatured?: boolean
 }
@@ -33,9 +35,11 @@ export function StorageProviderCard({
   description,
   labels,
   pricing,
+  priceLabel,
   bestFor,
   keyFeatures,
   url,
+  ctaLabel,
   logo,
   isFeatured,
 }: StorageProviderCardProps) {
@@ -79,7 +83,7 @@ export function StorageProviderCard({
               pricing ? (
                 <StorageProviderPricePerMonth pricing={pricing} />
               ) : (
-                <PriceDisplay value={t('customPricing')} />
+                <PriceDisplay value={priceLabel ?? t('customPricing')} />
               )
             }
           />
@@ -100,7 +104,7 @@ export function StorageProviderCard({
         </div>
 
         <Button href={url} variant="ghost">
-          {t('storeWith', { name })}
+          {ctaLabel ?? t('storeWith', { name })}
         </Button>
       </article>
     </Tag>

--- a/apps/filecoin-site/src/app/[locale]/store-data/data/storageProviders.ts
+++ b/apps/filecoin-site/src/app/[locale]/store-data/data/storageProviders.ts
@@ -17,8 +17,10 @@ type StorageProvider = Pick<
   | 'labels'
   | 'keyFeatures'
   | 'url'
+  | 'ctaLabel'
   | 'logo'
   | 'pricing'
+  | 'priceLabel'
   | 'isFeatured'
 > & {
   bestFor: Array<string>
@@ -29,19 +31,21 @@ export function getFilecoinStorageProviders(t: TranslationFunction) {
     {
       name: 'Akave Cloud',
       description: t('providers.akave.description'),
-      labels: [t('providers.akave.labels.0'), t('providers.akave.labels.1')],
-      pricing: {
-        cents: 1_499,
-        monthlyStorageRate: t('providers.akave.monthlyStorageRate'),
-        offer: t('providers.akave.offer'),
-      },
-      bestFor: [t('bestFor.enterprises'), t('bestFor.aiMlDevelopers')],
+      labels: [
+        t('providers.akave.labels.0'),
+        t('providers.akave.labels.1'),
+        t('providers.akave.labels.2'),
+      ],
+      priceLabel: t('providers.akave.price'),
+      bestFor: [t('bestFor.dataLakesAnalyticsBackups')],
       keyFeatures: [
         t('providers.akave.keyFeatures.0'),
         t('providers.akave.keyFeatures.1'),
         t('providers.akave.keyFeatures.2'),
+        t('providers.akave.keyFeatures.3'),
       ],
-      url: 'https://www.akave.ai/',
+      url: 'https://akave.com/free-trial',
+      ctaLabel: t('providers.akave.cta'),
       logo: AkaveMiniatureLogo,
     },
     {

--- a/apps/filecoin-site/src/i18n/translations/en.json
+++ b/apps/filecoin-site/src/i18n/translations/en.json
@@ -355,20 +355,22 @@
       "archivalStorage": "Archival storage",
       "advancedTechnicalUsers": "Advanced technical users",
       "creators": "Creators",
+      "dataLakesAnalyticsBackups": "Data lakes, analytics and enterprise backups",
       "developers": "Developers",
       "enterprises": "Enterprises",
       "nftProjects": "NFT projects"
     },
     "providers": {
       "akave": {
-        "description": "Enterprise-grade hot storage for AI & data lakes.",
-        "labels": ["Drag and drop", "S3-compatible"],
-        "monthlyStorageRate": "/ TB / month",
-        "offer": "Free trial available",
+        "description": "AI-ready sovereign object storage with verifiable control.",
+        "labels": ["S3-compatible", "AI-ready", "Enterprise-grade"],
+        "price": "Enterprise plans available",
+        "cta": "Start Free Trial",
         "keyFeatures": [
-          "S3-compatible API",
-          "Client-side encryption",
-          "Access control"
+          "S3-compatible APIs",
+          "Snowflake & Apache Iceberg support",
+          "Immutable audit trail",
+          "Zero egress fees"
         ]
       },
       "aurora": {

--- a/apps/filecoin-site/src/i18n/translations/zh-cn.json
+++ b/apps/filecoin-site/src/i18n/translations/zh-cn.json
@@ -355,17 +355,23 @@
       "archivalStorage": "归档存储",
       "advancedTechnicalUsers": "高级技术用户",
       "creators": "创作者",
+      "dataLakesAnalyticsBackups": "数据湖、分析和企业备份",
       "developers": "开发者",
       "enterprises": "企业",
       "nftProjects": "NFT 项目"
     },
     "providers": {
       "akave": {
-        "description": "面向 AI 和数据湖的企业级热存储。",
-        "labels": ["拖放上传", "S3 兼容"],
-        "monthlyStorageRate": "/ TB / 月",
-        "offer": "提供免费试用",
-        "keyFeatures": ["兼容 S3 的 API", "客户端加密", "访问控制"]
+        "description": "AI 就绪的主权对象存储，具备可验证的控制权。",
+        "labels": ["S3 兼容", "AI 就绪", "企业级"],
+        "price": "提供企业版方案",
+        "cta": "开始免费试用",
+        "keyFeatures": [
+          "兼容 S3 的 API",
+          "支持 Snowflake 和 Apache Iceberg",
+          "不可变审计追踪",
+          "零出口费用"
+        ]
       },
       "aurora": {
         "description": "面向安全、大规模 AI 与数据工作负载的企业级基础设施。",


### PR DESCRIPTION
## 📝 Description

This PR updates the Akave storage provider information with refreshed branding, messaging, and features. Additionally, it introduces support for customizable CTA labels and price labels on storage provider cards, allowing for more flexible provider-specific messaging.

**Type:** New feature / Content update

## 🛠️ Key Changes

- **Added new type fields** to `StorageProvider`: `ctaLabel` and `priceLabel` for customizable provider-specific messaging
- **Updated Akave provider data**:
  - Refreshed description to emphasize "AI-ready sovereign object storage with verifiable control"
  - Updated labels from "Drag and drop, S3-compatible" to "S3-compatible, AI-ready, Enterprise-grade"
  - Replaced pricing structure with `priceLabel: "Enterprise plans available"`
  - Updated key features to highlight S3 APIs, Snowflake & Apache Iceberg support, immutable audit trail, and zero egress fees
  - Changed "bestFor" from enterprises/AI-ML developers to "Data lakes, analytics and enterprise backups"
  - Updated CTA URL from `akave.ai` to `akave.com/free-trial` with custom label "Start Free Trial"
- **Enhanced StorageProviderCard component**:
  - Added `priceLabel` and `ctaLabel` props with fallback to default translations
  - Updated price display logic to use `priceLabel` when pricing object is not provided
  - Updated button text to use `ctaLabel` when provided, otherwise use default "Store with [name]" translation
- **Added translations** for new `bestFor.dataLakesAnalyticsBackups` category in English and Chinese

## 📌 To-Do Before Merging

- [ ] Verify Akave provider card displays correctly with new content and styling
- [ ] Confirm CTA button links to correct free trial URL
- [ ] Test fallback behavior when `ctaLabel` and `priceLabel` are not provided for other providers

## 🧪 How to Test

- **Setup:** Navigate to the store-data page in the Filecoin site
- **Steps to Test:**
  1. Locate the Akave Cloud storage provider card
  2. Verify the description, labels, and key features match the updated content
  3. Confirm the CTA button displays "Start Free Trial" and links to `akave.com/free-trial`
  4. Verify the price section displays "Enterprise plans available"
  5. Check that other storage provider cards still render correctly with default CTA and price labels
- **Expected Results:** Akave card displays updated branding and messaging; other providers maintain existing behavior with fallback translations

## 🔖 Resources

- Storage provider configuration: `apps/filecoin-site/src/app/[locale]/store-data/data/storageProviders.ts`
- Component implementation: `apps/filecoin-site/src/app/[locale]/store-data/components/StorageProviderCard/StorageProviderCard.tsx`
- Translation files: `en.json` and `zh-cn.json`

https://claude.ai/code/session_01CtxXJxtyzLqtsBn3KAzeJx