### PR TITLE
content(ff-site): add ProPGF Batch 3 Selection Committee blog post

### DIFF
--- a/apps/ff-site/src/content/blog/announcing-filecoin-propgf-batch-3-selection-committee.md
+++ b/apps/ff-site/src/content/blog/announcing-filecoin-propgf-batch-3-selection-committee.md
@@ -1,0 +1,106 @@
+---
+title: 'Announcing Filecoin ProPGF Batch 3 Selection Committee'
+created-on: 2026-06-25T00:00:00Z
+updated-on: 2026-06-25T00:00:00Z
+published-on: 2026-06-25T00:00:00Z
+description:
+  'Meet the Selection Committee for Filecoin ProPGF Batch 3 — a diverse group of
+  ecosystem contributors guiding milestone-based funding decisions for core
+  infrastructure initiatives and projects responding to targeted RFPs.'
+image:
+  src: /assets/images/blog_strategy_2.webp
+  alt: Filecoin ProPGF Batch 3 Selection Committee
+category: news
+seo:
+  description:
+    Meet the Filecoin ProPGF Batch 3 Selection Committee and review the
+    application timeline, responsibilities, and funding priorities.
+---
+
+We are excited to introduce the Selection Committee for Filecoin ProPGF Batch 3, a diverse group of ecosystem contributors who will help guide milestone-based funding decisions for core infrastructure initiatives and projects responding to targeted RFPs.
+
+As Proactive Public Goods Funding (ProPGF) enters its [third batch](https://www.filecoin.io/blog/Announcing-Filecoin-ProPGF-Batch-3-General-Track), our goal is to continue strengthening a credible, transparent, and community-aligned funding process. The committee plays a central role in ensuring that projects selected for milestone-based funding have the potential to make Filecoin more useful, resilient, and impactful.
+
+## 🌐 Committee Composition
+
+The Batch 3 Selection Committee brings together experts from across decentralized storage, crypto-economics, public goods funding, governance, ecosystem development, and open source operations. Members were chosen for their domain expertise, and demonstrated commitment to strengthening the Filecoin ecosystem.
+
+**Selection Committee Members (Batch 3):**
+
+- Akersh Srivastava - Head of Product, Filecoin Foundation
+- Clara Tsao - A Founding Officer, Filecoin Foundation
+- Eva Shon - Founder, Fil-Ponto
+- Irma Jiang - Head of Orbit Greater China, Co-founder, ND Labs & MSquare
+- Josh Daniels - Lead, PL Filecoin Impact Fund (PLFIF)
+- Ken Toler - Director of Security, Filecoin Foundation
+- Marta Piekarska Geater - Executive Director, FIDL
+- Molly Mackinlay - CEO, FilOz
+- Paul Wagner - Business Development Lead, Filecoin Foundation
+- Sarah Thiam - Founder & CEO, FIL-B
+- Sejal Rekhan - FIL-PGF Steward, PL Filecoin Impact Fund (PLFIF)
+
+Together, they bring a balanced mix of technical depth, ecosystem experience, operational rigor, and global representation.
+
+## 📅 ProPGF Batch 3: Review & Decision Timeline
+
+The Selection Committee will operate on the following timeline for Batch 3:
+
+**📍 26 May 2026 – Applications Open.** Projects are invited to submit proposals on filpgf.io outlining how they plan to build on Filecoin, including team details, funding requests, proposed milestones, budgets, verification plans, and clear success criteria.
+
+**📍 Week of 26 May 2026 – Requests for Proposals (RFPs) Published.** RFPs for Pod-supporting work go live on filpgf.io and the Filecoin website. Applicants are encouraged to review them before preparing an RFP-response submission.
+
+**📍 9 June 2026 – Early Bird Deadline.** Cut-off for the June review window. Submissions received by this date will receive decisions by the end of June. Note: early bird status means earlier feedback only — not priority consideration or a higher chance of approval.
+
+**📍 16 June 2026 – Final Application Deadline.** Last day to submit Batch 3 applications.
+
+**📍 End of June 2026 – Early Bird Reviews Completed.** Reviews finalized for all early bird submissions.
+
+**📍 Mid-July 2026 – All Funding Decisions Shared.** Final decisions communicated to all remaining applicants.
+
+**📍 July - August 2026 – KYC & Payouts.** Selected projects will begin the KYC and onboarding process in July. Payouts will be processed after KYC is successfully completed, in line with the agreed milestone structure.
+
+## 🧭 Responsibilities of the Selection Committee
+
+The Selection Committee plays a pivotal role in ensuring milestone-based funding goes toward high-impact work for the Filecoin network. Their responsibilities include:
+
+### 1. Assessing Alignment with Filecoin Network Growth
+
+- **Core Infrastructure Maintenance** Committee members assess whether a project contributes to the foundational work that keeps the protocol reliable, performant, and safe. This includes implementations, critical libraries, dependencies, and essential services that the rest of the ecosystem builds on top of.
+- **RFP Responses:** Committee members evaluate whether a project meaningfully responds to published RFPs and delivers support or innovation work in service of ecosystem pods (working group structures focused on product-market fit exploration in key verticals, including Web3 Builders and Web2 Object Storage).
+
+### 2. Reviewing Application Responses Thoughtfully
+
+The application form is designed to give reviewers clarity on:
+
+- The project's goals
+- The pathway from outputs → outcomes → network-level impact
+- Milestones and their verification criteria
+- Why the work matters for Filecoin right now
+
+Reviewers use this information to identify what aligns best with Filecoin's ecosystem priorities.
+
+### 3. Conducting Reviews, Interviews & Final Alignment
+
+The committee will:
+
+- Review all applications
+- Conduct interviews or deep-dives when needed
+- Collaborate to align on recommended projects
+- Make final decisions on which proposals should receive funding under Batch 3
+
+### 4. Defining What Should Be Funded
+
+At a high level, reviewers will prioritize:
+
+- Work that aligns with [Filecoin Network Objectives](https://www.filecoin.io/blog/the-2026-filecoin-network-strategy)
+- Work that addresses essential infrastructure gaps
+- Work that enables ecosystem participants (such as storage providers, developers, users) to succeed
+- Teams with high credibility and verifiable progress plans
+
+Funding will go to critical, enabling, and meaningfully incremental work with measurable outcomes.
+
+## 🔭 Looking Ahead
+
+The Batch 3 Selection Committee plays an important role in driving a sustainable, milestone-based funding system for the Filecoin ecosystem. Their work ensures that capital supports projects driving real progress in infrastructure, research, tooling, and community growth.
+
+Ready to contribute to the future of Filecoin? Applications for Batch 3 are now live. Visit filpgf.io to learn more, review eligibility requirements, and apply.


### PR DESCRIPTION
## 📝 Description

Adds a new fil.org (`ff-site`) blog post announcing the **Filecoin ProPGF Batch 3 Selection Committee**. The post introduces the committee, lays out the review/decision timeline, and details the committee's responsibilities and funding priorities.

- **Type:** New feature (content)

## 🛠️ Key Changes

- New post: `apps/ff-site/src/content/blog/announcing-filecoin-propgf-batch-3-selection-committee.md`
- Frontmatter validated against the `ff-site` blog schema (`title`, `description`, `seo.description`, dates, `category: news`, `image`)
- Cleaned up source export artifacts (escaped `\-`, trailing-backslash line breaks, bolded headings) to match existing post conventions

## 📌 To-Do Before Merging

- [ ] Replace the placeholder hero image (currently reuses `blog_strategy_2.webp`) with a dedicated graphic
- [ ] Confirm `published-on` date is correct
- [ ] Confirm `category: news` is the intended category

## 🧪 How to Test

- **Setup:** `npx turbo dev --filter=ff-site`
- **Steps to Test:**
  1. Navigate to `/blog/announcing-filecoin-propgf-batch-3-selection-committee`
  2. Verify the post renders with correct title, hero image, and body content
  3. Confirm it appears in the blog index
- **Expected Results:** Post renders correctly and passes build-time Zod schema validation.

## 📸 Screenshots

N/A — content-only change. Preview before merging.

## 🔖 Resources

- Linked in post: [ProPGF Batch 3 General Track](https://www.filecoin.io/blog/Announcing-Filecoin-ProPGF-Batch-3-General-Track), [2026 Filecoin Network Strategy](https://www.filecoin.io/blog/the-2026-filecoin-network-strategy)

🤖 Generated with [Claude Code](https://claude.com/claude-code)